### PR TITLE
fix(installer): fail closed on incoherent Runtime releases

### DIFF
--- a/pypi/simplicio/simplicio/__init__.py
+++ b/pypi/simplicio/simplicio/__init__.py
@@ -1,7 +1,9 @@
 """Simplicio — AI coding agent that saves up to 96% on tokens."""
 
-__version__ = "1.0.0"
+__version__ = "3.5.2"
+
 
 def main():
-    import subprocess, sys
-    subprocess.run([sys.executable, "-m", "simplicio"] + sys.argv[1:])
+    """Console-script entry point; preserve the CLI's exit status."""
+    from .__main__ import main as cli_main
+    return cli_main()

--- a/pypi/simplicio/simplicio/__main__.py
+++ b/pypi/simplicio/simplicio/__main__.py
@@ -1,73 +1,274 @@
 #!/usr/bin/env python3
-"""Simplicio CLI entry point.
+"""The small PyPI launcher for the Simplicio runtime.
 
-'pip install simplicio && simplicio install' downloads and installs the real binary.
-All other commands are delegated to the binary.
+The launcher deliberately does not execute a remote shell script. It obtains
+the immutable GitHub Release for its own version, verifies the pinned manifest
+digest and asset checksum, and only then atomically installs the runtime.
 """
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import hashlib
+import hmac
+import json
 import os
 import platform
 import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.request import urlopen
 
-# Canonical install location (matches install.sh / install.ps1).
+from . import __version__
+
 INSTALL_DIR = os.path.expanduser("~/.local/bin")
 BINARY_NAME = "simplicio" + (".exe" if platform.system() == "Windows" else "")
 BINARY_PATH = os.path.join(INSTALL_DIR, BINARY_NAME)
+RELEASE_API_BASE = "https://api.github.com/repos/wesleysimplicio/simplicio/releases/tags"
+MANIFEST_ASSET = "simplicio-update-manifest.json"
+# The wheel anchors each release manifest before trusting its artifact hashes.
+TRUSTED_MANIFEST_SHA256 = {
+    "3.5.2": "85a486b1210d3610365ce78279f3b964c5713ab311407efa8812cd6eeda4fc1f",
+}
+
+# Kept in lockstep with distribution/targets.json.  The PyPI wheel must retain
+# this table because it is also used outside a checkout of the repository.
+TARGETS = {
+    ("Windows", "amd64"): ("windows-x64", "simplicio-windows-x64.exe"),
+    ("Windows", "x86_64"): ("windows-x64", "simplicio-windows-x64.exe"),
+    ("Darwin", "arm64"): ("macos-arm64", "simplicio-macos-arm64"),
+    ("Darwin", "aarch64"): ("macos-arm64", "simplicio-macos-arm64"),
+    ("Darwin", "x86_64"): ("macos-x64", "simplicio-macos-x64"),
+    ("Linux", "x86_64"): ("linux-x64", "simplicio-linux-x64"),
+    ("Linux", "amd64"): ("linux-x64", "simplicio-linux-x64"),
+}
+
+
+class InstallError(RuntimeError):
+    """An expected installation failure which should not show a traceback."""
+
+
+class ReleaseClient:
+    """Fetch one immutable GitHub Release; injectable for offline tests."""
+
+    def __init__(self, api_base: str = RELEASE_API_BASE, opener=urlopen):
+        self.api_base = api_base.rstrip("/")
+        self.opener = opener
+
+    def release(self, version: str) -> dict:
+        with self.opener(self.api_base + "/v" + version.lstrip("v")) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def download_asset(self, asset: dict) -> bytes:
+        url = asset.get("browser_download_url")
+        if not isinstance(url, str) or not url.startswith("https://github.com/"):
+            raise InstallError("Release asset has no valid GitHub download URL.")
+        with self.opener(url) as response:
+            return response.read()
+
 
 def _resolve_binary():
     """Find the installed real binary: canonical dir first, then PATH."""
-    if os.path.exists(BINARY_PATH):
+    if os.path.exists(BINARY_PATH) and os.path.realpath(BINARY_PATH) != os.path.realpath(
+        sys.argv[0]
+    ):
         return BINARY_PATH
     found = shutil.which("simplicio")
-    # Avoid recursing into this very wrapper if it shadows the real binary.
     if found and os.path.realpath(found) != os.path.realpath(sys.argv[0]):
         return found
     return None
 
-def do_install() -> None:
-    """Install the real Simplicio binary via the canonical platform installer.
 
-    Single source of truth: the shell/powershell installers handle release
-    asset-name resolution, PATH, and the centralized ~/.local/bin location.
-    """
-    print("Installing Simplicio...")
-    system = platform.system()
-    if system in ("Darwin", "Linux"):
-        subprocess.run(
-            "curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh",
-            shell=True, check=True,
+def _target(system=None, machine=None):
+    key = (system or platform.system(), (machine or platform.machine()).lower())
+    try:
+        return TARGETS[key]
+    except KeyError:
+        raise InstallError("Unsupported platform: %s/%s" % key) from None
+
+
+def _artifact(manifest: dict, target: str, asset: str, expected_version: str) -> dict:
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("artifacts"), list):
+        raise InstallError("Release manifest has an invalid structure.")
+    if not isinstance(manifest.get("version"), str):
+        raise InstallError("Release manifest has an invalid structure.")
+    for item in manifest["artifacts"]:
+        if not isinstance(item, dict):
+            raise InstallError("Release manifest has an invalid artifact entry.")
+    version = manifest["version"].lstrip("v")
+    if version != expected_version.lstrip("v"):
+        raise InstallError(
+            "Release/runtime version mismatch (expected %s, manifest has %s). "
+            "Install a matching simplicio-installer version."
+            % (expected_version, version or "none")
         )
-    elif system == "Windows":
-        subprocess.run(
-            ["powershell", "-NoProfile", "-Command",
-             "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex"],
-            check=True,
+    for item in manifest["artifacts"]:
+        if item.get("target") == target:
+            if item.get("artifact") != asset:
+                raise InstallError("Release manifest asset mismatch for %s." % target)
+            digest = item.get("sha256", "")
+            if (
+                isinstance(digest, str)
+                and len(digest) == 64
+                and all(c in "0123456789abcdefABCDEF" for c in digest)
+            ):
+                return item
+            raise InstallError("Release manifest has no valid SHA-256 for %s." % target)
+    raise InstallError(
+        "No release asset for %s. This release cannot be installed on this platform." % target
+    )
+
+
+def _release_asset(release: dict, name: str) -> dict:
+    assets = release.get("assets") if isinstance(release, dict) else None
+    if not isinstance(assets, list):
+        raise InstallError("GitHub Release has an invalid assets list.")
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise InstallError("GitHub Release has an invalid asset entry.")
+        if asset.get("name") == name:
+            return asset
+    raise InstallError("Release is missing required asset %s." % name)
+
+
+def _release_for_version(client, expected_version: str) -> dict:
+    try:
+        release = client.release(expected_version)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise InstallError(
+            "Could not fetch GitHub Release v%s; try again later." % expected_version
+        ) from exc
+    if not isinstance(release, dict) or release.get("tag_name") != "v" + expected_version.lstrip(
+        "v"
+    ):
+        raise InstallError(
+            "GitHub Release v%s was not found or does not match this installer." % expected_version
         )
-    else:
-        print(f"Unsupported platform: {system}")
-        sys.exit(1)
+    return release
+
+
+def _verified_manifest(payload: bytes, expected_version: str, trust_store: dict) -> dict:
+    version = expected_version.lstrip("v")
+    expected_digest = trust_store.get(version)
+    if not isinstance(expected_digest, str):
+        raise InstallError("No trusted manifest digest is available for version %s." % version)
+    actual_digest = hashlib.sha256(payload).hexdigest()
+    if not hmac.compare_digest(actual_digest, expected_digest.lower()):
+        raise InstallError("Release manifest digest mismatch; installation aborted.")
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise InstallError("Could not read the release manifest; installation aborted.") from exc
+
+
+def _validate_runtime(path: Path, expected_version: str, runner=subprocess.run) -> None:
+    try:
+        result = runner(
+            [str(path), "version", "--json"], check=True, capture_output=True, text=True
+        )
+        runtime = json.loads(result.stdout).get("runtime")
+        actual = str(runtime.get("version", "")).lstrip("v")
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        TypeError,
+        AttributeError,
+    ) as exc:
+        raise InstallError("Downloaded runtime did not return a valid version JSON.") from exc
+    if actual != expected_version.lstrip("v"):
+        raise InstallError(
+            "Release/runtime version mismatch (expected %s, runtime has %s)."
+            % (expected_version, actual or "none")
+        )
+
+
+def do_install(
+    client=None,
+    install_dir=None,
+    expected_version=__version__,
+    runner=subprocess.run,
+    trusted_manifest_sha256=None,
+) -> None:
+    """Download a verified release asset, validate it, then atomically install it."""
+    target, asset = _target()
+    client = client or ReleaseClient()
+    trust_store = (
+        TRUSTED_MANIFEST_SHA256
+        if trusted_manifest_sha256 is None
+        else trusted_manifest_sha256
+    )
+    release = _release_for_version(client, expected_version)
+    try:
+        manifest_payload = client.download_asset(_release_asset(release, MANIFEST_ASSET))
+    except OSError as exc:
+        raise InstallError("Could not read the release manifest; installation aborted.") from exc
+    manifest = _verified_manifest(manifest_payload, expected_version, trust_store)
+    info = _artifact(manifest, target, asset, expected_version)
+    try:
+        payload = client.download_asset(_release_asset(release, asset))
+    except OSError as exc:
+        raise InstallError("Could not download release asset %s." % asset) from exc
+    actual_digest = hashlib.sha256(payload).hexdigest()
+    if actual_digest.lower() != info["sha256"].lower():
+        raise InstallError("Downloaded asset checksum mismatch; installation aborted.")
+
+    destination_dir = Path(install_dir or INSTALL_DIR)
+    try:
+        destination_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise InstallError("Could not create the installation directory.") from exc
+    destination = destination_dir / BINARY_NAME
+    staged_path = None
+    try:
+        suffix = Path(asset).suffix
+        with tempfile.NamedTemporaryFile(
+            dir=str(destination_dir), prefix=".simplicio-", suffix=suffix, delete=False
+        ) as staged:
+            staged.write(payload)
+            staged_path = Path(staged.name)
+        staged_path.chmod(0o755)
+        _validate_runtime(staged_path, expected_version, runner)
+        os.replace(str(staged_path), str(destination))
+    except InstallError:
+        raise
+    except OSError as exc:
+        raise InstallError("Could not stage or install the verified runtime.") from exc
+    finally:
+        install_error_in_flight = sys.exc_info()[0] is not None
+        if staged_path is not None and staged_path.exists():
+            try:
+                staged_path.unlink()
+            except OSError as exc:
+                # Do not replace the actionable install error already in flight.
+                if not install_error_in_flight:
+                    raise InstallError("Could not clean up the staged runtime.") from exc
+    print("Installed Simplicio %s to %s" % (expected_version, destination))
+
 
 def main():
     args = sys.argv[1:]
-    
     if not args or args[0] == "install":
-        do_install()
+        try:
+            do_install()
+        except InstallError as exc:
+            print("Simplicio install failed: %s" % exc, file=sys.stderr)
+            sys.exit(1)
         return
-    
-    # If the real binary is installed, delegate to it.
     binary = _resolve_binary()
     if binary:
         try:
             subprocess.run([binary] + args, check=True)
-        except subprocess.CalledProcessError as e:
-            sys.exit(e.returncode)
+        except subprocess.CalledProcessError as exc:
+            sys.exit(exc.returncode)
+        except OSError as exc:
+            print("Could not run installed Simplicio: %s" % exc, file=sys.stderr)
+            sys.exit(1)
     else:
         print("Simplicio is not installed. Run 'simplicio install' first.")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/unit/test_pypi_installer.py
+++ b/tests/unit/test_pypi_installer.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PACKAGE_ROOT = Path(__file__).parents[2] / "pypi" / "simplicio"
+REPO_ROOT = Path(__file__).parents[2]
+sys.path.insert(0, str(PACKAGE_ROOT))
+import simplicio  # noqa: E402
+from simplicio import __main__ as installer  # noqa: E402
+
+TEST_TRUST = {"3.5.2": "fixture-digest"}
+
+
+@pytest.fixture(autouse=True)
+def fixture_manifest_trust(monkeypatch, request):
+    if request.node.name != "test_default_manifest_pin_matches_versioned_checkout":
+        monkeypatch.setattr(installer, "TRUSTED_MANIFEST_SHA256", TEST_TRUST)
+
+
+def trusted_digest(payload):
+    TEST_TRUST["3.5.2"] = hashlib.sha256(payload).hexdigest()
+    return TEST_TRUST
+
+
+class FakeReleaseClient:
+    def __init__(self, manifest, payload=b"runtime", release=True):
+        self.manifest = manifest
+        self.payload = payload
+        trusted_digest(manifest)
+        self.release_data = (
+            {
+                "tag_name": "v3.5.2",
+                "assets": [
+                    {"name": installer.MANIFEST_ASSET},
+                    {"name": "simplicio-linux-x64"},
+                ],
+            }
+            if release
+            else None
+        )
+        self.downloaded = []
+
+    def release(self, version):
+        return self.release_data
+
+    def download_asset(self, asset):
+        self.downloaded.append(asset["name"])
+        if asset["name"] == installer.MANIFEST_ASSET:
+            return self.manifest
+        return self.payload
+
+
+class Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+def manifest_for(payload, version="3.5.2", target="linux-x64", asset="simplicio-linux-x64"):
+    return json_bytes(
+        {
+            "version": version,
+            "artifacts": [
+                {"target": target, "artifact": asset, "sha256": hashlib.sha256(payload).hexdigest()}
+            ],
+        }
+    )
+
+
+def json_bytes(value):
+    return json.dumps(value).encode("utf-8")
+
+
+def valid_runner(command, **kwargs):
+    assert command[1:] == ["version", "--json"]
+    assert kwargs["check"] and kwargs["capture_output"] and kwargs["text"]
+    return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.5.2"}}', "")
+
+
+def test_install_verifies_then_atomically_replaces_binary(tmp_path, monkeypatch):
+    payload = b"verified runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    destination = tmp_path / "simplicio"
+    destination.write_bytes(b"old")
+
+    installer.do_install(
+        client=client,
+        install_dir=tmp_path,
+        runner=valid_runner,
+        trusted_manifest_sha256=trusted_digest(client.manifest),
+    )
+
+    assert destination.read_bytes() == payload
+    assert client.downloaded == [installer.MANIFEST_ASSET, "simplicio-linux-x64"]
+    assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_install_rejects_missing_target_without_downloading(tmp_path, monkeypatch):
+    client = FakeReleaseClient(
+        manifest_for(b"x", target="macos-arm64", asset="simplicio-macos-arm64")
+    )
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+
+    with pytest.raises(installer.InstallError, match="No release asset for linux-x64"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+    assert client.downloaded == [installer.MANIFEST_ASSET]
+
+
+def test_install_rejects_checksum_before_writing(tmp_path, monkeypatch):
+    client = FakeReleaseClient(manifest_for(b"expected"), b"tampered")
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    destination = tmp_path / "simplicio"
+    destination.write_bytes(b"old")
+
+    with pytest.raises(installer.InstallError, match="checksum mismatch"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+    assert destination.read_bytes() == b"old"
+    assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_install_rejects_manifest_version_mismatch(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload, version="3.5.3"), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+
+    with pytest.raises(installer.InstallError, match="version mismatch"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+    assert client.downloaded == [installer.MANIFEST_ASSET]
+
+
+def test_install_rejects_runtime_version_and_preserves_existing_binary(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    (tmp_path / "simplicio").write_bytes(b"old")
+
+    def wrong_runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.5.3"}}', "")
+
+    with pytest.raises(installer.InstallError, match="runtime has 3.5.3"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=wrong_runner)
+
+    assert (tmp_path / "simplicio").read_bytes() == b"old"
+    assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_target_uses_canonical_distribution_asset_names():
+    assert installer._target("Linux", "x86_64") == ("linux-x64", "simplicio-linux-x64")
+    assert installer._target("Darwin", "arm64") == ("macos-arm64", "simplicio-macos-arm64")
+    assert installer._target("Windows", "AMD64") == ("windows-x64", "simplicio-windows-x64.exe")
+
+
+def test_install_rejects_missing_release_before_any_download(tmp_path, monkeypatch):
+    client = FakeReleaseClient(manifest_for(b"runtime"), release=False)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(installer.InstallError, match="Release v3.5.2 was not found"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+    assert client.downloaded == []
+
+
+def test_install_rejects_missing_manifest_asset(tmp_path, monkeypatch):
+    client = FakeReleaseClient(manifest_for(b"runtime"))
+    client.release_data["assets"] = [{"name": "simplicio-linux-x64"}]
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(
+        installer.InstallError,
+        match="missing required asset simplicio-update-manifest.json",
+    ):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+    assert client.downloaded == []
+
+
+def test_install_rejects_missing_runtime_asset_and_preserves_existing(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    client.release_data["assets"] = [{"name": installer.MANIFEST_ASSET}]
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    destination = tmp_path / "simplicio"
+    destination.write_bytes(b"old")
+    with pytest.raises(installer.InstallError, match="missing required asset simplicio-linux-x64"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+    assert destination.read_bytes() == b"old"
+    assert client.downloaded == [installer.MANIFEST_ASSET]
+
+
+def test_install_rejects_invalid_runtime_json_and_cleans_staging(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    (tmp_path / "simplicio").write_bytes(b"old")
+
+    def invalid_runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, "not-json", "")
+
+    with pytest.raises(installer.InstallError, match="valid version JSON"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=invalid_runner)
+    assert (tmp_path / "simplicio").read_bytes() == b"old"
+    assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_console_entry_point_propagates_install_failure(monkeypatch):
+    def failed_install():
+        raise installer.InstallError("checksum mismatch")
+
+    monkeypatch.setattr(installer, "do_install", failed_install)
+    monkeypatch.setattr(sys, "argv", ["simplicio", "install"])
+    with pytest.raises(SystemExit) as exc:
+        simplicio.main()
+    assert exc.value.code == 1
+
+
+def test_resolve_binary_rejects_wrapper_at_canonical_path(monkeypatch):
+    monkeypatch.setattr(installer.os.path, "exists", lambda path: path == installer.BINARY_PATH)
+    monkeypatch.setattr(installer.sys, "argv", [installer.BINARY_PATH])
+    monkeypatch.setattr(installer.shutil, "which", lambda name: None)
+    assert installer._resolve_binary() is None
+
+
+def test_resolve_binary_prefers_real_canonical_binary(monkeypatch):
+    monkeypatch.setattr(installer.os.path, "exists", lambda path: path == installer.BINARY_PATH)
+    monkeypatch.setattr(installer.sys, "argv", ["/tmp/wrapper"])
+    assert installer._resolve_binary() == installer.BINARY_PATH
+
+
+def test_resolve_binary_uses_path_when_canonical_is_absent(monkeypatch):
+    monkeypatch.setattr(installer.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(installer.shutil, "which", lambda name: "/opt/bin/simplicio")
+    monkeypatch.setattr(installer.sys, "argv", ["/tmp/wrapper"])
+    assert installer._resolve_binary() == "/opt/bin/simplicio"
+
+
+def test_release_client_fetches_versioned_release_and_asset():
+    calls = []
+
+    def opener(url):
+        calls.append(url)
+        return (
+            Response(b'{"tag_name":"v3.5.2"}')
+            if url.endswith("/v3.5.2")
+            else Response(b"binary")
+        )
+
+    client = installer.ReleaseClient("https://api.example/releases", opener)
+    assert client.release("v3.5.2")["tag_name"] == "v3.5.2"
+    assert client.download_asset(
+        {"browser_download_url": "https://github.com/org/repo/releases/download/v3/a"}
+    ) == b"binary"
+    assert calls == [
+        "https://api.example/releases/v3.5.2",
+        "https://github.com/org/repo/releases/download/v3/a",
+    ]
+
+
+def test_release_client_rejects_non_github_asset_url():
+    with pytest.raises(installer.InstallError, match="valid GitHub download URL"):
+        installer.ReleaseClient(opener=lambda url: None).download_asset(
+            {"browser_download_url": "https://example.com/a"}
+        )
+
+
+def test_default_manifest_pin_matches_versioned_checkout():
+    payload = (REPO_ROOT / "simplicio-update-manifest.json").read_bytes()
+    assert installer.TRUSTED_MANIFEST_SHA256["3.5.2"] == hashlib.sha256(payload).hexdigest()
+
+
+def test_install_rejects_substituted_or_unpinned_manifest_before_runtime_download(
+    tmp_path, monkeypatch
+):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(installer.InstallError, match="manifest digest mismatch"):
+        installer.do_install(
+            client=client,
+            install_dir=tmp_path,
+            runner=valid_runner,
+            trusted_manifest_sha256={"3.5.2": "0" * 64},
+        )
+    assert client.downloaded == [installer.MANIFEST_ASSET]
+
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    with pytest.raises(installer.InstallError, match="No trusted manifest digest"):
+        installer.do_install(
+            client=client, install_dir=tmp_path, runner=valid_runner, trusted_manifest_sha256={}
+        )
+    assert client.downloaded == [installer.MANIFEST_ASSET]
+
+
+def test_target_rejects_unsupported_platform():
+    with pytest.raises(installer.InstallError, match="Unsupported platform"):
+        installer._target("Plan9", "mips")
+
+
+def test_artifact_rejects_wrong_name_and_invalid_digest():
+    with pytest.raises(installer.InstallError, match="asset mismatch"):
+        installer._artifact(json.loads(manifest_for(b"x")), "linux-x64", "other", "3.5.2")
+    manifest = json.loads(manifest_for(b"x"))
+    manifest["artifacts"][0]["sha256"] = "not-a-digest"
+    with pytest.raises(installer.InstallError, match="valid SHA-256"):
+        installer._artifact(manifest, "linux-x64", "simplicio-linux-x64", "3.5.2")
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [[], {"version": "3.5.2", "artifacts": {}}, {"artifacts": ["bad"]}],
+)
+def test_install_rejects_invalid_manifest_structure(tmp_path, monkeypatch, manifest):
+    client = FakeReleaseClient(json_bytes(manifest))
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(installer.InstallError, match="invalid"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+
+def test_install_rejects_invalid_release_assets_structure(tmp_path, monkeypatch):
+    client = FakeReleaseClient(manifest_for(b"runtime"))
+    client.release_data["assets"] = {}
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(installer.InstallError, match="invalid assets list"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+
+def test_windows_staging_uses_exe_suffix(tmp_path, monkeypatch):
+    payload = b"windows runtime"
+    asset = "simplicio-windows-x64.exe"
+    client = FakeReleaseClient(manifest_for(payload, target="windows-x64", asset=asset), payload)
+    client.release_data["assets"].append({"name": asset})
+    monkeypatch.setattr(installer, "_target", lambda: ("windows-x64", asset))
+    monkeypatch.setattr(installer, "BINARY_NAME", "simplicio.exe")
+    staged_paths = []
+
+    def runner(command, **kwargs):
+        staged_paths.append(command[0])
+        return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.5.2"}}', "")
+
+    installer.do_install(client=client, install_dir=tmp_path, runner=runner)
+    assert staged_paths[0].endswith(".exe")
+    assert (tmp_path / "simplicio.exe").read_bytes() == payload
+
+
+def test_replace_failure_rolls_back_and_cleans_staging(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    destination = tmp_path / "simplicio"
+    destination.write_bytes(b"old")
+
+    def fail_replace(source, target):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(installer.os, "replace", fail_replace)
+    with pytest.raises(installer.InstallError, match="stage or install"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+    assert destination.read_bytes() == b"old"
+    assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_cleanup_failure_without_install_error_is_short_install_error(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    monkeypatch.setattr(installer.os, "replace", lambda source, target: None)
+
+    def fail_unlink(path):
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+    with pytest.raises(installer.InstallError, match="clean up the staged runtime"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+
+def test_cleanup_failure_preserves_original_install_error(tmp_path, monkeypatch):
+    payload = b"runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+
+    def invalid_runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, "not-json", "")
+
+    def fail_unlink(path):
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+    with pytest.raises(installer.InstallError, match="valid version JSON"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=invalid_runner)
+
+
+def test_install_reports_release_fetch_and_manifest_download_failures(tmp_path, monkeypatch):
+    class FailingRelease:
+        def release(self, version):
+            raise OSError("offline")
+
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    with pytest.raises(installer.InstallError, match="Could not fetch GitHub Release"):
+        installer.do_install(client=FailingRelease(), install_dir=tmp_path, runner=valid_runner)
+
+    client = FakeReleaseClient(b"not-json")
+    with pytest.raises(installer.InstallError, match="Could not read the release manifest"):
+        installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
+
+
+def test_main_delegates_and_reports_missing_binary(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(installer.sys, "argv", ["simplicio", "chat", "hello"])
+    monkeypatch.setattr(installer, "_resolve_binary", lambda: "/opt/simplicio")
+    monkeypatch.setattr(
+        installer.subprocess, "run", lambda command, check: calls.append((command, check))
+    )
+    installer.main()
+    assert calls == [(["/opt/simplicio", "chat", "hello"], True)]
+
+    monkeypatch.setattr(installer, "_resolve_binary", lambda: None)
+    with pytest.raises(SystemExit) as exc:
+        installer.main()
+    assert exc.value.code == 1
+    assert "not installed" in capsys.readouterr().out
+
+
+def test_main_preserves_delegated_binary_exit_code(monkeypatch):
+    monkeypatch.setattr(installer.sys, "argv", ["simplicio", "chat"])
+    monkeypatch.setattr(installer, "_resolve_binary", lambda: "/opt/simplicio")
+
+    def failing_run(command, check):
+        raise subprocess.CalledProcessError(7, command)
+
+    monkeypatch.setattr(installer.subprocess, "run", failing_run)
+    with pytest.raises(SystemExit) as exc:
+        installer.main()
+    assert exc.value.code == 7
+
+
+def test_main_reports_oserror_from_delegated_binary(monkeypatch, capsys):
+    monkeypatch.setattr(installer.sys, "argv", ["simplicio", "chat"])
+    monkeypatch.setattr(installer, "_resolve_binary", lambda: "/opt/simplicio")
+    monkeypatch.setattr(
+        installer.subprocess,
+        "run",
+        lambda command, check: (_ for _ in ()).throw(OSError("denied")),
+    )
+    with pytest.raises(SystemExit) as exc:
+        installer.main()
+    assert exc.value.code == 1
+    assert "Could not run installed Simplicio" in capsys.readouterr().err


### PR DESCRIPTION
## O que mudou

- troca o `curl | sh` do launcher PyPI por resolução da GitHub Release exata `v{versão}`;
- exige manifest e asset canônico na mesma release;
- ancora o manifest em um SHA-256 confiável embutido no wheel antes de parsear ou confiar nos hashes de artefatos;
- verifica SHA-256 do binário, executa `version --json` em staging e exige `runtime.version` igual ao wrapper;
- faz troca atômica somente depois de todas as validações, preservando instalação anterior e limpando staging nas falhas;
- evita recursão do console script e propaga erros/exit codes sem traceback;
- alinha `simplicio.__version__` a 3.5.2.

## Causa raiz

O pacote publicado usava nomes de tarball que não existem na release pública, fazia fallback para outro asset ausente e podia terminar com traceback. Além disso, o binário Linux disponível fora da release responde `runtime.version = 1.6.4`, embora wrapper/manifest indiquem 3.5.2. O entry point também descartava o exit code do subprocesso.

## Impacto

O instalador agora falha fechado diante de release ausente, manifest substituído, asset faltante, checksum divergente, JSON inválido ou Runtime com versão incorreta. Um binário existente nunca é substituído nesses casos.

## Evidência local

GitHub Actions não foi usado como critério, conforme solicitado.

- `32 passed` nos testes específicos;
- 96% de cobertura do launcher (`--fail-under=90`);
- suíte completa: `119 passed, 1 failed`; a única falha é o baseline preexistente de três assets sem assinatura Ed25519, rastreado em #5;
- `compileall` e `git diff --check` passaram;
- teste real contra a release v3.5.2: exit 1 curto, sem traceback, manifest ausente identificado e SHA do binário sentinela preservado;
- revisão independente: sem P0/P1.

## Limite conhecido

Este PR protege o usuário, mas não fabrica os assets ausentes. A release v3.5.2 continua incoerente e o Runtime 3.5.3 / Qwen3.5 de wesleysimplicio/simplicio-runtime#3486 ainda precisa ser publicado com manifest e binários coerentes. Isso permanece em #5 e wesleysimplicio/simplicio-runtime#3162.

Closes #16
Refs #5
Refs wesleysimplicio/simplicio-runtime#3162