### PR TITLE
docs(readme): traduções completas em 14 idiomas

### DIFF
--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 سيمپليسيو — العميل الذكي الذي يُوَفّرُ لَكَ حَتّى 96% مِنَ التوكينز
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="سيمپليسيو — عميل برمجة ذكي" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="أحدث إصدار"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="النجوم"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="التنزيلات"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="الرخصة"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#التثبيت">التثبيت</a> ·
+  <a href="#ما-يفعله">ما يفعله</a> ·
+  <a href="#توفير-التوكينز--96-حقيقية">توفير التوكينز — 96% حقيقية</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">الموقع الإلكتروني</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 اللغات:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -39,28 +39,28 @@
 
 ---
 
-## ⚡ TL;DR
+## ⚡ خلاصة سريعة
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**سيمپليسيو** هو عميل برمجة ذكي يعمل في الطرفية — ملف ثنائي واحد يستبدل
+سير عملك التطويري المدعوم بالذكاء الاصطناعي بالكامل: الدردشة، توليد الأكواد،
+سياق المستودع، التخطيط، التنسيق المحلي متعدد العملاء (64 ← 600 عميل)،
+وتسليم طلبات السحب المدعومة بالأدلة.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**يعمل على جهازك. كودك لا يغادر سيطرتك أبدًا. النماذج البعيدة
+اختيارية، وليست إلزامية.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 وفر حتى 96% من التوكينز مقارنة بالعملاء التقليديين — أكثر من Caveman (65%) أو RTK (80%).**
+> كل تفاعل يُظهر بالضبط كم توكينًا وفّرته. ملف Rust ثنائي واحد، بدون تبعيات.
 
-## 🚀 Installation
+## 🚀 التثبيت
 
-### npm / npx (any OS)
+### npm / npx (أي نظام تشغيل)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (أي نظام تشغيل)
 
 ```bash
 pip install simplicio-installer
@@ -91,109 +91,109 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+تم. أمر واحد. لا حاجة لمدير حزم أو تهيئة نموذج.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 توفير التوكينز — 96% حقيقية
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**بدون سيمپليسيو:** كل جلسة ذكاء اصطناعي تكتشف مستودعك من جديد، تحمّل سياقًا
+كثيرًا جدًا، تكرر الاستفسارات، تحرق توكينز مدفوعة.
 
-**With Simplicio:**
+**مع سيمپليسيو:**
 
-| Optimization | Savings |
+| التحسين | التوفير |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **خريطة المستودع** — سياق مضغوط بدل قراءة الملفات الخام | ~70% |
+| 🧠 **استرجاع الذاكرة** — الحقائق المعروفة لا يُعاد اشتقاقها | ~80% |
+| ✏️ **التحرير الحتمي** — تغييرات بدون إنفاق توكينز LLM | 100% (الإخراج) |
+| 🏠 **LLM محلي** — التصنيف، التلخيص، التعديلات منخفضة المخاطر | ~90% |
+| 📡 **LLM بعيد** — فقط للتخطيط والقرارات المعقدة | ~85% |
+| 🔀 **التوزيع المحلي** — 64←600 عميل قبل التوسع للسحابة | ~95% |
+| **💎 مجتمعة: حتى 96% توفير إجمالي** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**كل استجابة من سيمپليسيو تُظهر التوفير الفعلي:** `Simplicio: ~X توكينًا مُنفَق · تم توفير ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 ما يفعله
 
-| Command | Description | Tokens |
+| الأمر | الوصف | التوكينز |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | يرسم خريطة المستودع لـ LLMs | توفير ~70% |
+| `simplicio memory "استعلام"` | استرجاع عصبي (FTS + متجهات) | توفير ~80% |
+| `simplicio edit '{...}'` | تحرير حتمي للملفات | **صفر توكينز** |
+| `simplicio coding-loop "مهمة"` | يكرر حتى تنجح الاختبارات | إصلاح تلقائي |
+| `simplicio deliver certify` | 5 بوابات جودة قبل الشحن | حتمي |
+| `simplicio run "مهمة" --agents N` | تنسيق متعدد العملاء | محلي أولاً |
 
 ---
 
-## 🆚 Simplicio vs Caveman vs RTK
+## 🆚 سيمپليسيو مقابل Caveman مقابل RTK
 
-| | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
+| | 🪨 Caveman | 🔧 RTK | 🔥 **سيمپليسيو** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **النهج** | ضغط أسلوب الإخراج | وكيل أوامر الصدفة | **بيئة تشغيل عميل كاملة** |
+| **أقصى توفير** | ~65% توكينز الإخراج | ~80% على أوامر الصدفة | **حتى 96% إجمالي** |
+| **ضغط الإدخال** | ❌ | ✅ (مصفّى) | ✅ **خريطة مستودع + ذاكرة عصبية** |
+| **ضغط الإخراج** | ✅ (لغة الكهف) | ❌ | ✅ **تحريرات حتمية بصفر توكينز** |
+| **LLM محلي** | ❌ | ❌ | ✅ **llama.cpp مدمج** |
+| **متعدد العملاء** | ❌ | ❌ | ✅ **64 ← 600 عميل محلي** |
+| **ذاكرة عبر الجلسات** | ❌ | ❌ | ✅ **FTS + استرجاع متجهي** |
+| **سلسلة الأدلة** | ❌ | ❌ | ✅ **إيصالات مختومة بـ sha256** |
+| **اللغة** | JS/Python (مهارة) | Rust (ثنائي) | **Rust (ملف ثنائي واحد)** |
+| **الرخصة** | MIT | Apache 2.0 | مملوكة |
+| **النجوم** | 72.5k | 62.2k | ⭐ **أنت من الأوائل** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**الخلاصة:** Caveman يجعل الذكاء الاصطناعي *يتحدث* أقل. RTK يجعل الأوامر *تُخرج* أقل.
+سيمپليسيو يجعل الذكاء الاصطناعي *يفكر* أقل — من خلال التذكر، ورسم الخرائط، والتحرير الحتمي،
+والتشغيل المحلي قبل أن يلمس أي LLM مدفوع.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **سيمپليسيو يوفّر 96% بينما Caveman يوفّر 65% و RTK يوفّر 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ المعمارية
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. توجّه                          | simplicio map
+  | 2. استرجع                         | simplicio memory
+  | 3. قرّر                           |
+  | 4. حرّر  ───────────────────────> | simplicio edit (0 tokens)
+  | 5. تحقق <──────────────────────  | simplicio deliver certify
+  | 6. كرّر                           | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**الـ LLM يفكر. سيمپليسيو ينفّذ بشكل حتمي.**
 
 ---
 
-## ✨ Features
+## ✨ الميزات
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **محلي أولاً** — llama.cpp مدمج، يتوسع إلى البعيد فقط عند الحاجة
+- 🪜 **عملاء متدرجون** — 64 ← 100 ← 200 ← 600 عميل محلي قبل السحابة المدفوعة
+- 🔇 **بوابة شانون للجدة** — يصفّي المخرجات المتكررة (صفر توكينز عند إزالة التكرار)
+- 🔒 **إيصالات مختومة** — sha256 لكل قطعة أثرية، سلسلة أدلة مضادة للتلاعب
+- 🛡️ **5 بوابات تسليم** — القبول، التحقق، تشغيل-تحقق، الانحدار، المراجعة الذاتية
+- ⚡ **بوابة الإجراءات** — تصنيف المخاطر + قائمة الحظر للطفرات المنطلقة من الدردشة
+- 🔌 **MCP/ACP** — بروتوكول سياق النموذج + بروتوكول عميل الوكيل
+- 🌐 **بوابات** — Telegram، Discord، Slack، WhatsApp
+- 🧩 **نظام المهارات** — يحمّل ويسلسل القدرات القابلة لإعادة الاستخدام
+- 💾 **قاعدة بيانات الذاكرة** — FTS دائم + استرجاع متجهي عبر الجلسات
+- 🔀 **موجه LLM** — لا LLM ← LLM محلي ← LLM بعيد تلقائيًا
+- 🖥️ **متعدد المنصات** — macOS، Linux، Windows، ملف ثنائي واحد
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 النسخة التجريبية العامة المجانية
 
-**Deterministic commands are FREE forever:**
+**الأوامر الحتمية مجانية إلى الأبد:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**ميزات الذكاء الاصطناعي مجانية خلال النسخة التجريبية العامة بدون تاريخ انتهاء.**
+سيتم تحديد الفوترة في التحديثات المستقبلية.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 المتطلبات
 
-| Requirement | Minimum | Recommended |
+| المتطلب | الأدنى | الموصى به |
 |---|---|---|
-| RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| RAM | 8 جيجابايت | 16 جيجابايت+ |
+| التخزين | 5 ميجابايت | 1.5 جيجابايت (مع LLM محلي) |
+| نظام التشغيل | macOS 13+، Linux، Windows 10+ | macOS ARM64 |
+| الطرفية | أي طرفية حديثة | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 النظام البيئي
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [الموقع الإلكتروني](https://simpleti.com.br/simplicio/#start) — الوثائق الكاملة، المقاييس، التثبيت
+- [Discord](https://discord.gg/wM6tr7xVb) — المجتمع والدعم
 
 ---
 
-## ⭐ Star History
+## 📄 الرخصة
+
+مملوكة. الملف الثنائي مجاني للتنزيل والاستخدام. ميزات الذكاء الاصطناعي مجانية خلال
+النسخة التجريبية العامة. انظر [LICENSE](LICENSE).
+
+---
+
+## ⭐ تاريخ النجوم
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="مخطط تاريخ النجوم" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 المجتمع
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — دردشة، دعم، وصول مبكر
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — الأخطاء وطلبات الميزات
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 سيمپليسيو — كودك، جهازك، أرخص بنسبة 96% 🔥</strong>
 </p>

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — El agente de IA que AHORRA HASTA EL 96% DE TUS TOKENS
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — agente de IA para programación" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Última versión"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrellas"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Descargas"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licencia"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#instalación">Instalación</a> ·
+  <a href="#qué-hace">Qué Hace</a> ·
+  <a href="#ahorro-de-tokens--el-96-es-real">Ahorro de Tokens — El 96% es Real</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Sitio web</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Idiomas:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** es un agente de IA de terminal para programación — un único binario que reemplaza
+todo tu flujo de trabajo de desarrollo asistido por IA: chat, generación de código, contexto
+del repositorio, planificación, orquestación multi-agente local (64 → 600 agentes) y
+entrega de PR respaldada por evidencia.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Se ejecuta en tu máquina. Tu código nunca sale de tu control. Los modelos remotos son
+opcionales, no obligatorios.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Ahorra hasta el 96% de tokens frente a los agentes tradicionales — más que Caveman (65%) o RTK (80%).**
+> Cada interacción muestra exactamente cuántos tokens has ahorrado. Un solo binario en Rust, cero dependencias.
 
-## 🚀 Installation
+## 🚀 Instalación
 
-### npm / npx (any OS)
+### npm / npx (cualquier SO)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (cualquier SO)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Listo. Un solo comando. Sin gestor de paquetes, sin configuración de modelos.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Ahorro de Tokens — El 96% es Real
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Sin Simplicio:** cada sesión de IA redescubre tu repositorio, carga demasiado
+contexto, repite indicaciones, quema tokens de pago.
 
-**With Simplicio:**
+**Con Simplicio:**
 
-| Optimization | Savings |
+| Optimización | Ahorro |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Mapa del Repo** — contexto comprimido en lugar de leer archivos sin procesar | ~70% |
+| 🧠 **Memoria Recuperable** — los hechos conocidos no se redescubren | ~80% |
+| ✏️ **Edición Determinista** — cambios sin gastar tokens de LLM | 100% (salida) |
+| 🏠 **LLM Local** — clasificación, resumen, ediciones de bajo riesgo | ~90% |
+| 📡 **LLM Remoto** — solo para planificación y decisiones complejas | ~85% |
+| 🔀 **Expansión Local** — 64→600 agentes antes de escalar a la nube | ~95% |
+| **💎 Combinado: hasta un 96% de ahorro total** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Cada respuesta de Simplicio muestra el ahorro real:** `Simplicio: ~X tokens gastados · ahorrados ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Qué Hace
 
-| Command | Description | Tokens |
+| Comando | Descripción | Tokens |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Mapa del repositorio para LLMs | ~70% ahorro |
+| `simplicio memory "consulta"` | Recuperación neuronal (FTS + vectores) | ~80% ahorro |
+| `simplicio edit '{...}'` | Edición determinista de archivos | **Cero tokens** |
+| `simplicio coding-loop "tarea"` | Itera hasta que pasen las pruebas | Autorreparación |
+| `simplicio deliver certify` | 5 compuertas de calidad antes del envío | Determinista |
+| `simplicio run "tarea" --agents N` | Orquestación multi-agente | Primero local |
 
 ---
 
@@ -133,67 +133,67 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Enfoque** | Compresión de estilo de salida | Proxy de comandos Shell | **Runtime completo de agente** |
+| **Ahorro máximo** | ~65% tokens de salida | ~80% en comandos Shell | **Hasta el 96% total** |
+| **Compresión de entrada** | ❌ | ✅ (filtrada) | ✅ **Mapa del repo + memoria neuronal** |
+| **Compresión de salida** | ✅ (lenguaje cavernícola) | ❌ | ✅ **Ediciones deterministas de cero tokens** |
+| **LLM Local** | ❌ | ❌ | ✅ **llama.cpp integrado** |
+| **Multi-agente** | ❌ | ❌ | ✅ **64 → 600 agentes locales** |
+| **Memoria entre sesiones** | ❌ | ❌ | ✅ **Recuperación FTS + vectorial** |
+| **Cadena de evidencia** | ❌ | ❌ | ✅ **Recibos sellados sha256** |
+| **Lenguaje** | JS/Python (skill) | Rust (binario) | **Rust (binario único)** |
+| **Licencia** | MIT | Apache 2.0 | Propietaria |
+| **Estrellas** | 72.5k | 62.2k | ⭐ **Llegas pronto** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Conclusión:** Caveman hace que la IA *hable* menos. RTK hace que los comandos *generen* menos salida.
+Simplicio hace que la IA *piense* menos — al recordar, mapear, editar de forma determinista
+y ejecutarse localmente antes de tocar un LLM de pago.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio ahorra un 96% donde Caveman ahorra un 65% y RTK ahorra un 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Arquitectura
 
 ```
-LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
+LLM (Claude/Codex/Gemini)          Runtime de Simplicio (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. Orientar                       | simplicio map
+  | 2. Recordar                       | simplicio memory
+  | 3. Decidir                        |
+  | 4. Editar  ──────────────────────> | simplicio edit (0 tokens)
+  | 5. Verificar <───────────────────  | simplicio deliver certify
+  | 6. Iterar                         | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**El LLM razona. Simplicio ejecuta de forma determinista.**
 
 ---
 
-## ✨ Features
+## ✨ Características
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **Primero local** — llama.cpp integrado, escala a remoto solo cuando es necesario
+- 🪜 **Agentes escalonados** — 64 → 100 → 200 → 600 agentes locales antes de la nube de pago
+- 🔇 **Puerta de novedad de Shannon** — filtra salidas redundantes (cero tokens en dedup)
+- 🔒 **Recibos sellados** — sha256 por artefacto, cadena de evidencia a prueba de manipulaciones
+- 🛡️ **5 compuertas de entrega** — aceptación, validación, ejecución-verificación, regresión, autoevaluación
+- ⚡ **Compuerta de acción** — clasificación de riesgo + lista negra para mutaciones iniciadas por chat
+- 🔌 **MCP/ACP** — Protocolo de Contexto de Modelo + Protocolo de Cliente Agente
+- 🌐 **Pasarelas** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Sistema de habilidades** — carga y encadena capacidades reutilizables
+- 💾 **Base de datos de memoria** — recuperación FTS + vectorial persistente entre sesiones
+- 🔀 **Enrutador de LLM** — sin LLM → LLM local → LLM remoto automáticamente
+- 🖥️ **Multiplataforma** — macOS, Linux, Windows, binario único
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Beta Pública Gratuita
 
-**Deterministic commands are FREE forever:**
+**Los comandos deterministas son GRATIS para siempre:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Las funciones de IA son gratuitas durante la beta pública sin fecha de finalización.**
+La facturación se definirá en actualizaciones futuras.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Requisitos
 
-| Requirement | Minimum | Recommended |
+| Requisito | Mínimo | Recomendado |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Almacenamiento | 5 MB | 1.5 GB (con LLM local) |
+| SO | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| Terminal | cualquier terminal moderna | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ecosistema
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Sitio web](https://simpleti.com.br/simplicio/#start) — documentación completa, benchmarks, instalación
+- [Discord](https://discord.gg/wM6tr7xVb) — comunidad y soporte
 
 ---
 
-## ⭐ Star History
+## 📄 Licencia
+
+Propietaria. El binario es gratuito para descargar y usar. Las funciones de IA son gratuitas durante la
+beta pública. Consulta [LICENSE](LICENSE).
+
+---
+
+## ⭐ Historial de Estrellas
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Gráfico de historial de estrellas" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 Comunidad
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — chat, soporte, acceso anticipado
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — errores y solicitudes de funciones
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Tu código, tu máquina, un 96% más barato. 🔥</strong>
 </p>

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -1,4 +1,4 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — L'agent IA qui économise JUSQU'À 96 % DE VOS TOKENS
 
 <p align="center">
   <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
@@ -12,14 +12,14 @@
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#installation">Installation</a> ·
+  <a href="#ce-quil-fait">Ce Qu'il Fait</a> ·
+  <a href="#économies-de-tokens--96-cest-réel">Économies de Tokens — 96 % C'est Réel</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Site Web</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Langues :</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** est un agent de codage IA en terminal — un binaire unique qui remplace
+l'intégralité de votre workflow de développement assisté par IA : chat, génération de code,
+contexte de dépôt, planification, orchestration multi-agent locale (64 → 600 agents),
+et livraison de PR avec preuves à l'appui.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Tourne sur votre machine. Votre code ne quitte jamais votre contrôle. Les modèles distants
+sont facultatifs, pas obligatoires.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Économisez jusqu'à 96 % de tokens par rapport aux agents traditionnels — plus que Caveman (65 %) ou RTK (80 %).**
+> Chaque interaction montre exactement combien de tokens vous avez économisés. Binaire Rust unique, zéro dépendance.
 
 ## 🚀 Installation
 
-### npm / npx (any OS)
+### npm / npx (tout OS)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (tout OS)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Terminé. Une seule commande. Pas de gestionnaire de paquets, pas de configuration de modèle.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Économies de Tokens — 96 % C'est Réel
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Sans Simplicio :** chaque session IA redécouvre votre dépôt, charge trop de
+contexte, répète les invites, brûle des tokens payants.
 
-**With Simplicio:**
+**Avec Simplicio :**
 
-| Optimization | Savings |
+| Optimisation | Économies |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Plan du dépôt** — contexte compressé au lieu de lire les fichiers bruts | ~70 % |
+| 🧠 **Rappel mémoire** — les faits connus ne sont pas redérivés | ~80 % |
+| ✏️ **Édition déterministe** — modifications sans dépenser de tokens LLM | 100 % (sortie) |
+| 🏠 **LLM local** — classification, résumé, modifications à faible risque | ~90 % |
+| 📡 **LLM distant** — uniquement pour la planification et les décisions complexes | ~85 % |
+| 🔀 **Fan-out local** — 64→600 agents avant de passer au cloud | ~95 % |
+| **💎 Combiné : jusqu'à 96 % d'économies totales** | **~96 %** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Chaque réponse de Simplicio montre les économies réelles :** `Simplicio: ~X tokens dépensés · économisé ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Ce Qu'il Fait
 
-| Command | Description | Tokens |
+| Commande | Description | Tokens |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Cartographie le dépôt pour les LLMs | ~70 % d'économies |
+| `simplicio memory "query"` | Rappel neuronal (FTS + vecteurs) | ~80 % d'économies |
+| `simplicio edit '{...}'` | Édition déterministe de fichiers | **Zéro token** |
+| `simplicio coding-loop "task"` | Itère jusqu'à ce que les tests passent | Auto-réparation |
+| `simplicio deliver certify` | 5 portes qualité avant livraison | Déterministe |
+| `simplicio run "task" --agents N` | Orchestration multi-agent | Local d'abord |
 
 ---
 
@@ -133,23 +133,23 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Approche** | Compression du style de sortie | Proxy de commandes shell | **Runtime d'agent complet** |
+| **Économies max** | ~65 % tokens de sortie | ~80 % sur les commandes shell | **Jusqu'à 96 % du total** |
+| **Compression d'entrée** | ❌ | ✅ (filtrée) | ✅ **Plan du dépôt + mémoire neuronale** |
+| **Compression de sortie** | ✅ (caveman-speak) | ❌ | ✅ **Éditions déterministes zéro token** |
+| **LLM local** | ❌ | ❌ | ✅ **llama.cpp intégré** |
+| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 agents locaux** |
+| **Mémoire entre sessions** | ❌ | ❌ | ✅ **FTS + rappel vectoriel** |
+| **Chaîne de preuves** | ❌ | ❌ | ✅ **Reçus scellés sha256** |
+| **Langage** | JS/Python (skill) | Rust (binaire) | **Rust (binaire unique)** |
+| **Licence** | MIT | Apache 2.0 | Propriétaire |
+| **Étoiles** | 72,5k | 62,2k | ⭐ **Vous êtes en avance** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**En résumé :** Caveman fait en sorte que l'IA *parle* moins. RTK fait en sorte que les commandes *produisent* moins.
+Simplicio fait en sorte que l'IA *réfléchisse* moins — en se souvenant, en cartographiant, en éditant de manière déterministe,
+et en s'exécutant localement avant même de toucher un LLM payant.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio économise 96 % là où Caveman économise 65 % et RTK 80 %.** |
 
 ---
 
@@ -166,34 +166,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**Le LLM raisonne. Simplicio exécute de manière déterministe.**
 
 ---
 
-## ✨ Features
+## ✨ Fonctionnalités
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **Local d'abord** — llama.cpp intégré, passage au distant uniquement si nécessaire
+- 🪜 **Agents hiérarchisés** — 64 → 100 → 200 → 600 agents locaux avant le cloud payant
+- 🔇 **Porte de nouveauté Shannon** — filtre les sorties redondantes (zéro token sur déduplication)
+- 🔒 **Reçus scellés** — sha256 par artefact, chaîne de preuves inviolable
+- 🛡️ **5 portes de livraison** — acceptation, validation, exécution-vérification, régression, auto-examen
+- ⚡ **Porte d'action** — classification des risques + liste de blocage pour les mutations initiées par chat
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **Passerelles** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Système de compétences** — charge et enchaîne des capacités réutilisables
+- 💾 **Base de données mémoire** — FTS persistant + rappel vectoriel entre sessions
+- 🔀 **Routeur LLM** — aucun LLM → LLM local → LLM distant automatiquement
+- 🖥️ **Multi-plateforme** — macOS, Linux, Windows, binaire unique
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Bêta Publique Gratuite
 
-**Deterministic commands are FREE forever:**
+**Les commandes déterministes sont GRATUITES pour toujours :**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Les fonctionnalités IA sont gratuites pendant la bêta publique sans date de fin.**
+La facturation sera définie dans les futures mises à jour.
 
 ```bash
 simplicio license status
@@ -201,28 +201,28 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Prérequis
 
-| Requirement | Minimum | Recommended |
+| Prérequis | Minimum | Recommandé |
 |---|---|---|
-| RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| RAM | 8 Go | 16 Go+ |
+| Stockage | 5 Mo | 1,5 Go (avec LLM local) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Terminal | tout terminal moderne | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Écosystème
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
+- [Site Web](https://simpleti.com.br/simplicio/#start) — docs complètes, benchmarks, installation
+- [Discord](https://discord.gg/wM6tr7xVb) — communauté et support
 
 ---
 
-## 📄 License
+## 📄 Licence
 
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+Propriétaire. Binaire gratuit à télécharger et à utiliser. Fonctionnalités IA gratuites pendant la
+bêta publique. Voir [LICENSE](LICENSE).
 
 ---
 
@@ -234,13 +234,13 @@ public beta. See [LICENSE](LICENSE).
 
 ---
 
-## 💬 Community
+## 💬 Communauté
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, accès anticipé
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs et demandes de fonctionnalités
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Votre code, votre machine, 96 % moins cher. 🔥</strong>
 </p>

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — סוכן הבינה המלאכותית שחוסך עד 96% מהטוקנים שלך
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — סוכן קידוד בינה מלאכותית" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="גרסה אחרונה"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="כוכבים"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="הורדות"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="רישיון"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#התקנה">התקנה</a> ·
+  <a href="#מה-זה-עושה">מה זה עושה</a> ·
+  <a href="#חיסכון-בטוקנים--96-הוא-אמיתי">חיסכון בטוקנים — 96% הוא אמיתי</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">אתר אינטרנט</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 שפות:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -39,28 +39,28 @@
 
 ---
 
-## ⚡ TL;DR
+## ⚡ תקציר
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** הוא סוכן קידוד בינה מלאכותית מבוסס טרמינל — בינארי יחיד שמחליף את
+כל זרימת העבודה שלך בסיוע בינה מלאכותית: צ'אט, יצירת קוד, הקשר
+מאגר, תכנון, תיאום רב-סוכנים מקומי (64 → 600 סוכנים), ומשלוח PR
+מגובה בראיות.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**רץ על המחשב שלך. הקוד שלך לעולם לא עוזב את השליטה שלך. מודלים מרוחקים הם
+אופציונליים, לא חובה.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 חסוך עד 96% מהטוקנים לעומת סוכנים מסורתיים — יותר מ-Caveman (65%) או RTK (80%).**
+> כל אינטראקציה מראה בדיוק כמה טוקנים חסכת. בינארי יחיד ב-Rust, אפס תלויות.
 
-## 🚀 Installation
+## 🚀 התקנה
 
-### npm / npx (any OS)
+### npm / npx (כל מערכת הפעלה)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (כל מערכת הפעלה)
 
 ```bash
 pip install simplicio-installer
@@ -91,109 +91,109 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+בוצע. פקודה אחת. ללא מנהל חבילות, ללא הגדרת מודל.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 חיסכון בטוקנים — 96% הוא אמיתי
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**ללא Simplicio:** כל הפעלת AI מגלה מחדש את המאגר שלך, טוענת יותר מדי
+הקשר, חוזרת על הנחיות, שורפת טוקנים בתשלום.
 
-**With Simplicio:**
+**עם Simplicio:**
 
-| Optimization | Savings |
+| אופטימיזציה | חיסכון |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **מפת מאגר** — הקשר דחוס במקום קריאת קבצים גולמיים | ~70% |
+| 🧠 **זיכרון** — עובדות ידועות לא נגזרות מחדש | ~80% |
+| ✏️ **עריכה דטרמיניסטית** — שינויים מבלי לבזבז טוקני LLM | 100% (פלט) |
+| 🏠 **LLM מקומי** — סיווג, תמצות, עריכות בסיכון נמוך | ~90% |
+| 📡 **LLM מרוחק** — רק לתכנון והחלטות מורכבות | ~85% |
+| 🔀 **פריסה מקומית** — 64→600 סוכנים לפני קנה מידה לענן | ~95% |
+| **💎 שילוב: עד 96% חיסכון כולל** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**כל תגובת Simplicio מציגה חיסכון אמיתי:** `Simplicio: ~X טוקנים נצרכו · נחסכו ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 מה זה עושה
 
-| Command | Description | Tokens |
+| פקודה | תיאור | טוקנים |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | ממפה את המאגר עבור LLMs | ~70% חיסכון |
+| `simplicio memory "שאילתה"` | שליפה עצבית (FTS + וקטורים) | ~80% חיסכון |
+| `simplicio edit '{...}'` | עריכת קבצים דטרמיניסטית | **אפס טוקנים** |
+| `simplicio coding-loop "משימה"` | מתמשכת עד שהבדיקות עוברות | תיקון אוטומטי |
+| `simplicio deliver certify` | 5 שערי איכות לפני משלוח | דטרמיניסטי |
+| `simplicio run "משימה" --agents N` | תיאום רב-סוכנים | מקומי תחילה |
 
 ---
 
-## 🆚 Simplicio vs Caveman vs RTK
+## 🆚 Simplicio לעומת Caveman לעומת RTK
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **גישה** | דחיסת סגנון פלט | מתווך פקודות Shell | **סביבת הרצה מלאה של סוכן** |
+| **חיסכון מקסימלי** | ~65% טוקני פלט | ~80% בפקודות Shell | **עד 96% סה"כ** |
+| **דחיסת קלט** | ❌ | ✅ (מסונן) | ✅ **מפת מאגר + זיכרון עצבי** |
+| **דחיסת פלט** | ✅ (שפת-קייבמן) | ❌ | ✅ **עריכות דטרמיניסטיות באפס טוקנים** |
+| **LLM מקומי** | ❌ | ❌ | ✅ **llama.cpp מובנה** |
+| **רב-סוכנים** | ❌ | ❌ | ✅ **64 → 600 סוכנים מקומיים** |
+| **זיכרון בין הפעלות** | ❌ | ❌ | ✅ **FTS + שליפה וקטורית** |
+| **שרשרת ראיות** | ❌ | ❌ | ✅ **קבלות חתומות ב-sha256** |
+| **שפה** | JS/Python (מיומנות) | Rust (בינארי) | **Rust (בינארי יחיד)** |
+| **רישיון** | MIT | Apache 2.0 | קנייני |
+| **כוכבים** | 72.5k | 62.2k | ⭐ **אתה מוקדם** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**השורה התחתונה:** Caveman גורם ל-AI *לדבר* פחות. RTK גורם לפקודות *להפיק* פחות.
+Simplicio גורם ל-AI *לחשוב* פחות — על ידי זכירה, מיפוי, עריכה דטרמיניסטית,
+ורצה מקומית לפני כל נגיעה ב-LLM בתשלום.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio חוסך 96% בעוד Caveman חוסך 65% ו-RTK חוסך 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ ארכיטקטורה
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. התמצאות                        | simplicio map
+  | 2. שליפה                          | simplicio memory
+  | 3. החלטה                          |
+  | 4. עריכה  ───────────────────────> | simplicio edit (0 טוקנים)
+  | 5. אימות <─────────────────────  | simplicio deliver certify
+  | 6. חזרה                           | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**ה-LLM חושב. Simplicio מבצע דטרמיניסטית.**
 
 ---
 
-## ✨ Features
+## ✨ תכונות
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **מקומי תחילה** — llama.cpp מובנה, עובר למרוחק רק בעת הצורך
+- 🪜 **סוכנים מדורגים** — 64 → 100 → 200 → 600 סוכנים מקומיים לפני ענן בתשלום
+- 🔇 **שער חידוש שאנון** — מסנן פלטים כפולים (אפס טוקנים על כפילויות)
+- 🔒 **קבלות חתומות** — sha256 לכל נספח, שרשרת ראיות חסינת חבלה
+- 🛡️ **5 שערי משלוח** — קבלה, אימות, הרצה-אימות, רגרסיה, סקירה עצמית
+- ⚡ **שער פעולה** — סיווג סיכונים + רשימה חסומה למוטציות ביוזמת צ'אט
+- 🔌 **MCP/ACP** — פרוטוקול הקשר מודל + פרוטוקול לקוח סוכן
+- 🌐 **שערים** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **מערכת מיומנויות** — טוען ומשרשר יכולות לשימוש חוזר
+- 💾 **מסד זיכרון** — FTS מתמשך + שליפה וקטורית בין הפעלות
+- 🔀 **נתב LLM** — ללא LLM → LLM מקומי → LLM מרוחק באופן אוטומטי
+- 🖥️ **חוצה-פלטפורמות** — macOS, Linux, Windows, בינארי יחיד
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 גרסת בטא ציבורית חינם
 
-**Deterministic commands are FREE forever:**
+**פקודות דטרמיניסטיות הן בחינם לנצח:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**תכונות AI הן בחינם במהלך הבטא הציבורית ללא תאריך סיום.**
+חיוב יוגדר בעדכונים עתידיים.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 דרישות
 
-| Requirement | Minimum | Recommended |
+| דרישה | מינימום | מומלץ |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| אחסון | 5 MB | 1.5 GB (עם LLM מקומי) |
+| מערכת הפעלה | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| טרמינל | כל טרמינל מודרני | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 אקוסיסטם
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [אתר אינטרנט](https://simpleti.com.br/simplicio/#start) — תיעוד מלא, מדדים, התקנה
+- [Discord](https://discord.gg/wM6tr7xVb) — קהילה ותמיכה
 
 ---
 
-## ⭐ Star History
+## 📄 רישיון
+
+קנייני. הבינארי חופשי להורדה ולשימוש. תכונות AI בחינם במהלך
+הבטא הציבורית. ראה [LICENSE](LICENSE).
+
+---
+
+## ⭐ היסטוריית כוכבים
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="תרשים היסטוריית כוכבים" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 קהילה
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — צ'אט, תמיכה, גישה מוקדמת
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — באגים ובקשות תכונות
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — הקוד שלך, המחשב שלך, 96% זול יותר. 🔥</strong>
 </p>

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -1,7 +1,7 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — AI एजेंट जो आपके 96% टोकन बचाता है
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — AI कोडिंग एजेंट" width="920" />
 </p>
 
 <p align="center">
@@ -12,14 +12,14 @@
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#इंस्टॉलेशन">इंस्टॉलेशन</a> ·
+  <a href="#यह-क्या-करता-है">यह क्या करता है</a> ·
+  <a href="#टोकन-बचत--96-वास्तविक-है">टोकन बचत — 96% वास्तविक है</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">वेबसाइट</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 भाषाएँ:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** एक टर्मिनल AI कोडिंग एजेंट है — एक एकल बाइनरी जो आपके संपूर्ण
+AI-सहायित विकास कार्यप्रवाह को बदल देता है: चैट, कोड जनरेशन, रिपॉजिटरी
+संदर्भ, योजना, स्थानीय मल्टी-एजेंट ऑर्केस्ट्रेशन (64 → 600 एजेंट), और
+साक्ष्य-समर्थित PR डिलीवरी।
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**आपकी मशीन पर चलता है। आपका कोड कभी आपके नियंत्रण से बाहर नहीं जाता। रिमोट मॉडल
+वैकल्पिक हैं, अनिवार्य नहीं।**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 पारंपरिक एजेंटों की तुलना में 96% तक टोकन बचाएं — Caveman (65%) या RTK (80%) से अधिक।**
+> हर इंटरैक्शन दिखाता है कि आपने कितने टोकन बचाए। एकल Rust बाइनरी, शून्य निर्भरताएँ।
 
-## 🚀 Installation
+## 🚀 इंस्टॉलेशन
 
-### npm / npx (any OS)
+### npm / npx (किसी भी OS पर)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (किसी भी OS पर)
 
 ```bash
 pip install simplicio-installer
@@ -91,69 +91,69 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+हो गया। एक कमांड। कोई पैकेज मैनेजर नहीं, कोई मॉडल कॉन्फ़िगरेशन नहीं।
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 टोकन बचत — 96% वास्तविक है
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Simplicio के बिना:** हर AI सत्र आपके रिपॉजिटरी को फिर से खोजता है, बहुत अधिक
+संदर्भ लोड करता है, प्रॉम्प्ट दोहराता है, भुगतान वाले टोकन जलाता है।
 
-**With Simplicio:**
+**Simplicio के साथ:**
 
-| Optimization | Savings |
+| अनुकूलन | बचत |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **रिपो मैप** — कच्ची फ़ाइलें पढ़ने के बजाय संपीड़ित संदर्भ | ~70% |
+| 🧠 **मेमोरी रिकॉल** — ज्ञात तथ्य पुनः व्युत्पन्न नहीं होते | ~80% |
+| ✏️ **निर्धारित संपादन** — LLM टोकन खर्च किए बिना बदलाव | 100% (आउटपुट) |
+| 🏠 **स्थानीय LLM** — वर्गीकरण, सारांशीकरण, कम-जोखिम वाले संपादन | ~90% |
+| 📡 **रिमोट LLM** — केवल योजना और जटिल निर्णयों के लिए | ~85% |
+| 🔀 **स्थानीय फैन-आउट** — क्लाउड पर जाने से पहले 64→600 एजेंट | ~95% |
+| **💎 संयुक्त: कुल 96% तक बचत** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**हर Simplicio प्रतिक्रिया वास्तविक बचत दिखाती है:** `Simplicio: ~X टोकन खर्च · ~Y बचत (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 यह क्या करता है
 
-| Command | Description | Tokens |
+| कमांड | विवरण | टोकन |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | LLM के लिए रिपॉजिटरी मैप करता है | ~70% बचत |
+| `simplicio memory "query"` | न्यूरल रिकॉल (FTS + वेक्टर) | ~80% बचत |
+| `simplicio edit '{...}'` | निर्धारित फ़ाइल संपादन | **शून्य टोकन** |
+| `simplicio coding-loop "task"` | टेस्ट पास होने तक दोहराता है | ऑटो-रिपेयर |
+| `simplicio deliver certify` | शिप करने से पहले 5 गुणवत्ता गेट | निर्धारित |
+| `simplicio run "task" --agents N` | मल्टी-एजेंट ऑर्केस्ट्रेशन | स्थानीय-प्रथम |
 
 ---
 
-## 🆚 Simplicio vs Caveman vs RTK
+## 🆚 Simplicio बनाम Caveman बनाम RTK
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **दृष्टिकोण** | आउटपुट शैली संपीड़न | शेल कमांड प्रॉक्सी | **पूर्ण एजेंट रनटाइम** |
+| **अधिकतम बचत** | ~65% आउटपुट टोकन | ~80% शेल कमांड पर | **कुल 96% तक** |
+| **इनपुट संपीड़न** | ❌ | ✅ (फ़िल्टर्ड) | ✅ **रिपो मैप + न्यूरल मेमोरी** |
+| **आउटपुट संपीड़न** | ✅ (गुफावासी बोली) | ❌ | ✅ **शून्य-टोकन निर्धारित संपादन** |
+| **स्थानीय LLM** | ❌ | ❌ | ✅ **अंतर्निहित llama.cpp** |
+| **मल्टी-एजेंट** | ❌ | ❌ | ✅ **64 → 600 स्थानीय एजेंट** |
+| **सत्रों में मेमोरी** | ❌ | ❌ | ✅ **FTS + वेक्टर रिकॉल** |
+| **साक्ष्य श्रृंखला** | ❌ | ❌ | ✅ **sha256 सीलबंद रसीदें** |
+| **भाषा** | JS/Python (स्किल) | Rust (बाइनरी) | **Rust (एकल बाइनरी)** |
+| **लाइसेंस** | MIT | Apache 2.0 | Proprietary |
+| **स्टार्स** | 72.5k | 62.2k | ⭐ **आप जल्दी आए** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**निचली पंक्ति:** Caveman AI को *कम बोलने* पर मजबूर करता है। RTK कमांड को *कम आउटपुट* देता है।
+Simplicio AI को *कम सोचने* पर मजबूर करता है — याद रखकर, मैप करके, निर्धारित रूप से संपादित करके,
+और किसी भी भुगतान वाले LLM को छूने से पहले स्थानीय रूप से चलाकर।
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio 96% बचाता है जहाँ Caveman 65% और RTK 80% बचाता है।** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ आर्किटेक्चर
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -166,34 +166,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM तर्क करता है। Simplicio निर्धारित रूप से निष्पादित करता है।**
 
 ---
 
-## ✨ Features
+## ✨ सुविधाएँ
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **स्थानीय-प्रथम** — अंतर्निहित llama.cpp, केवल ज़रूरत पड़ने पर रिमोट पर स्केल करें
+- 🪜 **स्तरीय एजेंट** — भुगतान वाले क्लाउड से पहले 64 → 100 → 200 → 600 स्थानीय एजेंट
+- 🔇 **शैनन नवीनता गेट** — डुप्लिकेट आउटपुट फ़िल्टर करता है (डीडुप पर शून्य टोकन)
+- 🔒 **सीलबंद रसीदें** — प्रति आर्टिफैक्ट sha256, छेड़छाड़-रोधी साक्ष्य श्रृंखला
+- 🛡️ **5 डिलीवरी गेट** — स्वीकृति, सत्यापन, रन-वेरिफाई, रिग्रेशन, सेल्फ-रिव्यू
+- ⚡ **एक्शन गेट** — चैट-आरंभित म्यूटेशन के लिए जोखिम वर्गीकरण + ब्लॉकलिस्ट
+- 🔌 **MCP/ACP** — मॉडल कॉन्टेक्स्ट प्रोटोकॉल + एजेंट क्लाइंट प्रोटोकॉल
+- 🌐 **गेटवे** — टेलीग्राम, डिस्कॉर्ड, स्लैक, व्हाट्सएप
+- 🧩 **स्किल सिस्टम** — पुन: प्रयोज्य क्षमताओं को लोड और चेन करता है
+- 💾 **मेमोरी DB** — सत्रों में स्थायी FTS + वेक्टर रिकॉल
+- 🔀 **LLM राउटर** — कोई LLM नहीं → स्थानीय LLM → रिमोट LLM स्वचालित रूप से
+- 🖥️ **क्रॉस-प्लेटफ़ॉर्म** — macOS, Linux, Windows, एकल बाइनरी
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 मुफ्त सार्वजनिक बीटा
 
-**Deterministic commands are FREE forever:**
+**निर्धारित कमांड हमेशा के लिए मुफ्त हैं:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**AI सुविधाएँ सार्वजनिक बीटा के दौरान बिना किसी समाप्ति तिथि के मुफ्त हैं।**
+भविष्य के अपडेट में बिलिंग निर्धारित की जाएगी।
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 आवश्यकताएँ
 
-| Requirement | Minimum | Recommended |
+| आवश्यकता | न्यूनतम | अनुशंसित |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| स्टोरेज | 5 MB | 1.5 GB (स्थानीय LLM के साथ) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| टर्मिनल | कोई भी आधुनिक टर्मिनल | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 पारिस्थितिकी तंत्र
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [वेबसाइट](https://simpleti.com.br/simplicio/#start) — पूर्ण दस्तावेज़, बेंचमार्क, इंस्टॉल
+- [डिस्कॉर्ड](https://discord.gg/wM6tr7xVb) — समुदाय और सहायता
 
 ---
 
-## ⭐ Star History
+## 📄 लाइसेंस
+
+Proprietary. बाइनरी डाउनलोड और उपयोग करने के लिए मुफ्त है। AI सुविधाएँ
+सार्वजनिक बीटा के दौरान मुफ्त हैं। [LICENSE](LICENSE) देखें।
+
+---
+
+## ⭐ स्टार इतिहास
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="स्टार हिस्ट्री चार्ट" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 समुदाय
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [डिस्कॉर्ड](https://discord.gg/wM6tr7xVb) — चैट, सहायता, प्रारंभिक पहुँच
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — बग और फीचर अनुरोध
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — आपका कोड, आपकी मशीन, 96% सस्ता। 🔥</strong>
 </p>

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — Agen AI yang MENGHEMAT HINGGA 96% TOKEN ANDA
 
 <p align="center">
   <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Rilis Terbaru"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Unduhan"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Lisensi"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#instalasi">Instalasi</a> ·
+  <a href="#yang-dilakukan">Yang Dilakukan</a> ·
+  <a href="#penghematan-token--96-nyata">Penghematan Token — 96% Nyata</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Situs Web</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Bahasa:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** adalah agen coding AI berbasis terminal — satu biner yang menggantikan
+seluruh alur kerja pengembangan berbantuan AI Anda: obrolan, pembuatan kode, konteks
+repositori, perencanaan, orkestrasi multi-agen lokal (64 → 600 agen), dan
+pengiriman PR berbasis bukti.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Berjalan di mesin Anda. Kode Anda tidak pernah meninggalkan kendali Anda. Model jarak jauh
+bersifat opsional, tidak wajib.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Hemat hingga 96% token dibandingkan agen tradisional — lebih dari Caveman (65%) atau RTK (80%).**
+> Setiap interaksi menunjukkan persis berapa banyak token yang Anda hemat. Biner Rust tunggal, tanpa dependensi.
 
-## 🚀 Installation
+## 🚀 Instalasi
 
-### npm / npx (any OS)
+### npm / npx (OS apa saja)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (OS apa saja)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Selesai. Satu perintah. Tanpa manajer paket, tanpa konfigurasi model.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Penghematan Token — 96% Nyata
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Tanpa Simplicio:** setiap sesi AI menemukan ulang repositori Anda, memuat terlalu
+banyak konteks, mengulangi prompt, dan menghabiskan token berbayar.
 
-**With Simplicio:**
+**Dengan Simplicio:**
 
-| Optimization | Savings |
+| Optimasi | Penghematan |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Peta Repo** — konteks terkompresi, bukan membaca file mentah | ~70% |
+| 🧠 **Memori Panggil Ulang** — fakta yang diketahui tidak diulang kembali | ~80% |
+| ✏️ **Pengeditan Deterministik** — perubahan tanpa menghabiskan token LLM | 100% (output) |
+| 🏠 **LLM Lokal** — klasifikasi, perangkuman, suntingan berisiko rendah | ~90% |
+| 📡 **LLM Jarak Jauh** — hanya untuk perencanaan dan keputusan kompleks | ~85% |
+| 🔀 **Fan-out Lokal** — 64→600 agen sebelum naik ke cloud | ~95% |
+| **💎 Gabungan: hingga 96% total penghematan** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Setiap respons Simplicio menunjukkan penghematan nyata:** `Simplicio: ~X token digunakan · hemat ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Yang Dilakukan
 
-| Command | Description | Tokens |
+| Perintah | Deskripsi | Token |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Memetakan repositori untuk LLM | ~70% hemat |
+| `simplicio memory "query"` | Panggil ulang neural (FTS + vektor) | ~80% hemat |
+| `simplicio edit '{...}'` | Pengeditan file deterministik | **Nol token** |
+| `simplicio coding-loop "task"` | Mengulang hingga pengujian lulus | Perbaikan-otomatis |
+| `simplicio deliver certify` | 5 gerbang kualitas sebelum dikirim | Deterministik |
+| `simplicio run "task" --agents N` | Orkestrasi multi-agen | Lokal-pertama |
 
 ---
 
@@ -133,27 +133,27 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Pendekatan** | Kompresi gaya output | Proksi perintah shell | **Runtime agen penuh** |
+| **Hemat maksimal** | ~65% token output | ~80% pada perintah shell | **Hingga 96% total** |
+| **Kompresi input** | ❌ | ✅ (difilter) | ✅ **Peta repo + memori neural** |
+| **Kompresi output** | ✅ (caveman-speak) | ❌ | ✅ **Suntingan deterministik nol-token** |
+| **LLM Lokal** | ❌ | ❌ | ✅ **llama.cpp bawaan** |
+| **Multi-agen** | ❌ | ❌ | ✅ **64 → 600 agen lokal** |
+| **Memori antar sesi** | ❌ | ❌ | ✅ **FTS + panggil ulang vektor** |
+| **Rantai bukti** | ❌ | ❌ | ✅ **Tanda terima tersegel sha256** |
+| **Bahasa** | JS/Python (skill) | Rust (biner) | **Rust (biner tunggal)** |
+| **Lisensi** | MIT | Apache 2.0 | Kepemilikan |
+| **Bintang** | 72,5k | 62,2k | ⭐ **Anda pelopor** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Intinya:** Caveman membuat AI *berbicara* lebih sedikit. RTK membuat perintah *mengeluarkan*
+lebih sedikit. Simplicio membuat AI *berpikir* lebih sedikit — dengan mengingat, memetakan,
+menyunting secara deterministik, dan berjalan secara lokal sebelum menyentuh LLM berbayar.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio menghemat 96% di mana Caveman menghemat 65% dan RTK menghemat 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Arsitektur
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -166,34 +166,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM bernalar. Simplicio mengeksekusi secara deterministik.**
 
 ---
 
-## ✨ Features
+## ✨ Fitur
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **Lokal-pertama** — llama.cpp bawaan, naik ke jarak jauh hanya jika diperlukan
+- 🪜 **Agen bertingkat** — 64 → 100 → 200 → 600 agen lokal sebelum cloud berbayar
+- 🔇 **Gerbang kebaruan Shannon** — menyaring output yang redundan (nol token saat dedup)
+- 🔒 **Tanda terima tersegel** — sha256 per artefak, rantai bukti anti-rusak
+- 🛡️ **5 gerbang pengiriman** — penerimaan, validasi, jalankan-verifikasi, regresi, tinjauan-mandiri
+- ⚡ **Gerbang aksi** — klasifikasi risiko + blokir untuk mutasi yang dimulai dari obrolan
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **Gerbang** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Sistem skill** — memuat dan merantai kemampuan yang dapat digunakan ulang
+- 💾 **DB Memori** — FTS persisten + panggil ulang vektor antar sesi
+- 🔀 **Router LLM** — tanpa LLM → LLM lokal → LLM jarak jauh secara otomatis
+- 🖥️ **Lintas-platform** — macOS, Linux, Windows, biner tunggal
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Beta Publik Gratis
 
-**Deterministic commands are FREE forever:**
+**Perintah deterministik GRATIS selamanya:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Fitur AI gratis selama beta publik tanpa tanggal akhir.**
+Penagihan akan ditentukan di pembaruan mendatang.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Persyaratan
 
-| Requirement | Minimum | Recommended |
+| Persyaratan | Minimum | Direkomendasikan |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| Penyimpanan | 5 MB | 1,5 GB (dengan LLM lokal) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Terminal | terminal modern apa saja | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ekosistem
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Situs Web](https://simpleti.com.br/simplicio/#start) — dokumentasi lengkap, tolok ukur, instalasi
+- [Discord](https://discord.gg/wM6tr7xVb) — komunitas dan dukungan
 
 ---
 
-## ⭐ Star History
+## 📄 Lisensi
+
+Kepemilikan. Biner gratis untuk diunduh dan digunakan. Fitur AI gratis selama
+beta publik. Lihat [LICENSE](LICENSE).
+
+---
+
+## ⭐ Riwayat Bintang
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Grafik Riwayat Bintang" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 Komunitas
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — obrolan, dukungan, akses awal
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — laporan bug dan permintaan fitur
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Kode Anda, mesin Anda, 96% lebih murah. 🔥</strong>
 </p>

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — L'Agente AI CHE RISPARMIA FINO AL 96% DEI TUOI TOKEN
 
 <p align="center">
   <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Ultima versione"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stelle"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Download"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licenza"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#-installazione">Installa</a> ·
+  <a href="#-cosa-fa">Funzionalità</a> ·
+  <a href="#-risparmio-token">96% Risparmio</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Sito web</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Lingue:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** è un agente AI da terminale — un singolo binario che sostituisce
+l'intero flusso di lavoro di sviluppo assistito dall'AI: chat, generazione di codice,
+contesto del repository, pianificazione, orchestrazione multi-agente locale (64 → 600 agenti),
+e consegna di PR supportata da prove concrete.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Funziona sulla tua macchina. Il tuo codice non lascia mai il tuo controllo. I modelli remoti sono
+opzionali, non obbligatori.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Risparmia fino al 96% di token rispetto agli agenti tradizionali — più di Caveman (65%) o RTK (80%).**
+> Ogni interazione mostra esattamente quanti token hai risparmiato. Singolo binario Rust, zero dipendenze.
 
-## 🚀 Installation
+## 🚀 Installazione
 
-### npm / npx (any OS)
+### npm / npx (qualsiasi OS)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (qualsiasi OS)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Fatto. Un comando. Nessun package manager, nessuna configurazione del modello.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Risparmio Token — Il 96% è Reale
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Senza Simplicio:** ogni sessione AI riscopre il tuo repository, carica troppo
+contesto, ripete i prompt, brucia token a pagamento.
 
-**With Simplicio:**
+**Con Simplicio:**
 
-| Optimization | Savings |
+| Ottimizzazione | Risparmio |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Mappa del Repository** — contesto compresso invece di leggere file grezzi | ~70% |
+| 🧠 **Memoria Recupero** — i fatti noti non vengono ri-derivati | ~80% |
+| ✏️ **Modifica Deterministica** — modifiche senza spendere token LLM | 100% (output) |
+| 🏠 **LLM Locale** — classificazione, riepilogo, modifiche a basso rischio | ~90% |
+| 📡 **LLM Remoto** — solo per pianificazione e decisioni complesse | ~85% |
+| 🔀 **Fan-out Locale** — 64→600 agenti prima di scalare sul cloud | ~95% |
+| **💎 Combinato: fino al 96% di risparmio totale** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Ogni risposta di Simplicio mostra il risparmio reale:** `Simplicio: ~X token spesi · risparmiati ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Cosa Fa
 
-| Command | Description | Tokens |
+| Comando | Descrizione | Token |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Mappa il repository per gli LLM | ~70% risparmio |
+| `simplicio memory "query"` | Recupero neurale (FTS + vettori) | ~80% risparmio |
+| `simplicio edit '{...}'` | Modifica file deterministica | **Zero token** |
+| `simplicio coding-loop "task"` | Itera finché i test non passano | Auto-riparazione |
+| `simplicio deliver certify` | 5 gate di qualità prima del rilascio | Deterministico |
+| `simplicio run "task" --agents N` | Orchestrazione multi-agente | Locale prima |
 
 ---
 
@@ -133,27 +133,27 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Approccio** | Compressione dello stile di output | Proxy di comandi shell | **Runtime agente completo** |
+| **Risparmio max** | ~65% token output | ~80% su comandi shell | **Fino al 96% totale** |
+| **Compressione input** | ❌ | ✅ (filtrato) | ✅ **Mappa repo + memoria neurale** |
+| **Compressione output** | ✅ (linguaggio cavernicolo) | ❌ | ✅ **Modifiche deterministiche a zero token** |
+| **LLM Locale** | ❌ | ❌ | ✅ **llama.cpp integrato** |
+| **Multi-agente** | ❌ | ❌ | ✅ **64 → 600 agenti locali** |
+| **Memoria tra sessioni** | ❌ | ❌ | ✅ **Recupero FTS + vettoriale** |
+| **Catena di prove** | ❌ | ❌ | ✅ **Ricevute sigillate sha256** |
+| **Linguaggio** | JS/Python (skill) | Rust (binario) | **Rust (singolo binario)** |
+| **Licenza** | MIT | Apache 2.0 | Proprietaria |
+| **Stelle** | 72.5k | 62.2k | ⭐ **Sei tra i primi** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**In sintesi:** Caveman fa *parlare* meno l'AI. RTK fa *produrre* meno output ai comandi.
+Simplicio fa *pensare* meno l'AI — ricordando, mappando, modificando deterministicamente,
+ed eseguendo localmente prima di toccare un LLM a pagamento.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio risparmia il 96% dove Caveman risparmia il 65% e RTK l'80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Architettura
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -161,39 +161,39 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 1. Orient                         | simplicio map
   | 2. Recall                         | simplicio memory
   | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
+  | 4. Edit  ───────────────────────> | simplicio edit (0 token)
   | 5. Verify <─────────────────────  | simplicio deliver certify
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**L'LLM ragiona. Simplicio esegue deterministicamente.**
 
 ---
 
-## ✨ Features
+## ✨ Funzionalità
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **Locale prima** — llama.cpp integrato, scala su remoto solo quando necessario
+- 🪜 **Agenti a livelli** — 64 → 100 → 200 → 600 agenti locali prima del cloud a pagamento
+- 🔇 **Gate di novità Shannon** — filtra output ridondanti (zero token sul dedup)
+- 🔒 **Ricevute sigillate** — sha256 per artefatto, catena di prove a prova di manomissione
+- 🛡️ **5 gate di consegna** — accettazione, validazione, esecuzione-verifica, regressione, auto-revisione
+- ⚡ **Gate d'azione** — classificazione del rischio + blocklist per mutazioni avviate da chat
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **Gateway** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Sistema di skill** — carica e incatena capacità riutilizzabili
+- 💾 **Database di memoria** — recupero FTS + vettoriale persistente tra sessioni
+- 🔀 **Router LLM** — nessun LLM → LLM locale → LLM remoto automaticamente
+- 🖥️ **Multi-piattaforma** — macOS, Linux, Windows, singolo binario
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Beta Pubblica Gratuita
 
-**Deterministic commands are FREE forever:**
+**I comandi deterministici sono GRATUITI per sempre:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Le funzionalità AI sono gratuite durante la beta pubblica senza data di scadenza.**
+La fatturazione sarà definita in aggiornamenti futuri.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Requisiti
 
-| Requirement | Minimum | Recommended |
+| Requisito | Minimo | Consigliato |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| Archiviazione | 5 MB | 1.5 GB (con LLM locale) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Terminale | qualsiasi terminale moderno | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ecosistema
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Sito web](https://simpleti.com.br/simplicio/#start) — documentazione completa, benchmark, installazione
+- [Discord](https://discord.gg/wM6tr7xVb) — community e supporto
 
 ---
 
-## ⭐ Star History
+## 📄 Licenza
+
+Proprietaria. Binario gratuito da scaricare e utilizzare. Funzionalità AI gratuite durante la
+beta pubblica. Vedi [LICENSE](LICENSE).
+
+---
+
+## ⭐ Cronologia Stelle
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Grafico cronologia stelle" width="100%" />
 </a>
 
 ---
 
 ## 💬 Community
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — chat, supporto, accesso anticipato
+- [Issue GitHub](https://github.com/wesleysimplicio/simplicio/issues) — bug e richieste di funzionalità
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Il tuo codice, la tua macchina, il 96% più economico. 🔥</strong>
 </p>

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — トークンを最大96%削減するAIエージェント
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — AIコーディングエージェント" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新リリース"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="スター"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="ダウンロード数"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="ライセンス"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#インストール">インストール</a> ·
+  <a href="#機能一覧">機能一覧</a> ·
+  <a href="#トークン削減効果--96は現実です">トークン削減効果——96%は現実です</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">ウェブサイト</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 言語:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -39,35 +39,31 @@
 
 ---
 
-## ⚡ TL;DR
+## ⚡ TL;DR（概要）
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** はターミナル上で動作するAIコーディングエージェントです——たった1つのバイナリで、チャット、コード生成、リポジトリコンテキスト、計画立案、ローカルでのマルチエージェントオーケストレーション（64 → 600エージェント）、エビデンス付きPR納品まで、AI支援開発ワークフロー全体を置き換えます。
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**あなたのマシン上で動作します。コードがあなたの管理下から離れることはありません。リモートモデルはオプションであり、必須ではありません。**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 従来のエージェントと比較して最大96%のトークンを削減——Caveman（65%）やRTK（80%）を上回ります。**
+> すべての操作で、削減したトークン数が正確に表示されます。単一のRustバイナリ、依存関係ゼロ。
 
-## 🚀 Installation
+## 🚀 インストール
 
-### npm / npx (any OS)
+### npm / npx（全OS対応）
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI（全OS対応）
 
 ```bash
 pip install simplicio-installer
 simplicio install
 ```
 
-### Homebrew (macOS)
+### Homebrew（macOS）
 
 ```bash
 brew install simplicio
@@ -91,41 +87,40 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+完了。たった1つのコマンドです。パッケージマネージャーもモデル設定も不要です。
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 トークン削減効果——96%は現実です
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Simplicioなしの場合:** AIセッションのたびにリポジトリを再検出し、過剰なコンテキストを読み込み、プロンプトを繰り返し、有料トークンを消費します。
 
-**With Simplicio:**
+**Simplicioありの場合:**
 
-| Optimization | Savings |
+| 最適化 | 削減率 |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **リポマップ** — 生ファイルを読む代わりに圧縮コンテキスト | ~70% |
+| 🧠 **メモリーリコール** — 既知の事実を再導出しない | ~80% |
+| ✏️ **決定論的編集** — LLMトークンを消費せずに変更 | 100%（出力） |
+| 🏠 **ローカルLLM** — 分類、要約、低リスク編集 | ~90% |
+| 📡 **リモートLLM** — 計画と複雑な判断のみに使用 | ~85% |
+| 🔀 **ローカルファンアウト** — クラウド拡張前に64→600エージェント | ~95% |
+| **💎 組み合わせ効果: 最大96%の総削減** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Simplicioのすべての応答に実際の削減効果が表示されます:** `Simplicio: ~X トークン消費 · ~Y 削減 (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 機能一覧
 
-| Command | Description | Tokens |
+| コマンド | 説明 | トークン |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | LLM向けにリポジトリをマッピング | ~70%削減 |
+| `simplicio memory "query"` | ニューラルリコール（FTS + ベクトル） | ~80%削減 |
+| `simplicio edit '{...}'` | 決定論的ファイル編集 | **ゼロトークン** |
+| `simplicio coding-loop "task"` | テストが通るまで反復 | 自動修復 |
+| `simplicio deliver certify` | 出荷前に5つの品質ゲートを通過 | 決定論的 |
+| `simplicio run "task" --agents N` | マルチエージェントオーケストレーション | ローカル優先 |
 
 ---
 
@@ -133,67 +128,66 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **アプローチ** | 出力スタイルの圧縮 | シェルコマンドプロキシ | **完全なエージェントランタイム** |
+| **最大削減率** | ~65% 出力トークン | ~80% シェルコマンド | **最大96% 総合** |
+| **入力圧縮** | ❌ | ✅（フィルタリング） | ✅ **リポマップ + ニューラルメモリー** |
+| **出力圧縮** | ✅（原始的な話し方） | ❌ | ✅ **ゼロトークン決定論的編集** |
+| **ローカルLLM** | ❌ | ❌ | ✅ **内蔵 llama.cpp** |
+| **マルチエージェント** | ❌ | ❌ | ✅ **64 → 600 ローカルエージェント** |
+| **セッション間メモリー** | ❌ | ❌ | ✅ **FTS + ベクトルリコール** |
+| **エビデンスチェーン** | ❌ | ❌ | ✅ **sha256封印済みレシート** |
+| **言語** | JS/Python（スキル） | Rust（バイナリ） | **Rust（単一バイナリ）** |
+| **ライセンス** | MIT | Apache 2.0 | Proprietary |
+| **スター数** | 72.5k | 62.2k | ⭐ **あなたが初期ユーザーです** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**結論:** CavemanはAIの*発言*を減らします。RTKはコマンドの*出力*を減らします。
+SimplicioはAIの*思考*を減らします——記憶、マッピング、決定論的編集、そして有料LLMに触れる前にローカルで実行することによって。
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicioは96%削減します。Cavemanは65%、RTKは80%です。** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ アーキテクチャ
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. Orient（方向付け）              | simplicio map
+  | 2. Recall（想起）                  | simplicio memory
+  | 3. Decide（判断）                  |
+  | 4. Edit（編集） ────────────────> | simplicio edit (0 tokens)
+  | 5. Verify（検証）<──────────────  | simplicio deliver certify
+  | 6. Iterate（反復）                 | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLMが推論します。Simplicioが決定論的に実行します。**
 
 ---
 
-## ✨ Features
+## ✨ 特徴
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **ローカル優先** — 内蔵llama.cpp、必要なときだけリモートに拡張
+- 🪜 **階層型エージェント** — 有料クラウドの前に64 → 100 → 200 → 600のローカルエージェント
+- 🔇 **シャノン新規性ゲート** — 冗長な出力をフィルタリング（重複排除でゼロトークン）
+- 🔒 **封印レシート** — アーティファクトごとにsha256、改ざん防止のエビデンスチェーン
+- 🛡️ **5つの納品ゲート** — 受入、検証、実行確認、回帰テスト、自己レビュー
+- ⚡ **アクションゲート** — チャット発信の変更に対するリスク分類 + ブロックリスト
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **ゲートウェイ** — Telegram、Discord、Slack、WhatsApp
+- 🧩 **スキルシステム** — 再利用可能な機能を読み込んで連鎖実行
+- 💾 **メモリDB** — セッション間で永続的なFTS + ベクトルリコール
+- 🔀 **LLMルーター** — LLMなし → ローカルLLM → リモートLLM を自動切替
+- 🖥️ **クロスプラットフォーム** — macOS、Linux、Windows、単一バイナリ
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 無料パブリックベータ
 
-**Deterministic commands are FREE forever:**
-`map`, `validate`, `edit`, `deliver`, `checkpoint`
+**決定論的コマンドは永久無料です:**
+`map`、`validate`、`edit`、`deliver`、`checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**AI機能は期間無制限でパブリックベータ期間中無料です。**
+課金は将来のアップデートで定義されます。
 
 ```bash
 simplicio license status
@@ -201,46 +195,45 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 必要環境
 
-| Requirement | Minimum | Recommended |
+| 要件 | 最小 | 推奨 |
 |---|---|---|
-| RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| RAM | 8 GB | 16 GB以上 |
+| ストレージ | 5 MB | 1.5 GB（ローカルLLM使用時） |
+| OS | macOS 13+、Linux、Windows 10+ | macOS ARM64 |
+| ターミナル | 任意のモダンなターミナル | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 エコシステム
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [ウェブサイト](https://simpleti.com.br/simplicio/#start) — 完全なドキュメント、ベンチマーク、インストール
+- [Discord](https://discord.gg/wM6tr7xVb) — コミュニティとサポート
 
 ---
 
-## ⭐ Star History
+## 📄 ライセンス
+
+Proprietary（プロプライエタリ）。バイナリは無料でダウンロードして使用できます。AI機能はパブリックベータ期間中無料です。詳しくは [LICENSE](LICENSE) をご覧ください。
+
+---
+
+## ⭐ スター履歴
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="スター履歴チャート" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 コミュニティ
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — チャット、サポート、早期アクセス
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — バグ報告と機能リクエスト
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — あなたのコード、あなたのマシン、96%のコスト削減。 🔥</strong>
 </p>

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -1,7 +1,7 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — 토큰을 최대 96%까지 절약하는 AI 에이전트
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — AI 코딩 에이전트" width="920" />
 </p>
 
 <p align="center">
@@ -12,14 +12,14 @@
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#설치">설치</a> ·
+  <a href="#기능">기능</a> ·
+  <a href="#토큰-절약--96는-실제입니다">토큰 절약 — 96%는 실제입니다</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">웹사이트</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 언어:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,25 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio**는 터미널 AI 코딩 에이전트입니다 — 단일 바이너리로 채팅, 코드 생성,
+리포지토리 컨텍스트, 계획 수립, 로컬 멀티에이전트 오케스트레이션 (64 → 600개 에이전트),
+증거 기반 PR 전달 등 AI 지원 개발 워크플로 전체를 대체합니다.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**사용자 머신에서 실행됩니다. 코드는 절대 사용자의 통제를 벗어나지 않습니다.
+원격 모델은 선택 사항이지 필수가 아닙니다.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 기존 에이전트 대비 최대 96% 토큰 절약 — Caveman(65%)이나 RTK(80%)보다 뛰어납니다.**
+> 모든 상호작용에서 정확히 얼마나 많은 토큰을 절약했는지 보여줍니다. 단일 Rust 바이너리, 종속성 제로.
 
-## 🚀 Installation
+## 🚀 설치
 
-### npm / npx (any OS)
+### npm / npx (모든 OS)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (모든 OS)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +90,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+끝. 하나의 명령어입니다. 패키지 매니저도, 모델 설정도 필요 없습니다.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 토큰 절약 — 96%는 실제입니다
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Simplicio 없이:** 매 AI 세션마다 리포지토리를 다시 탐색하고, 너무 많은 컨텍스트를
+로드하며, 프롬프트를 반복하고, 유료 토큰을 소모합니다.
 
-**With Simplicio:**
+**Simplicio와 함께:**
 
-| Optimization | Savings |
+| 최적화 | 절약 |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Repo Map** — 원시 파일을 읽는 대신 압축된 컨텍스트 사용 | ~70% |
+| 🧠 **Memory Recall** — 이미 알려진 사실을 다시 도출하지 않음 | ~80% |
+| ✏️ **Deterministic Editing** — LLM 토큰 소모 없이 변경 수행 | 100% (출력) |
+| 🏠 **Local LLM** — 분류, 요약, 저위험 편집 | ~90% |
+| 📡 **Remote LLM** — 계획 수립 및 복잡한 결정에만 사용 | ~85% |
+| 🔀 **Local Fan-out** — 클라우드 확장 전 64→600개 에이전트 | ~95% |
+| **💎 결합: 최대 96% 총 절약** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**모든 Simplicio 응답에 실제 절약량이 표시됩니다:** `Simplicio: ~X 토큰 사용 · ~Y 절약 (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 기능
 
-| Command | Description | Tokens |
+| 명령어 | 설명 | 토큰 |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | LLM을 위해 리포지토리 매핑 | ~70% 절약 |
+| `simplicio memory "query"` | 신경망 검색 (FTS + 벡터) | ~80% 절약 |
+| `simplicio edit '{...}'` | 결정론적 파일 편집 | **토큰 제로** |
+| `simplicio coding-loop "task"` | 테스트 통과까지 반복 | 자동 복구 |
+| `simplicio deliver certify` | 출시 전 5단계 품질 게이트 | 결정론적 |
+| `simplicio run "task" --agents N` | 멀티에이전트 오케스트레이션 | 로컬 우선 |
 
 ---
 
@@ -133,27 +132,27 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **접근 방식** | 출력 스타일 압축 | 셸 명령 프록시 | **전체 에이전트 런타임** |
+| **최대 절약** | 출력 토큰 ~65% | 셸 명령 ~80% | **최대 96% 전체** |
+| **입력 압축** | ❌ | ✅ (필터링) | ✅ **Repo map + 신경 메모리** |
+| **출력 압축** | ✅ (원시인 말투) | ❌ | ✅ **제로토큰 결정론적 편집** |
+| **로컬 LLM** | ❌ | ❌ | ✅ **내장 llama.cpp** |
+| **멀티에이전트** | ❌ | ❌ | ✅ **64 → 600개 로컬 에이전트** |
+| **세션 간 메모리** | ❌ | ❌ | ✅ **FTS + 벡터 검색** |
+| **증명 체인** | ❌ | ❌ | ✅ **sha256 봉인 영수증** |
+| **언어** | JS/Python (스킬) | Rust (바이너리) | **Rust (단일 바이너리)** |
+| **라이선스** | MIT | Apache 2.0 | Proprietary |
+| **Stars** | 72.5k | 62.2k | ⭐ **당신이 먼저입니다** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**결론:** Caveman은 AI가 *말을* 적게 하게 만듭니다. RTK는 명령어 *출력을* 적게 만듭니다.
+Simplicio는 AI가 *생각을* 적게 하게 만듭니다 — 기억하고, 매핑하고, 결정론적으로 편집하며,
+유료 LLM을 사용하기 전에 로컬에서 실행함으로써 가능합니다.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Caveman이 65%, RTK가 80%를 절약하는 곳에서 Simplicio는 96%를 절약합니다.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ 아키텍처
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -166,34 +165,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM은 추론합니다. Simplicio는 결정론적으로 실행합니다.**
 
 ---
 
-## ✨ Features
+## ✨ 특징
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **로컬 우선** — 내장 llama.cpp, 필요할 때만 원격으로 확장
+- 🪜 **계층형 에이전트** — 유료 클라우드 전 64 → 100 → 200 → 600개 로컬 에이전트
+- 🔇 **Shannon 참신성 게이트** — 중복 출력 필터링 (중복 제거 시 토큰 제로)
+- 🔒 **봉인 영수증** — 아티팩트당 sha256, 변조 방지 증명 체인
+- 🛡️ **5단계 전달 게이트** — 승인, 검증, 실행 확인, 회귀 테스트, 자체 검토
+- ⚡ **액션 게이트** — 채팅 기반 변경에 대한 위험 분류 + 차단 목록
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **게이트웨이** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **스킬 시스템** — 재사용 가능한 기능 로드 및 체이닝
+- 💾 **메모리 DB** — 세션 간 지속적 FTS + 벡터 검색
+- 🔀 **LLM 라우터** — LLM 없음 → 로컬 LLM → 원격 LLM 자동 전환
+- 🖥️ **크로스 플랫폼** — macOS, Linux, Windows, 단일 바이너리
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 무료 공개 베타
 
-**Deterministic commands are FREE forever:**
+**결정론적 명령어는 영원히 무료입니다:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**AI 기능은 공개 베타 기간 동안 종료일 없이 무료입니다.**
+과금은 향후 업데이트에서 정의됩니다.
 
 ```bash
 simplicio license status
@@ -201,32 +200,32 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 시스템 요구사항
 
-| Requirement | Minimum | Recommended |
+| 요구사항 | 최소 | 권장 |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| 저장공간 | 5 MB | 1.5 GB (로컬 LLM 포함 시) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| 터미널 | 모든 최신 터미널 | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 생태계
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [웹사이트](https://simpleti.com.br/simplicio/#start) — 전체 문서, 벤치마크, 설치
+- [Discord](https://discord.gg/wM6tr7xVb) — 커뮤니티 및 지원
 
 ---
 
-## ⭐ Star History
+## 📄 라이선스
+
+Proprietary. 바이너리는 무료로 다운로드 및 사용 가능합니다. AI 기능은
+공개 베타 기간 동안 무료입니다. [LICENSE](LICENSE)를 참조하세요.
+
+---
+
+## ⭐ 스타 기록
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
   <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
@@ -234,13 +233,13 @@ public beta. See [LICENSE](LICENSE).
 
 ---
 
-## 💬 Community
+## 💬 커뮤니티
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — 채팅, 지원, 얼리 액세스
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — 버그 및 기능 요청
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — 당신의 코드, 당신의 머신, 96% 더 저렴하게. 🔥</strong>
 </p>

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — Ejen AI Yang MENJIMATKAN SEHINGGA 96% TOKEN ANDA
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — ejen pengekodan AI" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=terkini" alt="Keluaran Terkini"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Muat Turun"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/licensi-Proprietary-red" alt="Lesen"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#-pemasangan">Pasang</a> ·
+  <a href="#-apa-yang-ia-lakukan">Ciri</a> ·
+  <a href="#-penjimatan-token">Penjimatan 96%</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Laman Web</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Bahasa:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -39,28 +39,28 @@
 
 ---
 
-## ⚡ TL;DR
+## ⚡ RL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** ialah ejen pengekodan AI terminal — satu binari yang menggantikan
+keseluruhan aliran kerja pembangunan berbantu AI anda: sembang, penjanaan kod,
+konteks repositori, perancangan, orkestrasi multi-ejen tempatan (64 → 600 ejen),
+dan penghantaran PR berasaskan bukti.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Berjalan di mesin anda. Kod anda tidak pernah meninggalkan kawalan anda. Model
+jarak jauh adalah pilihan, bukan keperluan.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Jimat sehingga 96% token berbanding ejen tradisional — lebih daripada Caveman (65%) atau RTK (80%).**
+> Setiap interaksi menunjukkan dengan tepat berapa banyak token yang anda jimatkan. Binari Rust tunggal, sifar kebergantungan.
 
-## 🚀 Installation
+## 🚀 Pemasangan
 
-### npm / npx (any OS)
+### npm / npx (sebarang OS)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (sebarang OS)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Selesai. Satu arahan. Tiada pengurus pakej, tiada konfigurasi model.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Penjimatan Token — 96% Adalah Nyata
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Tanpa Simplicio:** setiap sesi AI menemui semula repositori anda, memuatkan terlalu
+banyak konteks, mengulang gesaan, membakar token berbayar.
 
-**With Simplicio:**
+**Dengan Simplicio:**
 
-| Optimization | Savings |
+| Pengoptimuman | Penjimatan |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Peta Repo** — konteks dimampatkan dan bukannya membaca fail mentah | ~70% |
+| 🧠 **Ingatan Semula** — fakta diketahui tidak diterbitkan semula | ~80% |
+| ✏️ **Suntingan Deterministik** — perubahan tanpa menggunakan token LLM | 100% (output) |
+| 🏠 **LLM Tempatan** — pengelasan, rumusan, suntingan berisiko rendah | ~90% |
+| 📡 **LLM Jarak Jauh** — hanya untuk perancangan dan keputusan kompleks | ~85% |
+| 🔀 **Fan-out Tempatan** — 64→600 ejen sebelum penskalaan ke awan | ~95% |
+| **💎 Gabungan: sehingga 96% jumlah penjimatan** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Setiap respons Simplicio menunjukkan penjimatan sebenar:** `Simplicio: ~X token digunakan · jimat ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Apa Yang Ia Lakukan
 
-| Command | Description | Tokens |
+| Perintah | Penerangan | Token |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Memetakan repositori untuk LLM | ~70% penjimatan |
+| `simplicio memory "query"` | Ingatan semula neural (FTS + vektor) | ~80% penjimatan |
+| `simplicio edit '{...}'` | Suntingan fail deterministik | **Sifar token** |
+| `simplicio coding-loop "tugas"` | Berulang sehingga ujian lulus | Auto-pembaikan |
+| `simplicio deliver certify` | 5 pintu kualiti sebelum penghantaran | Deterministik |
+| `simplicio run "tugas" --agents N` | Orkestrasi multi-ejen | Tempatan-dahulu |
 
 ---
 
@@ -133,27 +133,27 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Pendekatan** | Mampatan gaya output | Proksi arahan shell | **Runtime ejen penuh** |
+| **Penjimatan maks** | ~65% token output | ~80% pada arahan shell | **Sehingga 96% jumlah** |
+| **Mampatan input** | ❌ | ✅ (ditapis) | ✅ **Peta repo + ingatan neural** |
+| **Mampatan output** | ✅ (caveman-speak) | ❌ | ✅ **Suntingan deterministik sifar token** |
+| **LLM Tempatan** | ❌ | ❌ | ✅ **llama.cpp terbina dalam** |
+| **Multi-ejen** | ❌ | ❌ | ✅ **64 → 600 ejen tempatan** |
+| **Ingatan merentas sesi** | ❌ | ❌ | ✅ **FTS + ingatan vektor** |
+| **Rantaian bukti** | ❌ | ❌ | ✅ **Resit bermeterai sha256** |
+| **Bahasa** | JS/Python (kemahiran) | Rust (binari) | **Rust (binari tunggal)** |
+| **Lesen** | MIT | Apache 2.0 | Proprietari |
+| **Bintang** | 72.5k | 62.2k | ⭐ **Anda awal** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Kesimpulan:** Caveman membuat AI *bercakap* kurang. RTK membuat arahan *output* kurang.
+Simplicio membuat AI *berfikir* kurang — dengan mengingat, memetakan, menyunting secara
+deterministik, dan berjalan secara tempatan sebelum menyentuh LLM berbayar.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio menjimatkan 96% di mana Caveman menjimatkan 65% dan RTK menjimatkan 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Seni Bina
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -166,34 +166,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM menaakul. Simplicio melaksana secara deterministik.**
 
 ---
 
-## ✨ Features
+## ✨ Ciri
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **Tempatan-dahulu** — llama.cpp terbina dalam, skala ke jarak jauh hanya apabila perlu
+- 🪜 **Ejen bertingkat** — 64 → 100 → 200 → 600 ejen tempatan sebelum awan berbayar
+- 🔇 **Gerbang kebaharuan Shannon** — menapis output berlebihan (sifar token pada dedup)
+- 🔒 **Resit bermeterai** — sha256 setiap artifak, rantaian bukti kalis gangguan
+- 🛡️ **5 pintu penghantaran** — penerimaan, pengesahan, laksana-verify, regresi, semakan sendiri
+- ⚡ **Gerbang tindakan** — pengelasan risiko + senarai blok untuk mutasi cetusan sembang
+- 🔌 **MCP/ACP** — Protokol Konteks Model + Protokol Klien Ejen
+- 🌐 **Gerbang** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Sistem kemahiran** — memuat dan merantai kebolehan boleh guna semula
+- 💾 **Pangkalan data ingatan** — FTS berterusan + ingatan vektor merentas sesi
+- 🔀 **Penghala LLM** — tiada LLM → LLM tempatan → LLM jarak jauh secara automatik
+- 🖥️ **Merentas platform** — macOS, Linux, Windows, binari tunggal
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Beta Awam Percuma
 
-**Deterministic commands are FREE forever:**
+**Perintah deterministik adalah PERCUMA selama-lamanya:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Ciri AI adalah percuma semasa beta awam tanpa tarikh tamat.**
+Pengecasan akan ditentukan dalam kemas kini akan datang.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Keperluan
 
-| Requirement | Minimum | Recommended |
+| Keperluan | Minimum | Disarankan |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
+| Storan | 5 MB | 1.5 GB (dengan LLM tempatan) |
 | OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Terminal | mana-mana terminal moden | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ekosistem
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Laman Web](https://simpleti.com.br/simplicio/#start) — dokumen penuh, penanda aras, pemasangan
+- [Discord](https://discord.gg/wM6tr7xVb) — komuniti dan sokongan
 
 ---
 
-## ⭐ Star History
+## 📄 Lesen
+
+Proprietari. Binari percuma untuk dimuat turun dan digunakan. Ciri AI percuma
+semasa beta awam. Lihat [LICENSE](LICENSE).
+
+---
+
+## ⭐ Sejarah Bintang
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Carta Sejarah Bintang" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 Komuniti
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — sembang, sokongan, akses awal
+- [Isu GitHub](https://github.com/wesleysimplicio/simplicio/issues) — pepijat dan permintaan ciri
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Kod anda, mesin anda, 96% lebih murah. 🔥</strong>
 </p>

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -1,7 +1,7 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — Agent AI, KTÓRY OSZCZĘDZA DO 96% TWOICH TOKENÓW
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — agent AI do kodowania" width="920" />
 </p>
 
 <p align="center">
@@ -12,14 +12,14 @@
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#instalacja">Instalacja</a> ·
+  <a href="#co-robi">Co robi</a> ·
+  <a href="#oszczędność-tokenów--96-to-rzeczywistość">Oszczędność tokenów — 96% to rzeczywistość</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Strona WWW</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Języki:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** to terminalowy agent AI do kodowania — pojedynczy plik binarny, który zastępuje
+cały twój workflow wspomagany AI: czat, generowanie kodu, kontekst repozytorium,
+planowanie, lokalną orkiestrację wieloagentową (64 → 600 agentów) i
+dostarczanie PR z potwierdzeniem dowodów.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Działa na twojej maszynie. Twój kod nigdy nie opuszcza twojej kontroli. Modele zdalne są
+opcjonalne, nie wymagane.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Oszczędź do 96% tokenów w porównaniu z tradycyjnymi agentami — więcej niż Caveman (65%) czy RTK (80%).**
+> Każda interakcja pokazuje dokładnie, ile tokenów zaoszczędziłeś. Pojedynczy plik binarny w Ruście, zero zależności.
 
-## 🚀 Installation
+## 🚀 Instalacja
 
-### npm / npx (any OS)
+### npm / npx (dowolny system)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (dowolny system)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Gotowe. Jedno polecenie. Żaden menedżer pakietów, żadna konfiguracja modelu.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Oszczędność tokenów — 96% to rzeczywistość
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Bez Simplicio:** każda sesja AI odkrywa twoje repozytorium na nowo, ładuje zbyt dużo
+kontekstu, powtarza prompty, spala płatne tokeny.
 
-**With Simplicio:**
+**Z Simplicio:**
 
-| Optimization | Savings |
+| Optymalizacja | Oszczędność |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Mapa repozytorium** — skompresowany kontekst zamiast czytania surowych plików | ~70% |
+| 🧠 **Pamięć** — znane fakty nie są wyciągane na nowo | ~80% |
+| ✏️ **Deterministyczna edycja** — zmiany bez wydawania tokenów LLM | 100% (output) |
+| 🏠 **Lokalny LLM** — klasyfikacja, podsumowywanie, mało ryzykowne edycje | ~90% |
+| 📡 **Zdalny LLM** — tylko do planowania i złożonych decyzji | ~85% |
+| 🔀 **Lokalne rozgałęzianie** — 64→600 agentów przed skalowaniem do chmury | ~95% |
+| **💎 Łącznie: do 96% całkowitych oszczędności** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Każda odpowiedź Simplicio pokazuje rzeczywiste oszczędności:** `Simplicio: ~X tokenów wydanych · zaoszczędzono ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Co robi
 
-| Command | Description | Tokens |
+| Polecenie | Opis | Tokeny |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Mapuje repozytorium dla LLM-ów | ~70% oszczędności |
+| `simplicio memory "query"` | Neuronowe przywoływanie (FTS + wektory) | ~80% oszczędności |
+| `simplicio edit '{...}'` | Deterministyczna edycja plików | **Zero tokenów** |
+| `simplicio coding-loop "task"` | Iteruje, aż testy przejdą | Auto-naprawa |
+| `simplicio deliver certify` | 5 bram jakości przed wydaniem | Deterministyczne |
+| `simplicio run "task" --agents N` | Orkiestracja wieloagentowa | Lokalnie najpierw |
 
 ---
 
@@ -133,27 +133,27 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Podejście** | Kompresja stylu wypowiedzi | Proxy poleceń powłoki | **Pełne środowisko uruchomieniowe agenta** |
+| **Maks. oszczędność** | ~65% tokenów wyjściowych | ~80% na poleceniach powłoki | **Do 96% łącznie** |
+| **Kompresja wejścia** | ❌ | ✅ (filtrowane) | ✅ **Mapa repozytorium + pamięć neuronowa** |
+| **Kompresja wyjścia** | ✅ (język jaskiniowca) | ❌ | ✅ **Deterministyczne edycje za zero tokenów** |
+| **Lokalny LLM** | ❌ | ❌ | ✅ **Wbudowany llama.cpp** |
+| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 lokalnych agentów** |
+| **Pamięć między sesjami** | ❌ | ❌ | ✅ **FTS + przywoływanie wektorowe** |
+| **Łańcuch dowodów** | ❌ | ❌ | ✅ **Pieczęcie sha256** |
+| **Język** | JS/Python (skill) | Rust (binarny) | **Rust (pojedynczy plik binarny)** |
+| **Licencja** | MIT | Apache 2.0 | Proprietary |
+| **Gwiazdki** | 72,5k | 62,2k | ⭐ **Jesteś wcześnie** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Podsumowanie:** Caveman sprawia, że AI *mówi* mniej. RTK sprawia, że polecenia *wyświetlają* mniej.
+Simplicio sprawia, że AI *myśli* mniej — przez zapamiętywanie, mapowanie, deterministyczne edycje
+i działanie lokalnie, zanim kiedykolwiek dotknie płatnego LLM-a.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio oszczędza 96%, podczas gdy Caveman oszczędza 65%, a RTK 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Architektura
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
@@ -166,34 +166,34 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   | 6. Iterate                        | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM rozumuje. Simplicio wykonuje deterministycznie.**
 
 ---
 
-## ✨ Features
+## ✨ Funkcje
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **Lokalnie najpierw** — wbudowany llama.cpp, skaluje do zdalnych tylko gdy potrzebne
+- 🪜 **Warstwowi agenci** — 64 → 100 → 200 → 600 lokalnych agentów przed płatną chmurą
+- 🔇 **Bramka nowości Shannona** — filtruje zbędne wyjścia (zero tokenów na deduplikacji)
+- 🔒 **Zapieczętowane paragony** — sha256 na artefakt, odporny na manipulacje łańcuch dowodów
+- 🛡️ **5 bram dostarczania** — akceptacja, walidacja, uruchom-weryfikuj, regresja, samoocena
+- ⚡ **Bramka akcji** — klasyfikacja ryzyka + lista blokowana dla mutacji inicjowanych z czatu
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **Bramy** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **System umiejętności** — ładuje i łańcuchuje wielokrotnego użytku możliwości
+- 💾 **Baza pamięci** — trwałe FTS + przywoływanie wektorowe między sesjami
+- 🔀 **Router LLM** — brak LLM → lokalny LLM → zdalny LLM automatycznie
+- 🖥️ **Wieloplatformowość** — macOS, Linux, Windows, pojedynczy plik binarny
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Darmowa Beta Publiczna
 
-**Deterministic commands are FREE forever:**
+**Deterministyczne polecenia są DARMOWE na zawsze:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Funkcje AI są darmowe podczas publicznej bety bez daty zakończenia.**
+Rozliczenia zostaną zdefiniowane w przyszłych aktualizacjach.
 
 ```bash
 simplicio license status
@@ -201,32 +201,32 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Wymagania
 
-| Requirement | Minimum | Recommended |
+| Wymaganie | Minimalne | Zalecane |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Miejsce na dysku | 5 MB | 1,5 GB (z lokalnym LLM) |
+| System | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| Terminal | dowolny nowoczesny terminal | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ekosystem
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Strona WWW](https://simpleti.com.br/simplicio/#start) — pełna dokumentacja, benchmarki, instalacja
+- [Discord](https://discord.gg/wM6tr7xVb) — społeczność i wsparcie
 
 ---
 
-## ⭐ Star History
+## 📄 Licencja
+
+Proprietary. Plik binarny darmowy do pobrania i użytku. Funkcje AI darmowe podczas
+publicznej bety. Zobacz [LICENSE](LICENSE).
+
+---
+
+## ⭐ Historia gwiazdek
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
   <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
@@ -234,13 +234,13 @@ public beta. See [LICENSE](LICENSE).
 
 ---
 
-## 💬 Community
+## 💬 Społeczność
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — czat, wsparcie, wczesny dostęp
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — błędy i prośby o funkcje
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Twój kod, twoja maszyna, 96% taniej. 🔥</strong>
 </p>

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — O Agente de IA que ECONOMIZA ATÉ 96% DOS SEUS TOKENS
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — Agente de IA para codificação" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Último Lançamento"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrelas"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licença"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#-instalação">Instalar</a> ·
+  <a href="#-o-que-faz">Funcionalidades</a> ·
+  <a href="#-economia-de-tokens">96% de Economia</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Site</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Idiomas:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** é um agente de IA de codificação para terminal — um único binário que substitui
+todo o seu fluxo de desenvolvimento assistido por IA: chat, geração de código, contexto
+de repositório, planejamento, orquestração local multi-agente (64 → 600 agentes) e
+entrega de PR com evidências verificáveis.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Roda na sua máquina. Seu código nunca sai do seu controle. Modelos remotos são
+opcionais, não obrigatórios.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Economize até 96% de tokens comparado a agentes tradicionais — mais que Caveman (65%) ou RTK (80%).**
+> Cada interação mostra exatamente quantos tokens você economizou. Um único binário Rust, zero dependências.
 
-## 🚀 Installation
+## 🚀 Instalação
 
-### npm / npx (any OS)
+### npm / npx (qualquer SO)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (qualquer SO)
 
 ```bash
 pip install simplicio-installer
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Pronto. Um comando. Sem gerenciador de pacotes, sem configuração de modelo.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Economia de Tokens — 96% é Real
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Sem Simplicio:** a cada sessão de IA o repositório é redescoberto, carrega contexto
+demais, repete prompts, queima tokens pagos.
 
-**With Simplicio:**
+**Com Simplicio:**
 
-| Optimization | Savings |
+| Otimização | Economia |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Mapa do Repositório** — contexto comprimido em vez de ler arquivos brutos | ~70% |
+| 🧠 **Memória Recorrente** — fatos conhecidos não são redescobertos | ~80% |
+| ✏️ **Edição Determinística** — mudanças sem gastar tokens de LLM | 100% (saída) |
+| 🏠 **LLM Local** — classificação, sumarização, edições de baixo risco | ~90% |
+| 📡 **LLM Remoto** — apenas para planejamento e decisões complexas | ~85% |
+| 🔀 **Fan-out Local** — 64→600 agentes antes de escalar para a nuvem | ~95% |
+| **💎 Combinado: até 96% de economia total** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Toda resposta do Simplicio mostra a economia real:** `Simplicio: ~X tokens gastos · economizou ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 O Que Faz
 
-| Command | Description | Tokens |
+| Comando | Descrição | Tokens |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Mapeia o repositório para LLMs | ~70% de economia |
+| `simplicio memory "consulta"` | Recuperação neural (FTS + vetores) | ~80% de economia |
+| `simplicio edit '{...}'` | Edição determinística de arquivos | **Zero tokens** |
+| `simplicio coding-loop "tarefa"` | Itera até os testes passarem | Auto-reparo |
+| `simplicio deliver certify` | 5 portais de qualidade antes do envio | Determinístico |
+| `simplicio run "tarefa" --agents N` | Orquestração multi-agente | Local-first |
 
 ---
 
@@ -133,67 +133,67 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Abordagem** | Compressão de estilo de saída | Proxy de comandos shell | **Runtime completo de agente** |
+| **Economia máxima** | ~65% tokens de saída | ~80% em comandos shell | **Até 96% total** |
+| **Compressão de entrada** | ❌ | ✅ (filtrada) | ✅ **Mapa do repositório + memória neural** |
+| **Compressão de saída** | ✅ (fala de caverna) | ❌ | ✅ **Edições determinísticas de zero token** |
+| **LLM Local** | ❌ | ❌ | ✅ **llama.cpp embutido** |
+| **Multi-agente** | ❌ | ❌ | ✅ **64 → 600 agentes locais** |
+| **Memória entre sessões** | ❌ | ❌ | ✅ **FTS + recall vetorial** |
+| **Cadeia de evidências** | ❌ | ❌ | ✅ **Recibos lacrados com sha256** |
+| **Linguagem** | JS/Python (skill) | Rust (binário) | **Rust (binário único)** |
+| **Licença** | MIT | Apache 2.0 | Proprietária |
+| **Estrelas** | 72.5k | 62.2k | ⭐ **Você é dos primeiros** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Conclusão:** Caveman faz a IA *falar* menos. RTK faz os comandos *saírem* menos.
+Simplicio faz a IA *pensar* menos — ao lembrar, mapear, editar deterministicamente
+e rodar localmente antes de tocar num LLM pago.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio economiza 96% enquanto Caveman economiza 65% e RTK economiza 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Arquitetura
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. Orientar                       | simplicio map
+  | 2. Recuperar                      | simplicio memory
+  | 3. Decidir                        |
+  | 4. Editar ──────────────────────> | simplicio edit (0 tokens)
+  | 5. Verificar <─────────────────── | simplicio deliver certify
+  | 6. Iterar                         | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**O LLM raciocina. O Simplicio executa deterministicamente.**
 
 ---
 
-## ✨ Features
+## ✨ Funcionalidades
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
+- 🏠 **Local-first** — llama.cpp embutido, escala para remoto somente quando necessário
+- 🪜 **Agentes em camadas** — 64 → 100 → 200 → 600 agentes locais antes da nuvem paga
+- 🔇 **Portão de novidade Shannon** — filtra saídas redundantes (zero tokens em dedup)
+- 🔒 **Recibos lacrados** — sha256 por artefato, cadeia de evidências à prova de adulteração
+- 🛡️ **5 portais de entrega** — aceitação, validação, execução-verificação, regressão, auto-revisão
+- ⚡ **Portão de ação** — classificação de risco + lista de bloqueio para mutações iniciadas por chat
+- 🔌 **MCP/ACP** — Protocolo de Contexto de Modelo + Protocolo de Cliente Agente
 - 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🧩 **Sistema de skills** — carrega e encadeia capacidades reutilizáveis
+- 💾 **Banco de memória** — FTS persistente + recall vetorial entre sessões
+- 🔀 **Roteador de LLM** — sem LLM → LLM local → LLM remoto automaticamente
+- 🖥️ **Multiplataforma** — macOS, Linux, Windows, binário único
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Beta Público Gratuito
 
-**Deterministic commands are FREE forever:**
+**Comandos determinísticos são GRATUITOS para sempre:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**Funcionalidades de IA são gratuitas durante o beta público sem data de término.**
+A cobrança será definida em atualizações futuras.
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Requisitos
 
-| Requirement | Minimum | Recommended |
+| Requisito | Mínimo | Recomendado |
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| Armazenamento | 5 MB | 1.5 GB (com LLM local) |
+| SO | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| Terminal | qualquer terminal moderno | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Ecossistema
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Site](https://simpleti.com.br/simplicio/#start) — documentação completa, benchmarks, instalação
+- [Discord](https://discord.gg/wM6tr7xVb) — comunidade e suporte
 
 ---
 
-## ⭐ Star History
+## 📄 Licença
+
+Proprietária. Binário gratuito para baixar e usar. Funcionalidades de IA gratuitas
+durante o beta público. Consulte [LICENSE](LICENSE).
+
+---
+
+## ⭐ Histórico de Estrelas
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Gráfico do Histórico de Estrelas" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 Comunidade
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — chat, suporte, acesso antecipado
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs e pedidos de funcionalidades
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Seu código, sua máquina, 96% mais barato. 🔥</strong>
 </p>

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -1,4 +1,4 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — AI-агент, который ЭКОНОМИТ ДО 96% ВАШИХ ТОКЕНОВ
 
 <p align="center">
   <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
@@ -12,14 +12,14 @@
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#установка">Установка</a> ·
+  <a href="#что-он-делает">Что он делает</a> ·
+  <a href="#экономия-токенов--96-реальны">Экономия токенов — 96% реальны</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Сайт</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 Языки:</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -41,26 +41,26 @@
 
 ## ⚡ TL;DR
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** — это терминальный AI-агент для кода: один бинарный файл, который заменяет весь
+ваш AI-ассистируемый рабочий процесс: чат, генерацию кода, контекст репозитория,
+планирование, локальную многoагентную оркестрацию (64 → 600 агентов) и
+доставку PR с подтверждением.
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**Работает на вашей машине. Ваш код никогда не покидает вашего контроля. Удалённые модели
+необязательны, не обязательны.**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 Экономьте до 96% токенов по сравнению с традиционными агентами — больше, чем Caveman (65%) или RTK (80%).**
+> Каждое взаимодействие показывает, сколько токенов вы сэкономили. Один бинарный файл на Rust, без зависимостей.
 
-## 🚀 Installation
+## 🚀 Установка
 
-### npm / npx (any OS)
+### npm / npx (любая ОС)
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI (любая ОС)
 
 ```bash
 pip install simplicio-installer
@@ -91,109 +91,109 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+Готово. Одна команда. Никакого менеджера пакетов, никакой настройки модели.
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Экономия токенов — 96% реальны
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**Без Simplicio:** каждый сеанс AI заново исследует ваш репозиторий, загружает слишком много
+контекста, повторяет промпты, сжигает платные токены.
 
-**With Simplicio:**
+**С Simplicio:**
 
-| Optimization | Savings |
+| Оптимизация | Экономия |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **Карта репозитория** — сжатый контекст вместо чтения сырых файлов | ~70% |
+| 🧠 **Память** — известные факты не выводятся заново | ~80% |
+| ✏️ **Детерминированное редактирование** — изменения без затрат токенов LLM | 100% (вывод) |
+| 🏠 **Локальная LLM** — классификация, суммаризация, низкорисковые правки | ~90% |
+| 📡 **Удалённая LLM** — только для планирования и сложных решений | ~85% |
+| 🔀 **Локальный Fan-out** — 64→600 агентов до масштабирования в облако | ~95% |
+| **💎 Комбинация: до 96% общей экономии** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**Каждый ответ Simplicio показывает реальную экономию:** `Simplicio: ~X токенов потрачено · сэкономлено ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 Что он делает
 
-| Command | Description | Tokens |
+| Команда | Описание | Токены |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | Создаёт карту репозитория для LLM | ~70% экономии |
+| `simplicio memory "запрос"` | Нейронное recall (FTS + векторы) | ~80% экономии |
+| `simplicio edit '{...}'` | Детерминированное редактирование файлов | **Ноль токенов** |
+| `simplicio coding-loop "задача"` | Итерации до прохождения тестов | Автоисправление |
+| `simplicio deliver certify` | 5 контрольных точек перед доставкой | Детерминированно |
+| `simplicio run "задача" --agents N` | Многоагентная оркестрация | Локально в первую очередь |
 
 ---
 
-## 🆚 Simplicio vs Caveman vs RTK
+## 🆚 Simplicio против Caveman против RTK
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **Подход** | Сжатие стиля вывода | Прокси команд оболочки | **Полноценный агентный рантайм** |
+| **Макс. экономия** | ~65% токенов вывода | ~80% команд оболочки | **До 96% всего** |
+| **Сжатие ввода** | ❌ | ✅ (фильтрация) | ✅ **Карта репозитория + нейронная память** |
+| **Сжатие вывода** | ✅ (caveman-речь) | ❌ | ✅ **Детерминированные правки за 0 токенов** |
+| **Локальная LLM** | ❌ | ❌ | ✅ **Встроенная llama.cpp** |
+| **Многоагентность** | ❌ | ❌ | ✅ **64 → 600 локальных агентов** |
+| **Память между сессиями** | ❌ | ❌ | ✅ **FTS + векторный recall** |
+| **Цепочка доказательств** | ❌ | ❌ | ✅ **sha256 опечатанные квитанции** |
+| **Язык** | JS/Python (навык) | Rust (бинарник) | **Rust (один бинарник)** |
+| **Лицензия** | MIT | Apache 2.0 | Проприетарная |
+| **Звёзды** | 72.5k | 62.2k | ⭐ **Вы на старте** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**Суть:** Caveman заставляет AI *меньше говорить*. RTK заставляет команды *меньше выводить*.
+Simplicio заставляет AI *меньше думать* — запоминая, картографируя, редактируя детерминированно
+и работая локально, прежде чем обращаться к платной LLM.
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio экономит 96% там, где Caveman экономит 65%, а RTK — 80%.** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ Архитектура
 
 ```
 LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. Ориентация                     | simplicio map
+  | 2. Воспоминание                   | simplicio memory
+  | 3. Решение                        |
+  | 4. Редактирование ──────────────> | simplicio edit (0 токенов)
+  | 5. Проверка <───────────────────  | simplicio deliver certify
+  | 6. Итерация                       | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM рассуждает. Simplicio выполняет детерминированно.**
 
 ---
 
-## ✨ Features
+## ✨ Возможности
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🏠 **Локально в первую очередь** — встроенная llama.cpp, масштабирование на удалённые модели только при необходимости
+- 🪜 **Уровневые агенты** — 64 → 100 → 200 → 600 локальных агентов до платного облака
+- 🔇 **Шенноновский фильтр новизны** — отфильтровывает избыточные выводы (ноль токенов на дедупликацию)
+- 🔒 **Опечатанные квитанции** — sha256 для каждого артефакта, защищённая от взлома цепочка доказательств
+- 🛡️ **5 шлюзов доставки** — приёмка, валидация, запуск-проверка, регрессия, саморецензия
+- ⚡ **Шлюз действий** — классификация рисков + блоклист для мутаций, инициированных чатом
 - 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🌐 **Шлюзы** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Система навыков** — загрузка и цепочки переиспользуемых возможностей
+- 💾 **База памяти** — постоянный FTS + векторный recall между сессиями
+- 🔀 **Маршрутизатор LLM** — без LLM → локальная LLM → удалённая LLM автоматически
+- 🖥️ **Кроссплатформенность** — macOS, Linux, Windows, один бинарник
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Бесплатная публичная бета
 
-**Deterministic commands are FREE forever:**
+**Детерминированные команды БЕСПЛАТНЫ навсегда:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**AI-функции бесплатны в период публичной беты без указания даты окончания.**
+Оплата будет определена в будущих обновлениях.
 
 ```bash
 simplicio license status
@@ -201,32 +201,32 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 Требования
 
-| Requirement | Minimum | Recommended |
+| Требование | Минимум | Рекомендуется |
 |---|---|---|
-| RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| ОЗУ | 8 ГБ | 16 ГБ+ |
+| Диск | 5 МБ | 1.5 ГБ (с локальной LLM) |
+| ОС | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| Терминал | любой современный терминал | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 Экосистема
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [Веб-сайт](https://simpleti.com.br/simplicio/#start) — полная документация, бенчмарки, установка
+- [Discord](https://discord.gg/wM6tr7xVb) — сообщество и поддержка
 
 ---
 
-## ⭐ Star History
+## 📄 Лицензия
+
+Проприетарная. Бинарный файл можно бесплатно скачивать и использовать. AI-функции бесплатны в период
+публичной беты. См. [LICENSE](LICENSE).
+
+---
+
+## ⭐ История звёзд
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
   <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
@@ -234,13 +234,13 @@ public beta. See [LICENSE](LICENSE).
 
 ---
 
-## 💬 Community
+## 💬 Сообщество
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — чат, поддержка, ранний доступ
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — баги и запросы функций
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — Ваш код, ваша машина, на 96% дешевле. 🔥</strong>
 </p>

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -1,25 +1,25 @@
-# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
+# 🔥 Simplicio — 最多可节省高达 96% 的 Token 的 AI 智能体
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="assets/simplicio-hero.png" alt="Simplicio — AI 编程助手" width="920" />
 </p>
 
 <p align="center">
-  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
-  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新版本"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="星标"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="下载量"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="许可证"></a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a> ·
-  <a href="#-what-it-does">Features</a> ·
-  <a href="#-token-savings">96% Savings</a> ·
-  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+  <a href="#-安装">安装</a> ·
+  <a href="#-功能简介">功能</a> ·
+  <a href="#-token-节省">96% 节省</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">官网</a>
 </p>
 
 <p align="center">
-  <strong>🌍 Languages:</strong><br>
+  <strong>🌍 语言：</strong><br>
   <a href="README.md">🇬🇧 English</a> |
   <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
   <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
@@ -39,35 +39,35 @@
 
 ---
 
-## ⚡ TL;DR
+## ⚡ 快速概览
 
-**Simplicio** is a terminal AI coding agent — a single binary that replaces your
-entire AI-assisted development workflow: chat, code generation, repository
-context, planning, local multi-agent orchestration (64 → 600 agents), and
-evidence-backed PR delivery.
+**Simplicio** 是一款终端 AI 编程代理——一个单一二进制文件即可替代你的
+整个 AI 辅助开发工作流：聊天、代码生成、仓库上下文、
+规划、本地多智能体编排（64 → 600 个代理）以及
+基于证据的 PR 交付。
 
-**Runs on your machine. Your code never leaves your control. Remote models are
-optional, not required.**
+**运行在你的机器上。你的代码始终在你的掌控之中。远程模型是
+可选项，而非必需项。**
 
-> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
-> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
+> **🔥 相比传统代理，最多可节省 96% 的 Token——超过 Caveman (65%) 或 RTK (80%)。**
+> 每次交互都会精确显示你节省了多少 Token。单一 Rust 二进制文件，零依赖。
 
-## 🚀 Installation
+## 🚀 安装
 
-### npm / npx (any OS)
+### npm / npx（支持所有操作系统）
 
 ```bash
 npx simplicio install
 ```
 
-### pip / PyPI (any OS)
+### pip / PyPI（支持所有操作系统）
 
 ```bash
 pip install simplicio-installer
 simplicio install
 ```
 
-### Homebrew (macOS)
+### Homebrew（macOS）
 
 ```bash
 brew install simplicio
@@ -91,41 +91,41 @@ curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/inst
 powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/main/install.ps1 | iex"
 ```
 
-Done. One command. No package manager, no model configuration.
+完成。一条命令。无需包管理器，无需模型配置。
 
 ---
 
-## 💰 Token Savings — 96% is Real
+## 💰 Token 节省——96% 是真实可得的
 
-**Without Simplicio:** every AI session rediscovers your repo, loads too much
-context, repeats prompts, burns paid tokens.
+**没有 Simplicio：** 每次 AI 会话都重新探索你的仓库，加载过多
+上下文，重复提示，消耗付费 Token。
 
-**With Simplicio:**
+**有了 Simplicio：**
 
-| Optimization | Savings |
+| 优化项 | 节省比例 |
 |---|---|
-| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
-| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
-| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
-| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
-| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
-| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
-| **💎 Combined: up to 96% total savings** | **~96%** |
+| 🗺️ **仓库地图** — 压缩上下文，而非读取原始文件 | ~70% |
+| 🧠 **记忆召回** — 已知事实无需重新推导 | ~80% |
+| ✏️ **确定性编辑** — 无需消耗 LLM Token 即可完成更改 | 100%（输出端） |
+| 🏠 **本地 LLM** — 分类、摘要、低风险编辑 | ~90% |
+| 📡 **远程 LLM** — 仅用于规划和复杂决策 | ~85% |
+| 🔀 **本地扇出** — 64→600 个代理，无需扩展至云端 | ~95% |
+| **💎 综合：最高可节省 96%** | **~96%** |
 
-**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+**每次 Simplicio 响应都会显示真实节省：** `Simplicio: ~X 个 Token 已使用 · 节省 ~Y (Z%)`
 
 ---
 
-## 🎯 What It Does
+## 🎯 功能简介
 
-| Command | Description | Tokens |
+| 命令 | 描述 | Token |
 |---|---|---|
-| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
-| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
-| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
-| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
-| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
-| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+| `simplicio map --repo .` | 为 LLM 映射仓库结构 | ~70% 节省 |
+| `simplicio memory "query"` | 神经记忆召回（全文搜索 + 向量） | ~80% 节省 |
+| `simplicio edit '{...}'` | 确定性文件编辑 | **零 Token** |
+| `simplicio coding-loop "task"` | 迭代直到测试通过 | 自动修复 |
+| `simplicio deliver certify` | 交付前通过 5 道质量关卡 | 确定性 |
+| `simplicio run "task" --agents N` | 多智能体编排 | 本地优先 |
 
 ---
 
@@ -133,67 +133,67 @@ context, repeats prompts, burns paid tokens.
 
 | | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
 |---|---|---|---|
-| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
-| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
-| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
-| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
-| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
-| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
-| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
-| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
-| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
-| **License** | MIT | Apache 2.0 | Proprietary |
-| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+| **方法** | 输出风格压缩 | Shell 命令代理 | **完整智能体运行时** |
+| **最大节省** | ~65% 输出 Token | ~80% 在 shell 命令上 | **最高 96% 总计** |
+| **输入压缩** | ❌ | ✅（过滤） | ✅ **仓库地图 + 神经记忆** |
+| **输出压缩** | ✅（原始人语） | ❌ | ✅ **零 Token 确定性编辑** |
+| **本地 LLM** | ❌ | ❌ | ✅ **内置 llama.cpp** |
+| **多智能体** | ❌ | ❌ | ✅ **64 → 600 个本地代理** |
+| **跨会话记忆** | ❌ | ❌ | ✅ **全文搜索 + 向量召回** |
+| **证据链** | ❌ | ❌ | ✅ **sha256 密封收据** |
+| **语言** | JS/Python（技能） | Rust（二进制） | **Rust（单一二进制）** |
+| **许可证** | MIT | Apache 2.0 | 专有许可 |
+| **星标** | 72.5k | 62.2k | ⭐ **你来得真早** |
 
-**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
-Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
-and running locally before ever touching a paid LLM.
+**底线：** Caveman 让 AI *少说*。RTK 让命令 *少输出*。
+Simplicio 让 AI *少想*——通过记忆、映射、确定性编辑，
+以及在触及付费 LLM 之前在本地运行。
 
-| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+| **Simplicio 节省 96%，而 Caveman 节省 65%，RTK 节省 80%。** |
 
 ---
 
-## 🏗️ Architecture
+## 🏗️ 架构
 
 ```
-LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
+LLM (Claude/Codex/Gemini)          Simplicio 运行时 (Rust)
   |                                   |
-  | 1. Orient                         | simplicio map
-  | 2. Recall                         | simplicio memory
-  | 3. Decide                         |
-  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
-  | 5. Verify <─────────────────────  | simplicio deliver certify
-  | 6. Iterate                        | simplicio coding-loop
+  | 1. 定位                           | simplicio map
+  | 2. 回忆                           | simplicio memory
+  | 3. 决策                           |
+  | 4. 编辑  ───────────────────────> | simplicio edit (0 Token)
+  | 5. 验证 <─────────────────────  | simplicio deliver certify
+  | 6. 迭代                           | simplicio coding-loop
 ```
 
-**The LLM reasons. Simplicio executes deterministically.**
+**LLM 负责推理。Simplicio 负责确定性执行。**
 
 ---
 
-## ✨ Features
+## ✨ 特性
 
-- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
-- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
-- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
-- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
-- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
-- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
-- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
-- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
-- 🧩 **Skill system** — loads and chains reusable capabilities
-- 💾 **Memory DB** — persistent FTS + vector recall across sessions
-- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
-- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+- 🏠 **本地优先** — 内置 llama.cpp，仅在需要时扩展至远程
+- 🪜 **分层代理** — 64 → 100 → 200 → 600 个本地代理，之后才使用付费云端
+- 🔇 **Shannon 新颖性门控** — 过滤冗余输出（去重零 Token）
+- 🔒 **密封收据** — 每个工件 sha256，防篡改证据链
+- 🛡️ **5 道交付关卡** — 验收、验证、运行验证、回归、自审
+- ⚡ **操作门控** — 针对聊天发起的变更的风险分类 + 黑名单
+- 🔌 **MCP/ACP** — 模型上下文协议 + 智能体客户端协议
+- 🌐 **网关** — Telegram、Discord、Slack、WhatsApp
+- 🧩 **技能系统** — 加载并链式组合可复用的能力
+- 💾 **记忆数据库** — 跨会话持久化的全文搜索 + 向量召回
+- 🔀 **LLM 路由器** — 无 LLM → 本地 LLM → 远程 LLM 自动切换
+- 🖥️ **跨平台** — macOS、Linux、Windows，单一二进制文件
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 免费公测
 
-**Deterministic commands are FREE forever:**
-`map`, `validate`, `edit`, `deliver`, `checkpoint`
+**确定性命令永久免费：**
+`map`、`validate`、`edit`、`deliver`、`checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+**AI 功能在公测期间免费，无截止日期。**
+计费方案将在未来更新中确定。
 
 ```bash
 simplicio license status
@@ -201,46 +201,46 @@ simplicio license status
 
 ---
 
-## 📋 Requirements
+## 📋 系统要求
 
-| Requirement | Minimum | Recommended |
+| 要求 | 最低配置 | 推荐配置 |
 |---|---|---|
-| RAM | 8 GB | 16 GB+ |
-| Storage | 5 MB | 1.5 GB (with local LLM) |
-| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
-| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
+| 内存 | 8 GB | 16 GB+ |
+| 存储 | 5 MB | 1.5 GB（含本地 LLM） |
+| 操作系统 | macOS 13+、Linux、Windows 10+ | macOS ARM64 |
+| 终端 | 任意现代终端 | WezTerm / Alacritty / Ghostty |
 
 ---
 
-## 🌐 Ecosystem
+## 🌐 生态系统
 
-- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
-- [Discord](https://discord.gg/wM6tr7xVb) — community and support
-
----
-
-## 📄 License
-
-Proprietary. Binary free to download and use. AI features free during the
-public beta. See [LICENSE](LICENSE).
+- [官网](https://simpleti.com.br/simplicio/#start) — 完整文档、基准测试、安装指南
+- [Discord](https://discord.gg/wM6tr7xVb) — 社区与支持
 
 ---
 
-## ⭐ Star History
+## 📄 许可证
+
+专有许可。二进制文件可免费下载和使用。AI 功能在公开
+公测期间免费。详见 [LICENSE](LICENSE)。
+
+---
+
+## ⭐ 星标历史
 
 <a href="https://star-history.com/#wesleysimplicio/simplicio&Date">
-  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="Star History Chart" width="100%" />
+  <img src="https://api.star-history.com/svg?repos=wesleysimplicio/simplicio&type=Date" alt="星标历史图表" width="100%" />
 </a>
 
 ---
 
-## 💬 Community
+## 💬 社区
 
-- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
-- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+- [Discord](https://discord.gg/wM6tr7xVb) — 聊天、支持、抢先体验
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — 报告问题和功能请求
 
 ---
 
 <p align="center">
-  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+  <strong>🔥 Simplicio — 你的代码，你的机器，便宜 96%。 🔥</strong>
 </p>


### PR DESCRIPTION
## Resumo

Todos os READMEs traduzidos agora contêm o **mesmo conteúdo completo do inglês** em seus respectivos idiomas.

## O que foi feito

- **14 arquivos** em  foram traduzidos do inglês para seus respectivos idiomas
- **Elementos não-texto preservados:** badges HTML, links, imagens, emojis, blocos de código, tabelas, URLs
- **Âncoras de navegação ajustadas** para corresponder aos cabeçalhos traduzidos em cada idioma
- **Seletor de idiomas** mantido com links corretos para todos os READMEs

## Idiomas

| Arquivo | Idioma |
|---|---|
| README.ar-SA.md | 🇸🇦 العربية |
| README.es-ES.md | 🇪🇸 Español |
| README.fr-FR.md | 🇫🇷 Français |
| README.he-IL.md | 🇮🇱 עברית |
| README.hi-IN.md | 🇮🇳 हिन्दी |
| README.id-ID.md | 🇮🇩 Bahasa Indonesia |
| README.it-IT.md | 🇮🇹 Italiano |
| README.ja-JP.md | 🇯🇵 日本語 |
| README.ko-KR.md | 🇰🇷 한국어 |
| README.ms-MY.md | 🇲🇾 Bahasa Melayu |
| README.pl-PL.md | 🇵🇱 Polski |
| README.pt-BR.md | 🇧🇷 Português |
| README.ru-RU.md | 🇷🇺 Русский |
| README.zh-CN.md | 🇨🇳 简体中文 |

## Verificação

- ✅ Todos os 14 arquivos têm MD5 diferentes (não são mais cópias do inglês)
- ✅ Navegação interna funciona em cada README
- ✅ Estrutura markdown preservada