### PR TITLE
release: publish v3.5.1 signed macOS binary

### DIFF
--- a/simplicio-update-manifest.json
+++ b/simplicio-update-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "simplicio.update-manifest/v1",
-  "version": "3.0.2",
+  "version": "3.5.1",
   "channel": "stable",
   "security": {
     "checksum_algorithm": "SHA256",
@@ -17,10 +17,10 @@
     {
       "target": "macos-arm64",
       "artifact": "simplicio-macos-arm64",
-      "sha256": "1911069c423544985d4dbef204fc57617e1ed34f7ef48999a2e7d705877a6765",
-      "signature": "",
+      "sha256": "53f62026df78942ca9acba7fd87498fbd6f007e54bd9e479b44407fe97b97dc9",
+      "signature": "ed25519:6pttb85XjfCU2sB/tM8ZQbEk28iyEKkRm6JOhbPKcAVIDTBWm22ctrXQUoNrbf/AjM1o5knu1Ljym+rcExbpCA==",
       "signature_algorithm": "ed25519",
-      "url": "https://github.com/wesleysimplicio/simplicio/releases/download/v3.0.2/simplicio-macos-arm64"
+      "url": "https://github.com/wesleysimplicio/simplicio/releases/download/v3.5.1/simplicio-macos-arm64"
     }
   ]
 }


### PR DESCRIPTION
Publishes the v3.5.1 macOS arm64 binary and signed update manifest. SHA256 and Ed25519 artifact signature are verified against the v3.5.1 GitHub Release.