### PR TITLE
Make installers Runtime-only and verify embedded bundle

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,11 +166,20 @@ Use `simplicio deliver certify` before declaring done.
 
 Same workflow — Simplicio commands work from any terminal-based AI agent.
 
-## Ecossistema nativo no Runtime
+## Fontes Python no Runtime
 
-O binário Runtime é o artefato de instalação e carrega os contratos nativos de
-Mapper, Dev CLI, Loop, Fast, Prompt e Sprint projection. A instalação padrão
-não instala pacotes Python, não clona `simplicio-*` e não procura checkouts locais.
+O binário Runtime é o artefato de instalação e carrega as árvores de fontes
+Python reais de Mapper, Dev CLI, Loop, Fast, Prompt e Sprint. Esses projetos não
+são reescritos como Rust. A instalação padrão não instala pacotes Python, não
+clona `simplicio-*` e não procura checkouts locais.
+
+O Runtime ainda precisa de um interpretador Python 3 disponível para executar
+os fontes embutidos. A sessão do Google é obrigatória, inclusive durante o beta:
+
+```bash
+simplicio auth login
+simplicio auth status --json
+```
 
 Depois da instalação, valide o bundle e guarde o relatório opcional:
 
@@ -178,11 +187,11 @@ Depois da instalação, valide o bundle e guarde o relatório opcional:
 simplicio ecosystem verify --json
 ```
 
-O relatório identifica a versão, o commit de proveniência, o modo de
-implementação e o estado de compatibilidade de cada componente. Adaptadores
-Python/portáveis continuam disponíveis somente para fluxos explicitamente
-legados; eles não são parte do caminho normal e não podem substituir o Runtime
-verificado pelo instalador.
+O relatório identifica o digest/tamanho do arquivo-fonte embutido, a versão, o
+commit de proveniência, o modo de implementação e o estado de compatibilidade
+de cada componente. Adaptadores externos/portáveis continuam disponíveis
+somente para fluxos explicitamente legados; eles não são parte do caminho
+normal e não podem substituir o Runtime verificado pelo instalador.
 
 ## Building from Source
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,40 +166,23 @@ Use `simplicio deliver certify` before declaring done.
 
 Same workflow — Simplicio commands work from any terminal-based AI agent.
 
-## Instalação completa do ecossistema Python
+## Ecossistema nativo no Runtime
 
-A instalação oficial do Runtime também prepara o control-plane do Agent:
-`simplicio-loop`, `simplicio-mapper` e `simplicio-dev-cli`.
-### PyPI (recomendado)
+O binário Runtime é o artefato de instalação e carrega os contratos nativos de
+Mapper, Dev CLI, Loop, Fast, Prompt e Sprint projection. A instalação padrão
+não instala pacotes Python, não clona `simplicio-*` e não procura checkouts locais.
 
-```bash
-python3 -m pip install --upgrade "simplicio-agent[all,ecosystem]"
-# Runtime compilado + bootstrap de memória/seed:
-curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
-simplicio doctor --json
-simplicio memory status --json
-```
-
-### Clone do repositório
+Depois da instalação, valide o bundle e guarde o relatório opcional:
 
 ```bash
-git clone https://github.com/wesleysimplicio/simplicio-agent.git ~/Projetos/ai/simplicio-agent
-SIMPLICIO_AGENT_SOURCE_ROOT="$HOME/Projetos/ai/simplicio-agent" \
-  sh install.sh
+simplicio ecosystem verify --json
 ```
 
-Para usar o kernel compilado do novo `simplicio-fast` local, sem baixar binário:
-
-```bash
-SIMPLICIO_FAST_SOURCE_ROOT="$HOME/Projetos/ai/simplicio-fast" \
-SIMPLICIO_AGENT_SOURCE_ROOT="$HOME/Projetos/ai/simplicio-agent" \
-  sh install.sh
-```
-
-O instalador é idempotente e cria `~/.simplicio_agent/components.json`. O manifesto
-registra os caminhos reais dos adaptadores, o kernel usado, o estado da memória
-SQLite/FTS5 e a origem runtime-owned dos seeds. Falhas ficam explícitas no manifesto;
-não há download de kernel local não verificado.
+O relatório identifica a versão, o commit de proveniência, o modo de
+implementação e o estado de compatibilidade de cada componente. Adaptadores
+Python/portáveis continuam disponíveis somente para fluxos explicitamente
+legados; eles não são parte do caminho normal e não podem substituir o Runtime
+verificado pelo instalador.
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -1,153 +1,287 @@
-# Simplicio Runtime
+# 🔥 Simplicio — The AI Agent That SAVES UP TO 96% OF YOUR TOKENS
 
-Este repositório é a porta de entrada do Simplicio. Clone o repositório e use
-os instaladores versionados aqui para instalar o Runtime e os componentes CLI
-do ecossistema. Não é necessário acessar um site externo.
+<p align="center">
+  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+</p>
 
-O Runtime é distribuído como o binário nativo `simplicio` e expõe o Simplicio
-MCP pelo comando `simplicio serve --mcp --stdio`.
+<p align="center">
+  <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
+  <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+</p>
 
-## O que é instalado
+<p align="center">
+  <a href="#-installation">Install</a> ·
+  <a href="#-what-it-does">Features</a> ·
+  <a href="#-token-savings">96% Savings</a> ·
+  <a href="https://simpleti.com.br/simplicio/#start">Website</a>
+</p>
 
-Os instaladores baixam os assets oficiais das releases no GitHub:
+<p align="center">
+  <strong>🌍 Languages:</strong><br>
+  <a href="README.md">🇬🇧 English</a> |
+  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
+  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+</p>
 
-| Componente | Distribuição instalada |
-|---|---|
-| Runtime / MCP | Binário nativo `simplicio` |
-| Mapper | `simplicio-mapper` |
-| Dev CLI | `simplicio-dev-cli` |
-| Fast | `simplicio-fast` |
-| Loop | `simplicio-loop` |
-| Prompt | `simplicio-prompt` |
-| Sprint | `simplicio-sprint` |
+---
 
-Mapper, Dev CLI, Fast, Loop, Prompt e Sprint são publicados como wheels Python
-que fornecem seus executáveis CLI. O instalador usa uma virtualenv própria em
-`~/.simplicio/components-venv` e não instala extras de inferência nem pesos de
-LLM local.
+## ⚡ TL;DR
 
-## Instalação pelo repositório Git
+**Simplicio** is a terminal AI coding agent — a single binary that replaces your
+entire AI-assisted development workflow: chat, code generation, repository
+context, planning, local multi-agent orchestration (64 → 600 agents), and
+evidence-backed PR delivery.
 
-### macOS Apple Silicon e Linux
+**Runs on your machine. Your code never leaves your control. Remote models are
+optional, not required.**
 
-Requer Python 3.11 ou superior, `curl` e `git`:
+> **🔥 Save up to 96% of tokens vs traditional agents — more than Caveman (65%) or RTK (80%).**
+> Every interaction shows exactly how many tokens you saved. Single Rust binary, zero deps.
 
-```sh
-git clone https://github.com/wesleysimplicio/simplicio.git
-cd simplicio
-sh install.sh
-```
+## 🚀 Installation
 
-O `install.sh`:
+### macOS / Linux
 
-1. consulta as releases do Runtime em ordem decrescente;
-2. escolhe o asset mais recente compatível com o sistema e a arquitetura;
-3. recua para releases anteriores até encontrar Windows, macOS ou Linux quando
-   a release mais recente não tiver aquele asset;
-4. instala as wheels mais recentes disponíveis dos seis componentes;
-5. verifica SHA-256 quando o asset publica digest no GitHub.
-
-Para fixar uma release específica do Runtime:
-
-```sh
-SIMPLICIO_VERSION=v3.8.11 sh install.sh
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
 ```
 
 ### Windows
 
-Requer Git, PowerShell 5.1+ e Python 3.11 ou superior:
-
 ```powershell
-git clone https://github.com/wesleysimplicio/simplicio.git
-Set-Location simplicio
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex"
 ```
 
-O `install.ps1` aplica a mesma seleção por release. Na publicação atual, o
-Runtime encontra os assets publicados para macOS Apple Silicon e Linux em
-`v3.8.11` e o executável Windows na release anterior compatível. O instalador
-não assume que todas as plataformas estejam na mesma tag.
+Done. One command downloads the Runtime binary, verifies its checksum, and
+validates the embedded ecosystem. No Python package manager, sibling checkout,
+or model configuration is required.
 
-Para fixar a release do Runtime no Windows:
+### Embedded ecosystem
 
-```powershell
-powershell -ExecutionPolicy Bypass -File .\install.ps1 -Version v3.8.10
+The Runtime release is the distribution boundary. The generated binary carries
+the native capability surfaces for:
+
+| Capability | Binary surface |
+|---|---|
+| Mapper | `simplicio map` and MapperStore-backed recall |
+| Dev CLI | Runtime edit/validate/deliver workflows |
+| Loop | `simplicio loop` orchestration and decision flow |
+| Fast | `simplicio fast` snapshot/search/context workflow |
+| Prompt | Prompt contract and runtime prompt handling |
+| Sprint | Sprint projection/compatibility contract |
+
+Verify a release after installation:
+
+```bash
+simplicio ecosystem verify --json
 ```
 
-## Releases e assets
+The verification output includes the embedded component versions, upstream
+provenance commits, implementation mode, and compatibility status. Updating the
+Runtime release updates this bundle; the installer does not call or import the
+`simplicio-*` repositories. Legacy Python adapters and portable Claude skills
+may still be used explicitly, but they are outside the normal installation
+path and never replace the verified Runtime binary.
 
-As releases oficiais e seus assets ficam nos repositórios GitHub:
+### Plugin marketplace
 
-- [Runtime](https://github.com/wesleysimplicio/simplicio/releases)
-- [Mapper](https://github.com/wesleysimplicio/simplicio-mapper/releases)
-- [Dev CLI](https://github.com/wesleysimplicio/simplicio-dev-cli/releases)
-- [Fast](https://github.com/wesleysimplicio/simplicio-fast/releases)
-- [Loop](https://github.com/wesleysimplicio/simplicio-loop/releases)
-- [Prompt](https://github.com/wesleysimplicio/simplicio-prompt/releases)
-- [Sprint](https://github.com/wesleysimplicio/simplicio-sprint/releases)
+This public repository also publishes the Simplicio Claude Code marketplace:
 
-O instalador não usa o site de marketing, PyPI como fonte dos componentes ou
-modelos locais. Ele usa o GitHub para localizar as releases e instala as
-wheels oficiais encontradas nelas; as dependências Python normais são
-resolvidas pela virtualenv.
-
-## Verificação
-
-```sh
-simplicio version
-simplicio doctor
-simplicio-mapper --help
-simplicio-dev-cli --help
-simplicio-fast --help
-simplicio-loop --help
-sendsprint --help
+```text
+/plugin marketplace add wesleysimplicio/simplicio
+/plugin install simplicio-loop@simplicio
+/plugin install simplicio-prompt@simplicio
+/plugin install simplicio-sprint@simplicio
 ```
 
-O Prompt fornece, entre outros, os comandos `simplicio-subagents`,
-`simplicio-tui`, `simplicio-acp-adapter`, `simplicio-plugins` e
-`simplicio-skills`.
+The plugin bundle is documented in [`PLUGIN.md`](PLUGIN.md). These are optional
+Claude Code skill surfaces; they are not required to obtain the Runtime's
+embedded ecosystem. When present, the skills call the Runtime through
+`simplicio serve --mcp --stdio`.
 
-## Configurar o Simplicio MCP
+---
 
-O comando do servidor MCP é:
+## 💰 Token Savings — 96% is Real
 
-```sh
-simplicio serve --mcp --stdio
+**Without Simplicio:** every AI session rediscovers your repo, loads too much
+context, repeats prompts, burns paid tokens.
+
+**With Simplicio:**
+
+| Optimization | Savings |
+|---|---|
+| 🗺️ **Repo Map** — compressed context instead of reading raw files | ~70% |
+| 🧠 **Memory Recall** — known facts are not re-derived | ~80% |
+| ✏️ **Deterministic Editing** — changes without spending LLM tokens | 100% (output) |
+| 🏠 **Local LLM** — classification, summarization, low-risk edits | ~90% |
+| 📡 **Remote LLM** — only for planning and complex decisions | ~85% |
+| 🔀 **Local Fan-out** — 64→600 agents before scaling to cloud | ~95% |
+| **💎 Combined: up to 96% total savings** | **~96%** |
+
+**Every Simplicio response shows real savings:** `Simplicio: ~X tokens spent · saved ~Y (Z%)`
+
+---
+
+## 🎯 What It Does
+
+| Command | Description | Tokens |
+|---|---|---|
+| `simplicio map --repo .` | Maps the repository for LLMs | ~70% savings |
+| `simplicio memory "query"` | Neural recall (FTS + vectors) | ~80% savings |
+| `simplicio edit '{...}'` | Deterministic file editing | **Zero tokens** |
+| `simplicio coding-loop "task"` | Iterates until tests pass | Auto-repair |
+| `simplicio deliver certify` | 5 quality gates before shipping | Deterministic |
+| `simplicio run "task" --agents N` | Multi-agent orchestration | Local-first |
+
+---
+
+## 🆚 Simplicio vs Caveman vs RTK
+
+| | 🪨 Caveman | 🔧 RTK | 🔥 **Simplicio** |
+|---|---|---|---|
+| **Approach** | Output style compression | Shell command proxy | **Full agent runtime** |
+| **Max savings** | ~65% output tokens | ~80% on shell commands | **Up to 96% total** |
+| **Input compression** | ❌ | ✅ (filtered) | ✅ **Repo map + neural memory** |
+| **Output compression** | ✅ (caveman-speak) | ❌ | ✅ **Zero-token deterministic edits** |
+| **Local LLM** | ❌ | ❌ | ✅ **Built-in llama.cpp** |
+| **Multi-agent** | ❌ | ❌ | ✅ **64 → 600 local agents** |
+| **Memory across sessions** | ❌ | ❌ | ✅ **FTS + vector recall** |
+| **Evidence chain** | ❌ | ❌ | ✅ **sha256 sealed receipts** |
+| **Language** | JS/Python (skill) | Rust (binary) | **Rust (single binary)** |
+| **License** | MIT | Apache 2.0 | Proprietary |
+| **Stars** | 72.5k | 62.2k | ⭐ **You're early** |
+
+**Bottom line:** Caveman makes the AI *talk* less. RTK makes commands *output* less.
+Simplicio makes the AI *think* less — by remembering, mapping, editing deterministically,
+and running locally before ever touching a paid LLM.
+
+| **Simplicio saves 96% where Caveman saves 65% and RTK saves 80%.** |
+
+---
+
+## 🏗️ Architecture
+
+```
+LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
+  |                                   |
+  | 1. Orient                         | simplicio map
+  | 2. Recall                         | simplicio memory
+  | 3. Decide                         |
+  | 4. Edit  ───────────────────────> | simplicio edit (0 tokens)
+  | 5. Verify <─────────────────────  | simplicio deliver certify
+  | 6. Iterate                        | simplicio coding-loop
 ```
 
-Exemplo de configuração para um cliente MCP:
+**The LLM reasons. Simplicio executes deterministically.**
 
-```json
-{
-  "mcpServers": {
-    "simplicio": {
-      "command": "simplicio",
-      "args": ["serve", "--mcp", "--stdio"]
-    }
-  }
-}
+---
+
+## ✨ Features
+
+- 🏠 **Local-first** — built-in llama.cpp, scales to remote only when needed
+- 🪜 **Tiered agents** — 64 → 100 → 200 → 600 local agents before paid cloud
+- 🔇 **Shannon novelty gate** — filters redundant outputs (zero tokens on dedup)
+- 🔒 **Sealed receipts** — sha256 per artifact, tamper-proof evidence chain
+- 🛡️ **5 delivery gates** — acceptance, validation, run-verify, regression, self-review
+- ⚡ **Action gate** — risk classification + blocklist for chat-initiated mutations
+- 🔌 **MCP/ACP** — Model Context Protocol + Agent Client Protocol
+- 🌐 **Gateways** — Telegram, Discord, Slack, WhatsApp
+- 🧩 **Skill system** — loads and chains reusable capabilities
+- 💾 **Memory DB** — persistent FTS + vector recall across sessions
+- 🔀 **LLM router** — no LLM → local LLM → remote LLM automatically
+- 🖥️ **Cross-platform** — macOS, Linux, Windows, single binary
+
+---
+
+## 🎁 Free Public Beta
+
+**Deterministic commands are FREE forever:**
+`map`, `validate`, `edit`, `deliver`, `checkpoint`
+
+**AI features are free during the public beta with no end date.**
+Billing will be defined in future updates.
+
+```bash
+simplicio license status
 ```
 
-Se o cliente não encontrar o executável, use o caminho absoluto instalado em
-`~/.local/bin/simplicio` ou em `%USERPROFILE%\.local\bin\simplicio.exe`.
+---
 
-## Atualizar ou remover
+## 📋 Requirements
 
-Execute novamente o instalador para atualizar o Runtime e os componentes. Os
-instaladores são idempotentes e mantêm a virtualenv sob `~/.simplicio`.
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| RAM | 8 GB | 16 GB+ |
+| Storage | 5 MB | 1.5 GB (with local LLM) |
+| OS | macOS 13+, Linux, Windows 10+ | macOS ARM64 |
+| Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |
 
-```sh
-sh install.sh --doctor
-sh install.sh --uninstall
+---
+
+## 🧪 Testing this repo's tooling
+
+This repo ships committed release binaries plus the packaging/tooling around
+them (npm/PyPI wrappers, install scripts, a distribution-consistency checker).
+The official command to run that tooling's unit test suite:
+
+```bash
+pip install -r requirements-dev.txt
+python -m pytest tests/unit -v --cov=scripts --cov-report=term-missing --cov-fail-under=85
 ```
 
-No Windows:
+See [docs/testing-strategy.md](docs/testing-strategy.md) for what's covered,
+what's intentionally out of scope, and the plan for the rest of the testing
+epic. See also [CONTRIBUTING.md](CONTRIBUTING.md).
 
-```powershell
-powershell -ExecutionPolicy Bypass -File .\install.ps1 -Doctor
-powershell -ExecutionPolicy Bypass -File .\install.ps1 -Uninstall
-```
+---
 
-## Licença
+## 🌐 Ecosystem
 
-Proprietária. Consulte [LICENSE](LICENSE).
+- [Website](https://simpleti.com.br/simplicio/#start) — full docs, benchmarks, install
+- [Discord](https://discord.gg/wM6tr7xVb) — community and support
+
+---
+
+## 📄 License
+
+Proprietary. Binary free to download and use. AI features free during the
+public beta. See [LICENSE](LICENSE).
+
+---
+
+## ⭐ Star History
+
+<a href="https://www.star-history.com/?repos=wesleysimplicio%2Fsimplicio&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=wesleysimplicio/simplicio&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=wesleysimplicio/simplicio&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=wesleysimplicio/simplicio&type=date&legend=top-left" />
+ </picture>
+</a>
+
+---
+
+## 💬 Community
+
+- [Discord](https://discord.gg/wM6tr7xVb) — chat, support, early access
+- [GitHub Issues](https://github.com/wesleysimplicio/simplicio/issues) — bugs and feature requests
+
+---
+
+<p align="center">
+  <strong>🔥 Simplicio — Your code, your machine, 96% cheaper. 🔥</strong>
+</p>

--- a/README.md
+++ b/README.md
@@ -67,22 +67,26 @@ powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/m
 ```
 
 Done. One command downloads the Runtime binary, verifies its checksum, and
-validates the embedded ecosystem. No Python package manager, sibling checkout,
-or model configuration is required.
+validates the embedded Python source bundle. The installer does not use a
+Python package manager or sibling checkout. A Google login with an active
+entitlement is mandatory before product commands run; public beta access may
+be free, but it does not bypass login.
 
-### Embedded ecosystem
+### Python projects embedded in the Runtime
 
 The Runtime release is the distribution boundary. The generated binary carries
-the native capability surfaces for:
+the real Python source trees for the six projects below. They remain Python
+projects; the Runtime host is not a native-Rust rewrite and normal installation
+does not clone or download their repositories:
 
 | Capability | Binary surface |
 |---|---|
-| Mapper | `simplicio map` and MapperStore-backed recall |
-| Dev CLI | Runtime edit/validate/deliver workflows |
-| Loop | `simplicio loop` orchestration and decision flow |
-| Fast | `simplicio fast` snapshot/search/context workflow |
-| Prompt | Prompt contract and runtime prompt handling |
-| Sprint | Sprint projection/compatibility contract |
+| Mapper | Embedded Mapper Python source + Runtime bridge |
+| Dev CLI | Embedded Dev CLI Python source + Runtime bridge |
+| Loop | Embedded Loop Python source + Runtime bridge |
+| Fast | Embedded Fast Python source + Runtime bridge |
+| Prompt | Embedded Prompt Python source + Runtime bridge |
+| Sprint | Embedded Sprint Python source + Runtime bridge |
 
 Verify a release after installation:
 
@@ -90,12 +94,20 @@ Verify a release after installation:
 simplicio ecosystem verify --json
 ```
 
-The verification output includes the embedded component versions, upstream
-provenance commits, implementation mode, and compatibility status. Updating the
-Runtime release updates this bundle; the installer does not call or import the
-`simplicio-*` repositories. Legacy Python adapters and portable Claude skills
-may still be used explicitly, but they are outside the normal installation
-path and never replace the verified Runtime binary.
+The verification output includes the source archive size/digest, embedded
+component versions, provenance commits, and compatibility status. Updating the
+Runtime release updates this bundle. The binary still uses an available Python
+3 interpreter to execute the embedded sources; it never downloads packages or
+falls back to sibling checkouts. Legacy external adapters and portable Claude
+skills may still be used explicitly, but they are outside the normal path.
+
+After installation, authenticate with the Google-backed device flow when
+prompted, or run:
+
+```bash
+simplicio auth login
+simplicio auth status --json
+```
 
 ### Plugin marketplace
 
@@ -207,13 +219,14 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime (Rust)
 
 ---
 
-## 🎁 Free Public Beta
+## 🎁 Public Beta
 
 **Deterministic commands are FREE forever:**
 `map`, `validate`, `edit`, `deliver`, `checkpoint`
 
-**AI features are free during the public beta with no end date.**
-Billing will be defined in future updates.
+AI features may be free while the public beta flag is active. Login and an
+active entitlement are still required; when beta access ends, the entitlement
+must come from an active subscription.
 
 ```bash
 simplicio license status

--- a/SIMPLICIO_ECOSYSTEM.md
+++ b/SIMPLICIO_ECOSYSTEM.md
@@ -6,6 +6,10 @@ Consumidores finais via release do Runtime e, opcionalmente, via `npx @wesleysim
 ## De quem este repo depende
 - [simplicio-runtime](https://github.com/wesleysimplicio/simplicio-runtime) — fonte do binário compilado e do bundle nativo incluído no release
 
+## Versão atual
+
+3.6.7 (manifest público legado; bundle nativo novo pendente de release)
+
 ## Regra de distribuição
 
 O Runtime binário é a fronteira de instalação. Cada release compatível deve

--- a/SIMPLICIO_ECOSYSTEM.md
+++ b/SIMPLICIO_ECOSYSTEM.md
@@ -1,17 +1,47 @@
-# simplicio (npm packaging) no Ecossistema Simplicio
+# simplicio no Ecossistema Simplicio
 
 ## Quem depende deste repo
-Consumidores finais via `npx @wesleysimplicio/simplicio`.
+Consumidores finais via release do Runtime e, opcionalmente, via `npx @wesleysimplicio/simplicio`.
 
 ## De quem este repo depende
-- [simplicio-runtime](https://github.com/wesleysimplicio/simplicio-runtime) — binário compilado incluído no release
+- [simplicio-runtime](https://github.com/wesleysimplicio/simplicio-runtime) — fonte do binário compilado e do bundle nativo incluído no release
 
-## Versão atual
-3.5.2 (simplicio-update-manifest.json)
+## Regra de distribuição
+
+O Runtime binário é a fronteira de instalação. Cada release compatível deve
+conter e verificar estas seis superfícies nativas:
+
+- Mapper
+- Dev CLI
+- Loop
+- Fast
+- Prompt
+- Sprint projection
+
+O instalador chama apenas `simplicio ecosystem verify --json`. Ele não instala
+pacotes Python, não clona os repositórios `simplicio-*` e não substitui o
+Runtime por um checkout local. Adapters legados podem ser acionados somente por
+um fluxo explícito fora do instalador.
+
+Validação local:
+
+```bash
+simplicio ecosystem verify --json
+```
+
+O resultado deve listar a versão real, commit de proveniência, modo de
+implementação e compatibilidade de cada componente.
+
+## Estado do manifest público
+
+O manifest atualmente publicado neste repositório ainda é o `3.6.7`, um
+release legado de transição. A próxima publicação do Runtime precisa substituir
+seus artefatos pelos binários que passam na verificação do bundle acima; esta
+documentação não declara que o asset legado já contém os seis componentes.
 
 ## Versão mínima esperada pelos dependentes
 Nenhuma — repo é ponto de entrada para usuários finais.
 
 ---
 
-_Last updated: 2026-07-14_
+_Last updated: 2026-08-14_

--- a/SIMPLICIO_ECOSYSTEM.md
+++ b/SIMPLICIO_ECOSYSTEM.md
@@ -4,23 +4,24 @@
 Consumidores finais via release do Runtime e, opcionalmente, via `npx @wesleysimplicio/simplicio`.
 
 ## De quem este repo depende
-- [simplicio-runtime](https://github.com/wesleysimplicio/simplicio-runtime) — fonte do binário compilado e do bundle nativo incluído no release
+- [simplicio-runtime](https://github.com/wesleysimplicio/simplicio-runtime) — fonte do binário compilado e do bundle de fontes Python incluído no release
 
 ## Versão atual
 
-3.6.7 (manifest público legado; bundle nativo novo pendente de release)
+3.6.7 (manifest público legado; bundle Python novo pendente de release)
 
 ## Regra de distribuição
 
 O Runtime binário é a fronteira de instalação. Cada release compatível deve
-conter e verificar estas seis superfícies nativas:
+conter e verificar as fontes Python reais destas seis superfícies, sem
+reescrevê-las como Rust nativo:
 
 - Mapper
 - Dev CLI
 - Loop
 - Fast
 - Prompt
-- Sprint projection
+- Sprint
 
 O instalador chama apenas `simplicio ecosystem verify --json`. Ele não instala
 pacotes Python, não clona os repositórios `simplicio-*` e não substitui o
@@ -33,8 +34,8 @@ Validação local:
 simplicio ecosystem verify --json
 ```
 
-O resultado deve listar a versão real, commit de proveniência, modo de
-implementação e compatibilidade de cada componente.
+O resultado deve listar a versão real, commit de proveniência, prefixo do
+pacote, digest do arquivo-fonte e compatibilidade de cada componente.
 
 ## Estado do manifest público
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,267 +1,269 @@
-#requires -Version 5.1
+#!/usr/bin/env pwsh
+# install.ps1 — Install/update/uninstall/doctor the Simplicio Runtime on Windows
+#
+# Usage:
+#   powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex"
+#   pwsh install.ps1 -Doctor
+#   pwsh install.ps1 -Uninstall
+#
+# Environment variables:
+#   SIMPLICIO_VERSION           - pin a specific version (default: latest)
+#   SIMPLICIO_BIN_DIR           - custom install directory
+#   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
+#                                 published for this target (default: refuse)
+#   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
+#
+# Asset naming follows distribution/targets.json (the canonical target
+# triplet table for the whole ecosystem) — target "windows-x64", asset
+# "simplicio-windows-x64.exe". Any drift between this script, the release
+# workflow and simplicio-update-manifest.json is caught by
+# scripts/verify_distribution_consistency.py in CI.
 
-[CmdletBinding()]
 param(
   [string]$Version = "",
   [switch]$Doctor,
   [switch]$Uninstall
 )
 
-# Simplicio ecosystem installer for Windows.
-# Runtime assets are selected newest-first for Windows. Component wheels are
-# selected newest-first and fall back to older releases when needed.
-
 $ErrorActionPreference = "Stop"
-$RuntimeRepo = "wesleysimplicio/simplicio"
-$ApiRoot = "https://api.github.com/repos"
-$InstallDir = if ($env:SIMPLICIO_BIN_DIR) { $env:SIMPLICIO_BIN_DIR } else { Join-Path $env:USERPROFILE ".local\bin" }
-$StateDir = if ($env:SIMPLICIO_STATE_DIR) { $env:SIMPLICIO_STATE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
-$VenvDir = if ($env:SIMPLICIO_COMPONENT_VENV) { $env:SIMPLICIO_COMPONENT_VENV } else { Join-Path $StateDir "components-venv" }
-$ManifestPath = Join-Path $StateDir "components.json"
-$RuntimePath = Join-Path $InstallDir "simplicio.exe"
 
-function Info([string]$Message) { Write-Host "==> $Message" }
-function Ok([string]$Message) { Write-Host "  ✓ $Message" }
-function Warn([string]$Message) { Write-Warning $Message }
-function Fail([string]$Message) { throw $Message }
+$Repo = "wesleysimplicio/simplicio"
+$BinName = "simplicio.exe"
+$Target = "windows-x64"
+$Asset = "simplicio-windows-x64.exe"
 
-function Get-Python {
-  $command = Get-Command python -ErrorAction SilentlyContinue
-  if ($command) {
-    return [PSCustomObject]@{ Exe = $command.Source; Args = @() }
-  }
-  $command = Get-Command py -ErrorAction SilentlyContinue
-  if ($command) {
-    return [PSCustomObject]@{ Exe = $command.Source; Args = @("-3") }
-  }
-  Fail "Python 3.11 ou superior não encontrado"
+if ($env:SIMPLICIO_BIN_DIR) {
+  $InstallDir = $env:SIMPLICIO_BIN_DIR
+} else {
+  $InstallDir = "$env:USERPROFILE\.local\bin"
+}
+$DestPath = Join-Path $InstallDir $BinName
+
+function Test-InPath([string]$dir) {
+  return ($env:Path -split ";") -contains $dir
 }
 
-function Get-Releases {
-  param(
-    [Parameter(Mandatory = $true)][string]$Repository,
-    [string]$PinnedVersion = ""
-  )
-  $headers = @{
-    Accept = "application/vnd.github+json"
-    "User-Agent" = "simplicio-installer"
-  }
-  if ($PinnedVersion) {
-    $url = "$ApiRoot/$Repository/releases/tags/$PinnedVersion"
-    return @(Invoke-RestMethod -Uri $url -Headers $headers -ErrorAction Stop)
-  }
-  $url = "$ApiRoot/$Repository/releases?per_page=100"
-  return @(Invoke-RestMethod -Uri $url -Headers $headers -ErrorAction Stop)
-}
-
-function Find-ReleaseAsset {
-  param(
-    [Parameter(Mandatory = $true)][string]$Repository,
-    [Parameter(Mandatory = $true)][string[]]$Patterns,
-    [string]$PinnedVersion = ""
-  )
-  $releases = Get-Releases -Repository $Repository -PinnedVersion $PinnedVersion
-  foreach ($release in $releases) {
-    if ($release.draft -or $release.prerelease) { continue }
-    foreach ($asset in @($release.assets)) {
-      foreach ($pattern in $Patterns) {
-        if ($asset.name -match $pattern) {
-          return [PSCustomObject]@{
-            Repository = $Repository
-            Release = $release.tag_name
-            Asset = $asset.name
-            Url = $asset.browser_download_url
-            Digest = $asset.digest
-          }
-        }
-      }
-    }
-  }
-  throw "Nenhum asset compatível encontrado em $Repository para: $($Patterns -join ', ')"
-}
-
-function Download-VerifiedAsset {
-  param(
-    [Parameter(Mandatory = $true)]$Asset,
-    [Parameter(Mandatory = $true)][string]$Destination
-  )
-  $staging = "$Destination.download-$([guid]::NewGuid().ToString('N'))"
+function Test-EmbeddedEcosystem {
+  if (-not (Test-Path $DestPath)) { return $false }
   try {
-    Invoke-WebRequest -Uri $Asset.Url -OutFile $staging -UseBasicParsing -ErrorAction Stop
-    if (-not (Test-Path $staging) -or (Get-Item $staging).Length -eq 0) {
-      throw "download vazio: $($Asset.Url)"
-    }
-    if ($Asset.Digest -and $Asset.Digest -match '^sha256:(.+)$') {
-      $expected = $Matches[1].ToLowerInvariant()
-      $actual = (Get-FileHash -Path $staging -Algorithm SHA256).Hash.ToLowerInvariant()
-      if ($actual -ne $expected) {
-        throw "SHA-256 inválido para $($Asset.Asset): esperado $expected, obtido $actual"
-      }
-      Ok "SHA-256 verificado: $($Asset.Asset)"
-    } else {
-      Warn "sem digest SHA-256 publicado para $($Asset.Asset); instalação continua"
-    }
-    Move-Item -Force -Path $staging -Destination $Destination
-  } finally {
-    if (Test-Path $staging) { Remove-Item -Force $staging -ErrorAction SilentlyContinue }
+    $null = & $DestPath ecosystem verify --json 2>$null
+    return ($LASTEXITCODE -eq 0)
+  } catch {
+    return $false
   }
 }
 
-function Remove-ManagedInstall {
-  Info "Removendo Simplicio Runtime e componentes gerenciados"
-  if (Test-Path $ManifestPath) {
-    try {
-      $manifest = Get-Content -Raw -Path $ManifestPath | ConvertFrom-Json
-      foreach ($path in @($manifest.managed_paths)) {
-        if ($path -and (Test-Path $path)) {
-          Remove-Item -Force -Path $path -ErrorAction SilentlyContinue
-        }
-      }
-    } catch {
-      Warn "não foi possível ler o manifesto; removendo apenas os caminhos padrão"
-    }
-  } else {
-    if (Test-Path $RuntimePath) { Remove-Item -Force $RuntimePath }
-  }
-  if (Test-Path $VenvDir) { Remove-Item -Recurse -Force $VenvDir }
-  if (Test-Path $ManifestPath) { Remove-Item -Force $ManifestPath }
-  Ok "componentes removidos; demais configurações foram preservadas"
-}
-
-function Test-Install {
-  $failed = $false
-  if (Test-Path $RuntimePath) {
-    try {
-      & $RuntimePath version | Out-Null
-      Ok "Runtime executável"
-    } catch {
-      Warn "Runtime não executa: $RuntimePath"
-      $failed = $true
-    }
-  } else {
-    Warn "Runtime ausente: $RuntimePath"
-    $failed = $true
-  }
-  if (Test-Path $ManifestPath) {
-    $manifest = Get-Content -Raw -Path $ManifestPath | ConvertFrom-Json
-    foreach ($path in @($manifest.managed_paths)) {
-      if ($path -and (Test-Path $path)) { Ok "disponível: $(Split-Path -Leaf $path)" }
-      elseif ($path) { Warn "ausente: $path"; $failed = $true }
-    }
-    Ok "manifesto: $ManifestPath"
-  } else {
-    Warn "manifesto ausente: $ManifestPath"
-    $failed = $true
-  }
-  if ($failed) { exit 1 }
-}
-
-if ($Uninstall) {
-  Remove-ManagedInstall
-  exit 0
-}
+# ─── -Doctor: idempotent, read-only health check ───────────────────────────
 if ($Doctor) {
-  Test-Install
+  Write-Host "==> simplicio doctor"
+  $ok = $true
+
+  if (Test-Path $DestPath) {
+    Write-Host "  [OK] binary present: $DestPath"
+  } else {
+    Write-Host "  [FAIL] binary missing at $DestPath"
+    $ok = $false
+  }
+
+  if (Test-InPath $InstallDir) {
+    Write-Host "  [OK] $InstallDir is on PATH"
+  } else {
+    Write-Host "  [WARN] $InstallDir is not on PATH (current session)"
+  }
+
+  if (Test-Path $DestPath) {
+    try {
+      $verOut = & $DestPath version 2>&1 | Out-String
+      if ($LASTEXITCODE -ne 0) { throw "version command returned $LASTEXITCODE" }
+      Write-Host "  [OK] binary runs: $($verOut.Trim())"
+    } catch {
+      Write-Host "  [FAIL] binary present but failed to execute: $($_.Exception.Message)"
+      $ok = $false
+    }
+
+    if (Test-EmbeddedEcosystem) {
+      Write-Host "  [OK] embedded ecosystem bundle is present"
+    } else {
+      Write-Host "  [FAIL] binary does not contain the expected embedded ecosystem bundle"
+      $ok = $false
+    }
+  }
+
+  if ($ok) {
+    Write-Host ""
+    Write-Host "  ✓ simplicio looks healthy"
+    exit 0
+  } else {
+    Write-Host ""
+    Write-Host "  ✗ simplicio has problems — re-run the installer"
+    exit 1
+  }
+}
+
+# ─── -Uninstall: idempotent removal, safe to run repeatedly ────────────────
+if ($Uninstall) {
+  Write-Host "==> simplicio uninstall"
+  if (Test-Path $DestPath) {
+    Remove-Item -Force $DestPath
+    Write-Host "  ✓ removed $DestPath"
+  } else {
+    Write-Host "  ✓ already removed (nothing at $DestPath)"
+  }
+  # Data/config is intentionally preserved (idempotent, non-destructive
+  # uninstall) — user data under ~/.simplicio is never touched here.
+  Write-Host "  ✓ user data under `$env:USERPROFILE\.simplicio was preserved"
+  Write-Host ""
+  Write-Host "  Note: if you added $InstallDir to your PowerShell profile's"
+  Write-Host "  `$env:Path, remove that line manually — this script never"
+  Write-Host "  edits your profile."
   exit 0
 }
 
-$python = Get-Python
-$pythonVersion = (& $python.Exe @($python.Args) -c "import sys; print('%d.%d' % sys.version_info[:2])").Trim()
+# ─── Install / update ───────────────────────────────────────────────────────
+Write-Host "==> simplicio installer for Windows ($Target)"
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+if (-not $Version -and $env:SIMPLICIO_VERSION) {
+  $Version = $env:SIMPLICIO_VERSION
+}
+if (-not $Version) {
+  Write-Host "==> fetching latest version..."
+  try {
+    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -ErrorAction Stop
+    $Version = $latest.tag_name
+    Write-Host "  - latest version: $Version"
+  } catch {
+    $Version = "latest"
+    Write-Host "  ! could not determine latest, using '$Version'"
+  }
+}
+
+# Resolve the release base (pinned tag, or the 'latest' redirect) once so the
+# binary and the manifest we verify it against come from the same place.
+if ($Version -eq "latest") {
+  $ReleaseBase = "https://github.com/$Repo/releases/latest/download"
+} else {
+  $ReleaseBase = "https://github.com/$Repo/releases/download/$Version"
+}
+
+# ─── Fetch update manifest for checksum verification ───────────────────────
+$ManifestUrl = "$ReleaseBase/simplicio-update-manifest.json"
+$Manifest = $null
 try {
-  if ([version]$pythonVersion -lt [version]"3.11") { Fail "Python 3.11 ou superior é necessário; encontrado $pythonVersion" }
+  Write-Host "==> fetching update manifest for verification..."
+  $Manifest = Invoke-RestMethod -Uri $ManifestUrl -ErrorAction Stop
 } catch {
-  if ($_.Exception.Message -like "Python 3.11*") { throw }
-  Fail "não foi possível verificar a versão do Python"
+  Write-Host "  ! could not fetch update manifest: $($_.Exception.Message)"
 }
 
-$pinnedRuntime = if ($Version) { $Version } elseif ($env:SIMPLICIO_VERSION) { $env:SIMPLICIO_VERSION } else { "" }
-$runtimePatterns = @(
-  '^simplicio-windows-x64\.exe$',
-  '^simplicio-windows-x86_64\.exe$',
-  '^simplicio\.exe$'
-)
+$ExpectedSha256 = $null
+$ExpectedSigned = $false
+if ($Manifest) {
+  $artifact = $Manifest.artifacts | Where-Object { $_.target -eq $Target } | Select-Object -First 1
+  if ($artifact) {
+    $ExpectedSha256 = $artifact.sha256
+    $ExpectedSigned = [bool]$artifact.signed
+  }
+}
 
-New-Item -ItemType Directory -Force -Path $InstallDir, $StateDir | Out-Null
-$tempDir = Join-Path $env:TEMP ("simplicio-install-" + [guid]::NewGuid().ToString('N'))
-New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+if (-not $ExpectedSha256) {
+  if ($env:SIMPLICIO_ALLOW_UNVERIFIED -eq "1") {
+    Write-Host "  ! no published checksum for target '$Target' — proceeding UNVERIFIED (SIMPLICIO_ALLOW_UNVERIFIED=1)"
+  } else {
+    Write-Error "Refusing to install: no published SHA256 checksum for target '$Target' in the update manifest. Set SIMPLICIO_ALLOW_UNVERIFIED=1 to override at your own risk."
+    exit 1
+  }
+} elseif (-not $ExpectedSigned) {
+  Write-Host "  ! checksum will be verified, but this artifact is not cryptographically signed yet (ed25519 signing not wired for $Target — see issue #5)"
+}
 
+# ─── Download to a staging file, verify, then atomically swap in ──────────
+$DownloadUrl = "$ReleaseBase/$Asset"
+$StagingPath = "$DestPath.download-$([guid]::NewGuid().ToString('N')).tmp"
+
+Write-Host "==> downloading $DownloadUrl"
 try {
-  Info "Procurando o binário Runtime Windows mais recente"
-  $runtime = Find-ReleaseAsset -Repository $RuntimeRepo -Patterns $runtimePatterns -PinnedVersion $pinnedRuntime
-  $runtimeStaging = Join-Path $tempDir $runtime.Asset
-  Download-VerifiedAsset -Asset $runtime -Destination $runtimeStaging
-  Move-Item -Force -Path $runtimeStaging -Destination $RuntimePath
-  Ok "Runtime $($runtime.Release) instalado: $RuntimePath"
-
-  $components = @(
-    [PSCustomObject]@{ Name = "simplicio-mapper"; Repository = "wesleysimplicio/simplicio-mapper"; Pattern = '^simplicio_mapper-.*\.whl$' },
-    [PSCustomObject]@{ Name = "simplicio-prompt"; Repository = "wesleysimplicio/simplicio-prompt"; Pattern = '^simplicio_prompt-.*\.whl$' },
-    [PSCustomObject]@{ Name = "simplicio-dev-cli"; Repository = "wesleysimplicio/simplicio-dev-cli"; Pattern = '^simplicio_cli-.*\.whl$' },
-    [PSCustomObject]@{ Name = "simplicio-fast"; Repository = "wesleysimplicio/simplicio-fast"; Pattern = '^simplicio_fast-.*\.whl$' },
-    [PSCustomObject]@{ Name = "simplicio-loop"; Repository = "wesleysimplicio/simplicio-loop"; Pattern = '^simplicio_loop-.*\.whl$' },
-    [PSCustomObject]@{ Name = "simplicio-sprint"; Repository = "wesleysimplicio/simplicio-sprint"; Pattern = '^simplicio_sprint-.*\.whl$' }
-  )
-
-  & $python.Exe @($python.Args) -m venv $VenvDir
-  if ($LASTEXITCODE -ne 0) { Fail "não foi possível criar a virtualenv: $VenvDir" }
-  $venvPython = Join-Path $VenvDir "Scripts\python.exe"
-  if (-not (Test-Path $venvPython)) { Fail "Python da virtualenv não encontrado: $venvPython" }
-  & $venvPython -m pip install --disable-pip-version-check --upgrade pip | Out-Host
-  if ($LASTEXITCODE -ne 0) { Fail "não foi possível preparar o pip da virtualenv" }
-
-  $wheelPaths = @()
-  $componentRecords = @()
-  foreach ($component in $components) {
-    Info "Procurando wheel de $($component.Name)"
-    $asset = Find-ReleaseAsset -Repository $component.Repository -Patterns @($component.Pattern)
-    $wheelPath = Join-Path $tempDir $asset.Asset
-    Download-VerifiedAsset -Asset $asset -Destination $wheelPath
-    $wheelPaths += $wheelPath
-    $componentRecords += [PSCustomObject]@{
-      name = $component.Name
-      repository = $component.Repository
-      release = $asset.Release
-      asset = $asset.Asset
-    }
-  }
-
-  & $venvPython -m pip install --disable-pip-version-check --upgrade --force-reinstall $wheelPaths | Out-Host
-  if ($LASTEXITCODE -ne 0) { Fail "falha ao instalar as wheels dos componentes" }
-
-  $managedPaths = New-Object System.Collections.Generic.List[string]
-  $managedPaths.Add($RuntimePath)
-  $scriptsDir = Join-Path $VenvDir "Scripts"
-  foreach ($entry in @(Get-ChildItem -Path $scriptsDir -Filter "simplicio-*.exe" -File -ErrorAction SilentlyContinue)) {
-    $destination = Join-Path $InstallDir $entry.Name
-    Copy-Item -Force -Path $entry.FullName -Destination $destination
-    $managedPaths.Add($destination)
-  }
-  foreach ($entry in @(Get-ChildItem -Path $scriptsDir -Filter "sendsprint.exe" -File -ErrorAction SilentlyContinue)) {
-    $destination = Join-Path $InstallDir $entry.Name
-    Copy-Item -Force -Path $entry.FullName -Destination $destination
-    $managedPaths.Add($destination)
-  }
-
-  $manifest = [ordered]@{
-    schema = "simplicio.ecosystem-manifest/v2"
-    source = "github-releases"
-    runtime = [ordered]@{
-      repository = $RuntimeRepo
-      target = "windows-x64"
-      release = $runtime.Release
-      asset = $runtime.Asset
-      path = $RuntimePath
-    }
-    components = @($componentRecords)
-    python_venv = $VenvDir
-    managed_paths = @($managedPaths)
-  }
-  $manifest | ConvertTo-Json -Depth 8 | Set-Content -Encoding UTF8 -Path $ManifestPath
-  Ok "manifesto gravado: $ManifestPath"
-  Write-Host ""
-  Write-Host "Instalação concluída."
-  Write-Host "MCP: simplicio serve --mcp --stdio"
-  Write-Host "PATH: adicione $InstallDir ao PATH se necessário."
-} finally {
-  if (Test-Path $tempDir) { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
+  Invoke-WebRequest -Uri $DownloadUrl -OutFile $StagingPath -UseBasicParsing -ErrorAction Stop
+} catch {
+  Write-Error "Download failed for $Asset from $DownloadUrl : $($_.Exception.Message)"
+  if (Test-Path $StagingPath) { Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue }
+  exit 1
 }
+
+if (-not (Test-Path $StagingPath) -or (Get-Item $StagingPath).Length -eq 0) {
+  Write-Error "Downloaded file is missing or empty: $StagingPath"
+  if (Test-Path $StagingPath) { Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue }
+  exit 1
+}
+
+if ($ExpectedSha256) {
+  $actualSha256 = (Get-FileHash -Path $StagingPath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
+    Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
+    Write-Error "Checksum mismatch for $Asset. Expected $ExpectedSha256, got $actualSha256. Refusing to install a tampered or corrupt binary."
+    exit 1
+  }
+  Write-Host "  ✓ SHA256 verified: $actualSha256"
+}
+
+# Atomic swap: rename into place on the same volume so there is never a
+# window where $DestPath is a half-written file, and re-running this script
+# (idempotent update) never leaves stale .tmp files behind on success.
+try {
+  Move-Item -Force -Path $StagingPath -Destination $DestPath
+} catch {
+  Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
+  Write-Error "Could not move verified binary into place: $($_.Exception.Message)"
+  exit 1
+}
+Write-Host "  ✓ installed: $DestPath"
+
+# ─── Verify the downloaded Runtime and its embedded ecosystem ────────────────
+try {
+  $output = & $DestPath version 2>&1 | Out-String
+  if ($LASTEXITCODE -ne 0) { throw "version command returned $LASTEXITCODE" }
+} catch {
+  Write-Error "Binary installed but version verification failed: $($_.Exception.Message)"
+  exit 1
+}
+
+if (-not (Test-EmbeddedEcosystem)) {
+  Write-Error "This Runtime does not contain the expected embedded ecosystem bundle; refusing to finish installation. Install a compatible Runtime release."
+  exit 1
+}
+Write-Host "  ✓ embedded ecosystem bundle verified in the binary"
+
+$BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
+New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null
+$BundleReport = Join-Path $BundleDir "ecosystem-bundle.json"
+try {
+  $bundleJson = & $DestPath ecosystem verify --json 2>&1
+  if ($LASTEXITCODE -ne 0) { throw "ecosystem verify returned $LASTEXITCODE" }
+  $bundleJson | Set-Content -Encoding UTF8 $BundleReport
+  Write-Host "  ✓ embedded ecosystem report: $BundleReport"
+} catch {
+  if (Test-Path $BundleReport) { Remove-Item -Force $BundleReport -ErrorAction SilentlyContinue }
+  Write-Error "Could not persist the embedded ecosystem verification: $($_.Exception.Message)"
+  exit 1
+}
+
+# PATH hint
+if (-not (Test-InPath $InstallDir)) {
+  Write-Host ""
+  Write-Host "  ! $InstallDir is not in PATH"
+  Write-Host "    Add it to your PowerShell profile:"
+  Write-Host "    `$env:Path += `";$InstallDir`""
+  Write-Host ""
+}
+
+Write-Host ""
+Write-Host "  ✓ simplicio Runtime $Version (windows-x64) installed successfully"
+Write-Host "  ✓ Mapper, Dev CLI, Loop, Fast, Prompt and Sprint projection are in the binary"
+Write-Host "  ✓ no Python packages, sibling checkouts or external adapters were installed"
+Write-Host ""
+Write-Host "  Run:     simplicio chat 'hello' --repo ."
+Write-Host "  REPL:    simplicio chat --repl --repo ."
+Write-Host "  Doctor:  pwsh install.ps1 -Doctor"
+Write-Host "  Remove:  pwsh install.ps1 -Uninstall"
+Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,7 @@
 #!/usr/bin/env pwsh
 # install.ps1 — Install/update/uninstall/doctor the Simplicio Runtime on Windows
+# The Runtime binary carries the real Python project sources; it does not
+# rewrite them as Rust or download sibling simplicio-* repositories.
 #
 # Usage:
 #   powershell -c "irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex"
@@ -53,6 +55,25 @@ function Test-EmbeddedEcosystem {
   }
 }
 
+function Test-ActiveLogin {
+  if (-not (Test-Path $DestPath)) { return $false }
+  try {
+    $null = & $DestPath auth status --json 2>$null
+    return ($LASTEXITCODE -eq 0)
+  } catch {
+    return $false
+  }
+}
+
+function Require-ActiveLogin {
+  if (Test-ActiveLogin) { return }
+  Write-Host "==> Google login is required to activate Simplicio Runtime"
+  & $DestPath auth login
+  if ($LASTEXITCODE -ne 0 -or -not (Test-ActiveLogin)) {
+    throw "Login ausente, expirado, revogado ou sem entitlement ativo; instalação bloqueada"
+  }
+}
+
 # ─── -Doctor: idempotent, read-only health check ───────────────────────────
 if ($Doctor) {
   Write-Host "==> simplicio doctor"
@@ -82,9 +103,16 @@ if ($Doctor) {
     }
 
     if (Test-EmbeddedEcosystem) {
-      Write-Host "  [OK] embedded ecosystem bundle is present"
+      Write-Host "  [OK] real Python sources are embedded in the binary"
     } else {
-      Write-Host "  [FAIL] binary does not contain the expected embedded ecosystem bundle"
+      Write-Host "  [FAIL] binary does not contain the expected Python source bundle"
+      $ok = $false
+    }
+
+    if (Test-ActiveLogin) {
+      Write-Host "  [OK] active Google session and entitlement"
+    } else {
+      Write-Host "  [FAIL] missing, expired, revoked, or inactive Google session"
       $ok = $false
     }
   }
@@ -219,7 +247,7 @@ try {
 }
 Write-Host "  ✓ installed: $DestPath"
 
-# ─── Verify the downloaded Runtime and its embedded ecosystem ────────────────
+# ─── Verify the downloaded Runtime and its embedded Python source bundle ─────
 try {
   $output = & $DestPath version 2>&1 | Out-String
   if ($LASTEXITCODE -ne 0) { throw "version command returned $LASTEXITCODE" }
@@ -229,10 +257,19 @@ try {
 }
 
 if (-not (Test-EmbeddedEcosystem)) {
-  Write-Error "This Runtime does not contain the expected embedded ecosystem bundle; refusing to finish installation. Install a compatible Runtime release."
+  Write-Error "This Runtime does not contain the expected embedded Python source bundle; refusing to finish installation. Install a compatible Runtime release."
   exit 1
 }
-Write-Host "  ✓ embedded ecosystem bundle verified in the binary"
+Write-Host "  ✓ real Python source bundle verified in the binary"
+
+# ─── Active login is mandatory; beta does not bypass this gate ──────────────
+try {
+  Require-ActiveLogin
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+Write-Host "  ✓ active Google session and entitlement verified"
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
 New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null
@@ -241,7 +278,7 @@ try {
   $bundleJson = & $DestPath ecosystem verify --json 2>&1
   if ($LASTEXITCODE -ne 0) { throw "ecosystem verify returned $LASTEXITCODE" }
   $bundleJson | Set-Content -Encoding UTF8 $BundleReport
-  Write-Host "  ✓ embedded ecosystem report: $BundleReport"
+  Write-Host "  ✓ embedded Python source report: $BundleReport"
 } catch {
   if (Test-Path $BundleReport) { Remove-Item -Force $BundleReport -ErrorAction SilentlyContinue }
   Write-Error "Could not persist the embedded ecosystem verification: $($_.Exception.Message)"
@@ -259,8 +296,9 @@ if (-not (Test-InPath $InstallDir)) {
 
 Write-Host ""
 Write-Host "  ✓ simplicio Runtime $Version (windows-x64) installed successfully"
-Write-Host "  ✓ Mapper, Dev CLI, Loop, Fast, Prompt and Sprint projection are in the binary"
-Write-Host "  ✓ no Python packages, sibling checkouts or external adapters were installed"
+Write-Host "  ✓ Mapper, Dev CLI, Loop, Fast, Prompt and Sprint Python sources are in the binary"
+Write-Host "  ✓ no pip packages, sibling checkouts or simplicio-* downloads were installed"
+Write-Host "  ✓ active Google login is required for product commands"
 Write-Host ""
 Write-Host "  Run:     simplicio chat 'hello' --repo ."
 Write-Host "  REPL:    simplicio chat --repl --repo ."

--- a/install.sh
+++ b/install.sh
@@ -1,312 +1,292 @@
 #!/usr/bin/env sh
+# install.sh — Simplicio Runtime: instalador do binário e ecossistema nativo
+#
+# Um comando instala o Runtime. Mapper, Dev CLI, Loop, Fast, Prompt e Sprint
+# projection são entregues pelo próprio binário.
+#
+#   curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+#
+# Idempotent subcommands:
+#   sh install.sh --doctor      # health check, safe to re-run
+#   sh install.sh --uninstall   # removes the binary, preserves user data
+#
+# Environment variables:
+#   SIMPLICIO_VERSION           - pin a specific version (default: latest)
+#   SIMPLICIO_BIN_DIR           - custom install directory
+#   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
+#                                 published for this target (default: refuse)
+#   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
+#
+# Asset naming follows distribution/targets.json (the canonical target
+# triplet table for the whole ecosystem): id "macos-arm64" -> asset
+# "simplicio-macos-arm64", id "macos-x64" -> "simplicio-macos-x64", id
+# "linux-x64" -> "simplicio-linux-x64". Drift between this script, the
+# release workflow and simplicio-update-manifest.json is caught by
+# scripts/verify_distribution_consistency.py in CI.
+
 set -eu
 
-# Simplicio ecosystem installer for macOS and Linux.
-# The source of truth is GitHub releases from the component repositories.
-# Runtime assets are selected newest-first per OS/architecture. Component
-# wheels are selected newest-first and fall back to older releases when the
-# newest release has no published wheel.
-
 REPO="wesleysimplicio/simplicio"
-API_ROOT="https://api.github.com/repos"
-INSTALL_DIR="${SIMPLICIO_BIN_DIR:-$HOME/.local/bin}"
-STATE_DIR="${SIMPLICIO_STATE_DIR:-$HOME/.simplicio}"
-VENV_DIR="${SIMPLICIO_COMPONENT_VENV:-$STATE_DIR/components-venv}"
-MANIFEST="$STATE_DIR/components.json"
-TMP_DIR="${TMPDIR:-/tmp}/simplicio-install-$$"
+GITHUB="https://github.com/$REPO"
+BIN_NAME="simplicio"
 
-info() { printf '%s\n' "==> $*"; }
-ok() { printf '%s\n' "  ✓ $*"; }
-warn() { printf '%s\n' "  ! $*" >&2; }
-fail() { printf '%s\n' "  ✗ $*" >&2; exit 1; }
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
 
-cleanup() { rm -rf "$TMP_DIR"; }
-trap cleanup EXIT INT TERM
+info()  { printf "${CYAN}==>${NC} %s\n" "$*"; }
+ok()    { printf "${GREEN}  ✓${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}  ⚠${NC} %s\n" "$*"; }
+err()   { printf "${RED}  ✗${NC} %s\n" "$*"; exit 1; }
 
-sha256_file() {
+BIN_DIR="${SIMPLICIO_BIN_DIR:-$HOME/.local/bin}"
+DEST_PATH="$BIN_DIR/$BIN_NAME"
+
+# ─── Detect platform (canonical os/arch naming, matches distribution/targets.json) ──
+detect_platform() {
+  case "$(uname -m)" in
+    x86_64|amd64) ARCH="x64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) err "Arquitetura não suportada: $(uname -m)" ;;
+  esac
+
+  case "$(uname -s)" in
+    Darwin) OS="macos" ;;
+    Linux)  OS="linux" ;;
+    *) err "Sistema não suportado: $(uname -s)" ;;
+  esac
+}
+
+sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
   else
-    return 1
+    err "Precisa de sha256sum ou shasum para verificar a integridade do download"
   fi
 }
 
-verify_digest() {
-  path=$1
-  digest=$2
-  [ -n "$digest" ] || { warn "sem digest SHA-256 publicado para $(basename "$path"); instalação continua"; return 0; }
-  case "$digest" in
-    sha256:*) digest=${digest#sha256:} ;;
+verify_embedded_ecosystem() {
+  if "$DEST_PATH" ecosystem verify --json >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# ─── --doctor: idempotent, read-only health check ──────────────────────────
+run_doctor() {
+  info "simplicio doctor"
+  status=0
+
+  if [ -x "$DEST_PATH" ]; then
+    ok "binário presente: $DEST_PATH"
+  else
+    warn "binário ausente em $DEST_PATH"
+    status=1
+  fi
+
+  case ":$PATH:" in
+    *":$BIN_DIR:"*) ok "$BIN_DIR está no PATH" ;;
+    *) warn "$BIN_DIR não está no PATH (sessão atual)" ;;
   esac
-  actual=$(sha256_file "$path" 2>/dev/null || true)
-  [ -n "$actual" ] || { warn "não foi possível calcular SHA-256 para $(basename "$path"); instalação continua"; return 0; }
-  [ "$actual" = "$(printf '%s' "$digest" | tr '[:upper:]' '[:lower:]')" ] || fail "SHA-256 inválido para $(basename "$path")";
-  ok "SHA-256 verificado: $(basename "$path")"
-}
 
-download_asset() {
-  url=$1
-  destination=$2
-  digest=$3
-  staging="$destination.download-$$"
-  rm -f "$staging"
-  curl -fL --retry 3 --retry-delay 1 -sS "$url" -o "$staging" || fail "download falhou: $url"
-  [ -s "$staging" ] || fail "asset vazio: $url"
-  verify_digest "$staging" "$digest"
-  mv -f "$staging" "$destination"
-}
-
-fetch_releases() {
-  repo=$1
-  version=${2:-}
-  if [ -n "$version" ]; then
-    url="$API_ROOT/$repo/releases/tags/$version"
-  else
-    url="$API_ROOT/$repo/releases?per_page=100"
-  fi
-  curl -fL --retry 3 --retry-delay 1 -sS \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'User-Agent: simplicio-installer' \
-    "$url"
-}
-
-# Read a release JSON document from stdin and return:
-# release-tag|asset-name|download-url|sha256-digest
-select_asset() {
-  "$PYTHON" -c '
-import fnmatch
-import json
-import sys
-
-payload = json.load(sys.stdin)
-releases = [payload] if isinstance(payload, dict) else payload
-patterns = sys.argv[1:]
-
-for release in releases or []:
-    if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
-        continue
-    for asset in release.get("assets") or []:
-        name = asset.get("name", "")
-        if any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns):
-            url = asset.get("browser_download_url")
-            if url:
-                print("|".join([
-                    str(release.get("tag_name", "")),
-                    name,
-                    url,
-                    str(asset.get("digest") or ""),
-                ]))
-                raise SystemExit(0)
-raise SystemExit(1)
-' "$@"
-}
-
-uninstall() {
-  info "Removendo Simplicio Runtime e componentes gerenciados"
-  rm -f "$INSTALL_DIR/simplicio"
-  if [ -d "$VENV_DIR/bin" ]; then
-    for candidate in "$INSTALL_DIR"/simplicio-* "$INSTALL_DIR/sendsprint"; do
-      [ -L "$candidate" ] || continue
-      target=$(readlink "$candidate" 2>/dev/null || true)
-      case "$target" in
-        "$VENV_DIR/bin/"*) rm -f "$candidate" ;;
-      esac
-    done
-  fi
-  rm -rf "$VENV_DIR"
-  rm -f "$MANIFEST"
-  ok "componentes removidos; configurações fora da virtualenv foram preservadas"
-}
-
-doctor() {
-  ok_state=0
-  if [ -x "$INSTALL_DIR/simplicio" ]; then
-    "$INSTALL_DIR/simplicio" version >/dev/null 2>&1 && ok "Runtime executável" || { warn "Runtime não executa"; ok_state=1; }
-  else
-    warn "Runtime ausente: $INSTALL_DIR/simplicio"
-    ok_state=1
-  fi
-  for command_name in simplicio-mapper simplicio-dev-cli simplicio-fast simplicio-loop simplicio-subagents sendsprint; do
-    if [ -x "$INSTALL_DIR/$command_name" ]; then
-      ok "$command_name disponível"
+  if [ -x "$DEST_PATH" ]; then
+    if "$DEST_PATH" version >/dev/null 2>&1; then
+      ok "binário executa corretamente"
     else
-      warn "$command_name ausente"
-      ok_state=1
+      warn "binário presente mas falhou ao executar"
+      status=1
     fi
-  done
-  if [ -f "$MANIFEST" ]; then ok "manifesto: $MANIFEST"; else warn "manifesto ausente: $MANIFEST"; ok_state=1; fi
-  return "$ok_state"
+
+    if verify_embedded_ecosystem; then
+      ok "ecossistema nativo presente no binário"
+    else
+      warn "binário não contém o bundle nativo esperado; atualize para um release Runtime compatível"
+      status=1
+    fi
+  fi
+
+  if [ "$status" -eq 0 ]; then
+    ok "simplicio está saudável"
+  else
+    err "simplicio tem problemas — rode o instalador novamente"
+  fi
+  exit "$status"
 }
 
-action=${1:-install}
-case "$action" in
-  --uninstall|-u)
-    uninstall
-    exit 0
-    ;;
-  --doctor|-d)
-    doctor
-    exit $?
-    ;;
-  --help|-h)
-    printf '%s\n' 'Uso: sh install.sh [--doctor|--uninstall]' 'Variáveis: SIMPLICIO_VERSION, SIMPLICIO_BIN_DIR, SIMPLICIO_STATE_DIR, SIMPLICIO_COMPONENT_VENV'
-    exit 0
-    ;;
-  install)
-    ;;
-  *)
-    fail "argumento desconhecido: $action"
-    ;;
+# ─── --uninstall: idempotent removal, safe to run repeatedly ──────────────
+run_uninstall() {
+  info "simplicio uninstall"
+  if [ -e "$DEST_PATH" ]; then
+    rm -f "$DEST_PATH"
+    ok "removido $DEST_PATH"
+  else
+    ok "já estava removido (nada em $DEST_PATH)"
+  fi
+  # Dados do usuário são preservados intencionalmente (uninstall idempotente
+  # e não-destrutivo) — ~/.simplicio nunca é tocado aqui.
+  ok "dados do usuário em \$HOME/.simplicio foram preservados"
+  warn "se você adicionou $BIN_DIR ao PATH no seu ~/.zshrc ou ~/.bashrc, remova a linha manualmente"
+  exit 0
+}
+
+case "${1:-}" in
+  --doctor) detect_platform; run_doctor ;;
+  --uninstall) run_uninstall ;;
 esac
 
-if [ -n "${SIMPLICIO_PYTHON:-}" ]; then
-  PYTHON=$SIMPLICIO_PYTHON
-elif command -v python3 >/dev/null 2>&1; then
-  PYTHON=$(command -v python3)
-elif command -v python >/dev/null 2>&1; then
-  PYTHON=$(command -v python)
+printf "${GREEN}"
+cat << "EOF"
+  ╔══════════════════════════════════════╗
+  ║        Simplicio Agent v1.8.0       ║
+  ║    Seu assistente pessoal digital    ║
+  ╚══════════════════════════════════════╝
+EOF
+printf "${NC}"
+echo ""
+
+# ─── 1. Detect platform ──────────────────────────────────────────────────────
+detect_platform
+info "Plataforma detectada: $OS-$ARCH"
+
+# ─── 2. Instalar simplicio binary (staged download + SHA256 + atomic swap) ──
+info "Instalando Simplicio Runtime..."
+mkdir -p "$BIN_DIR"
+
+if [ -x "$DEST_PATH" ] && verify_embedded_ecosystem; then
+  ok "$BIN_NAME já instalado em $DEST_PATH"
 else
-  fail 'Python 3.11+ não encontrado'
+  if [ -x "$DEST_PATH" ]; then
+    warn "Runtime existente não contém o bundle nativo esperado; baixando uma versão compatível"
+  fi
+  VERSION="${SIMPLICIO_VERSION:-latest}"
+  ASSET="simplicio-$OS-$ARCH"
+  if [ "$VERSION" = "latest" ]; then
+    RELEASE_BASE="$GITHUB/releases/latest/download"
+  else
+    RELEASE_BASE="$GITHUB/releases/download/$VERSION"
+  fi
+  DOWNLOAD_URL="$RELEASE_BASE/$ASSET"
+  MANIFEST_URL="$RELEASE_BASE/simplicio-update-manifest.json"
+
+  fetch() {
+    # fetch <url> <dest-or-'-'>
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL "$1" -o "$2"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -q "$1" -O "$2"
+    else
+      err "Precisa de curl ou wget para baixar"
+    fi
+  }
+
+  TARGET_ID="$OS-$ARCH"
+  EXPECTED_SHA256=""
+  SIGNED="false"
+  MANIFEST_TMP="$(mktemp)"
+  trap 'rm -f "$MANIFEST_TMP"' EXIT
+  if fetch "$MANIFEST_URL" "$MANIFEST_TMP" 2>/dev/null; then
+    if command -v python3 >/dev/null 2>&1; then
+      EXPECTED_SHA256="$(python3 -c "
+import json,sys
+try:
+    m = json.load(open('$MANIFEST_TMP'))
+    for a in m.get('artifacts', []):
+        if a.get('target') == '$TARGET_ID':
+            print(a.get('sha256') or '')
+            print('true' if a.get('signed') else 'false')
+            break
+except Exception:
+    pass
+" 2>/dev/null | sed -n '1p')"
+      SIGNED="$(python3 -c "
+import json
+try:
+    m = json.load(open('$MANIFEST_TMP'))
+    for a in m.get('artifacts', []):
+        if a.get('target') == '$TARGET_ID':
+            print('true' if a.get('signed') else 'false')
+            break
+except Exception:
+    pass
+" 2>/dev/null)"
+    fi
+  fi
+
+  if [ -z "$EXPECTED_SHA256" ]; then
+    if [ "${SIMPLICIO_ALLOW_UNVERIFIED:-}" = "1" ]; then
+      warn "sem checksum publicado para o alvo '$TARGET_ID' — prosseguindo SEM VERIFICAÇÃO (SIMPLICIO_ALLOW_UNVERIFIED=1)"
+    else
+      err "recusando instalar: nenhum SHA256 publicado no manifest para o alvo '$TARGET_ID'. Defina SIMPLICIO_ALLOW_UNVERIFIED=1 para prosseguir por sua conta e risco."
+    fi
+  elif [ "$SIGNED" != "true" ]; then
+    warn "checksum será verificado, mas este artefato ainda não é assinado (ed25519 não configurado para $TARGET_ID — ver issue #5)"
+  fi
+
+  info "Baixando de $DOWNLOAD_URL ..."
+  STAGING_PATH="$DEST_PATH.download-$$.tmp"
+  fetch "$DOWNLOAD_URL" "$STAGING_PATH"
+
+  if [ ! -s "$STAGING_PATH" ]; then
+    rm -f "$STAGING_PATH"
+    err "download falhou ou arquivo vazio: $DOWNLOAD_URL"
+  fi
+
+  if [ -n "$EXPECTED_SHA256" ]; then
+    ACTUAL_SHA256="$(sha256_of "$STAGING_PATH")"
+    if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+      rm -f "$STAGING_PATH"
+      err "checksum não confere para $ASSET. esperado $EXPECTED_SHA256, obtido $ACTUAL_SHA256. Recusando instalar binário corrompido ou adulterado."
+    fi
+    ok "SHA256 verificado: $ACTUAL_SHA256"
+  fi
+
+  chmod +x "$STAGING_PATH"
+  # Swap atômico: mv no mesmo filesystem nunca deixa $DEST_PATH parcialmente
+  # escrito, e reexecutar este script (update idempotente) não deixa .tmp
+  # órfãos em caso de sucesso.
+  mv -f "$STAGING_PATH" "$DEST_PATH"
+  ok "Simplicio Runtime instalado em $DEST_PATH"
 fi
 
-"$PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
-  || fail 'Python 3.11 ou superior é necessário para todos os componentes'
-command -v curl >/dev/null 2>&1 || fail 'curl não encontrado'
+# ─── 2.1 Verificar o bundle nativo antes de anunciar sucesso ─────────────────
+if ! verify_embedded_ecosystem; then
+  err "este Runtime não contém o bundle nativo esperado; recusando concluir a instalação"
+fi
+ok "ecossistema nativo verificado no binário"
 
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
-case "$OS:$ARCH" in
-  linux:x86_64|linux:amd64)
-    RUNTIME_TARGET='linux-x64'
-    RUNTIME_PATTERNS='simplicio-linux-x64 simplicio-linux-x86_64'
-    ;;
-  linux:aarch64|linux:arm64)
-    RUNTIME_TARGET='linux-arm64'
-    RUNTIME_PATTERNS='simplicio-linux-arm64 simplicio-linux-aarch64'
-    ;;
-  darwin:arm64|darwin:aarch64)
-    RUNTIME_TARGET='macos-arm64'
-    RUNTIME_PATTERNS='simplicio-macos-arm64 simplicio-darwin-arm64'
-    ;;
-  darwin:x86_64|darwin:amd64)
-    RUNTIME_TARGET='macos-x64'
-    RUNTIME_PATTERNS='simplicio-macos-x64 simplicio-darwin-x64'
-    ;;
-  *)
-    fail "plataforma não suportada: $OS/$ARCH"
-    ;;
+# Adiciona ao PATH se não estiver
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) export PATH="$BIN_DIR:$PATH"
+     warn "Adicione export PATH=\"\$HOME/.local/bin:\$PATH\" ao seu ~/.zshrc ou ~/.bashrc"
+     ;;
 esac
 
-mkdir -p "$INSTALL_DIR" "$STATE_DIR" "$TMP_DIR"
+# ─── 3. Registrar e anunciar o bundle nativo ─────────────────────────────────
+BUNDLE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
+BUNDLE_REPORT="$BUNDLE_DIR/ecosystem-bundle.json"
+mkdir -p "$BUNDLE_DIR"
+if "$DEST_PATH" ecosystem verify --json >"$BUNDLE_REPORT" 2>/dev/null; then
+  ok "bundle nativo registrado em $BUNDLE_REPORT"
+else
+  rm -f "$BUNDLE_REPORT"
+  err "o binário não passou na verificação do bundle nativo; instalação interrompida"
+fi
 
-info "Procurando o binário Runtime mais recente para $RUNTIME_TARGET"
-runtime_json=$(fetch_releases "$REPO" "${SIMPLICIO_VERSION:-}") || fail 'não foi possível consultar as releases do Runtime'
-set -- $RUNTIME_PATTERNS
-runtime_selection=$(printf '%s' "$runtime_json" | select_asset "$@" 2>/dev/null) \
-  || fail "nenhum asset Runtime encontrado para $RUNTIME_TARGET nas releases disponíveis"
-IFS='|' read -r runtime_release runtime_asset runtime_url runtime_digest <<EOF
-$runtime_selection
-EOF
-runtime_download="$TMP_DIR/$runtime_asset"
-download_asset "$runtime_url" "$runtime_download" "$runtime_digest"
-chmod +x "$runtime_download"
-mv -f "$runtime_download" "$INSTALL_DIR/simplicio"
-ok "Runtime $runtime_release instalado: $INSTALL_DIR/simplicio"
-
-# Prompt is installed before Dev CLI because Dev CLI declares it as a runtime
-# dependency. All six component packages still come from their GitHub release
-# wheels, not from a source checkout.
-COMPONENTS='simplicio-mapper|wesleysimplicio/simplicio-mapper|simplicio_mapper-*.whl
-simplicio-prompt|wesleysimplicio/simplicio-prompt|simplicio_prompt-*.whl
-simplicio-dev-cli|wesleysimplicio/simplicio-dev-cli|simplicio_cli-*.whl
-simplicio-fast|wesleysimplicio/simplicio-fast|simplicio_fast-*.whl
-simplicio-loop|wesleysimplicio/simplicio-loop|simplicio_loop-*.whl
-simplicio-sprint|wesleysimplicio/simplicio-sprint|simplicio_sprint-*.whl'
-
-mkdir -p "$(dirname "$VENV_DIR")"
-"$PYTHON" -m venv "$VENV_DIR" || fail "não foi possível criar a virtualenv: $VENV_DIR"
-VENV_PYTHON="$VENV_DIR/bin/python"
-[ -x "$VENV_PYTHON" ] || fail "Python da virtualenv não encontrado: $VENV_PYTHON"
-"$VENV_PYTHON" -m pip install --disable-pip-version-check --upgrade pip >/dev/null \
-  || fail 'não foi possível preparar o pip da virtualenv'
-
-COMPONENT_RECORDS=''
-while IFS='|' read -r component component_repo wheel_pattern; do
-  [ -n "$component" ] || continue
-  info "Procurando wheel de $component"
-  component_json=$(fetch_releases "$component_repo" '') \
-    || fail "não foi possível consultar as releases de $component_repo"
-  component_selection=$(printf '%s' "$component_json" | select_asset "$wheel_pattern" 2>/dev/null) \
-    || fail "nenhuma wheel encontrada para $component em $component_repo"
-  IFS='|' read -r component_release component_asset component_url component_digest <<EOF
-$component_selection
-EOF
-  wheel_path="$TMP_DIR/$component_asset"
-  download_asset "$component_url" "$wheel_path" "$component_digest"
-  "$VENV_PYTHON" -m pip install --disable-pip-version-check --upgrade --force-reinstall "$wheel_path" \
-    || fail "falha ao instalar $component ($component_release)"
-  COMPONENT_RECORDS="${COMPONENT_RECORDS}${component}|${component_release}|${component_asset}
-"
-  ok "$component $component_release instalado"
-done <<EOF
-$COMPONENTS
-EOF
-
-# Expose every console script generated by the six installed wheels through
-# the same bin directory as the native Runtime. Symlinks keep updates atomic
-# and do not duplicate the Python entry-point files.
-for executable in "$VENV_DIR/bin"/simplicio-* "$VENV_DIR/bin"/sendsprint; do
-  [ -e "$executable" ] || continue
-  name=$(basename "$executable")
-  ln -sfn "$executable" "$INSTALL_DIR/$name"
-done
-
-export MANIFEST RUNTIME_TARGET runtime_release runtime_asset VENV_DIR INSTALL_DIR COMPONENT_RECORDS
-"$PYTHON" - "$MANIFEST" <<'PY'
-import json
-import os
-import pathlib
-import sys
-
-manifest = pathlib.Path(sys.argv[1])
-records = []
-for line in os.environ.get("COMPONENT_RECORDS", "").splitlines():
-    if line:
-        name, release, asset = line.split("|", 2)
-        records.append({"name": name, "release": release, "asset": asset})
-
-venv = pathlib.Path(os.environ["VENV_DIR"]).resolve()
-bin_dir = pathlib.Path(os.environ["INSTALL_DIR"])
-managed = [str(bin_dir / "simplicio")]
-for candidate in list(bin_dir.glob("simplicio-*")) + [bin_dir / "sendsprint"]:
-    if not candidate.is_symlink():
-        continue
-    try:
-        target = candidate.resolve()
-    except OSError:
-        continue
-    if str(target).startswith(str(venv) + os.sep):
-        managed.append(str(candidate))
-
-payload = {
-    "schema": "simplicio.ecosystem-manifest/v2",
-    "source": "github-releases",
-    "runtime": {
-        "repository": "wesleysimplicio/simplicio",
-        "target": os.environ["RUNTIME_TARGET"],
-        "release": os.environ["runtime_release"],
-        "asset": os.environ["runtime_asset"],
-        "path": str(bin_dir / "simplicio"),
-    },
-    "components": records,
-    "python_venv": str(venv),
-    "managed_paths": sorted(set(managed)),
-}
-manifest.parent.mkdir(parents=True, exist_ok=True)
-manifest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
-
-ok "manifesto gravado: $MANIFEST"
-printf '%s\n' '' 'Instalação concluída.' "MCP: simplicio serve --mcp --stdio" "PATH: adicione $INSTALL_DIR ao PATH se necessário."
+# ─── 4. Mensagem final ───────────────────────────────────────────────────────
+echo ""
+printf "${GREEN}╔══════════════════════════════════════════════════════════╗${NC}\n"
+printf "${GREEN}║                                                          ║${NC}\n"
+printf "${GREEN}║   Simplicio Runtime instalado com sucesso!              ║${NC}\n"
+printf "${GREEN}║                                                          ║${NC}\n"
+printf "${GREEN}║   ✓ Ecossistema nativo dentro do binário                 ║${NC}\n"
+printf "${GREEN}║   ✓ Sem pip, clones ou adaptadores externos               ║${NC}\n"
+printf "${GREEN}║   🩺 Doctor: sh install.sh --doctor                     ║${NC}\n"
+printf "${GREEN}║                                                          ║${NC}\n"
+printf "${GREEN}╚══════════════════════════════════════════════════════════╝${NC}\n"
+echo ""
+ok "Instalação Runtime concluída."

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
-# install.sh — Simplicio Runtime: instalador do binário e ecossistema nativo
+# install.sh — Simplicio Runtime: instalador do binário e fontes Python embutidos
 #
 # Um comando instala o Runtime. Mapper, Dev CLI, Loop, Fast, Prompt e Sprint
-# projection são entregues pelo próprio binário.
+# são entregues como fontes Python reais dentro do binário; não são reescritos
+# como Rust e não exigem checkout ou download dos repositórios irmãos.
 #
 #   curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
 #
@@ -76,6 +77,19 @@ verify_embedded_ecosystem() {
   return 1
 }
 
+verify_active_login() {
+  "$DEST_PATH" auth status --json >/dev/null 2>&1
+}
+
+require_active_login() {
+  if verify_active_login; then
+    return 0
+  fi
+  info "Login Google obrigatório para ativar o Simplicio Runtime"
+  "$DEST_PATH" auth login || err "login não concluído; instalação bloqueada"
+  verify_active_login || err "sessão ausente, expirada, revogada ou sem entitlement ativo; instalação bloqueada"
+}
+
 # ─── --doctor: idempotent, read-only health check ──────────────────────────
 run_doctor() {
   info "simplicio doctor"
@@ -102,9 +116,16 @@ run_doctor() {
     fi
 
     if verify_embedded_ecosystem; then
-      ok "ecossistema nativo presente no binário"
+      ok "fontes Python do ecossistema presentes no binário"
     else
-      warn "binário não contém o bundle nativo esperado; atualize para um release Runtime compatível"
+      warn "binário não contém o bundle de fontes Python esperado; atualize para um release Runtime compatível"
+      status=1
+    fi
+
+    if verify_active_login; then
+      ok "sessão Google ativa e entitlement válido"
+    else
+      warn "sessão Google ausente, expirada, revogada ou sem entitlement ativo"
       status=1
     fi
   fi
@@ -160,7 +181,7 @@ if [ -x "$DEST_PATH" ] && verify_embedded_ecosystem; then
   ok "$BIN_NAME já instalado em $DEST_PATH"
 else
   if [ -x "$DEST_PATH" ]; then
-    warn "Runtime existente não contém o bundle nativo esperado; baixando uma versão compatível"
+    warn "Runtime existente não contém o bundle Python esperado; baixando uma versão compatível"
   fi
   VERSION="${SIMPLICIO_VERSION:-latest}"
   ASSET="simplicio-$OS-$ARCH"
@@ -252,11 +273,15 @@ except Exception:
   ok "Simplicio Runtime instalado em $DEST_PATH"
 fi
 
-# ─── 2.1 Verificar o bundle nativo antes de anunciar sucesso ─────────────────
+# ─── 2.1 Verificar o bundle Python antes de anunciar sucesso ─────────────────
 if ! verify_embedded_ecosystem; then
-  err "este Runtime não contém o bundle nativo esperado; recusando concluir a instalação"
+  err "este Runtime não contém o bundle de fontes Python esperado; recusando concluir a instalação"
 fi
-ok "ecossistema nativo verificado no binário"
+ok "fontes Python reais do ecossistema verificadas no binário"
+
+# ─── 2.2 Login obrigatório: beta não elimina a sessão ativa ────────────────
+require_active_login
+ok "login Google ativo e entitlement válido"
 
 # Adiciona ao PATH se não estiver
 case ":$PATH:" in
@@ -266,15 +291,15 @@ case ":$PATH:" in
      ;;
 esac
 
-# ─── 3. Registrar e anunciar o bundle nativo ─────────────────────────────────
+# ─── 3. Registrar e anunciar o bundle Python ────────────────────────────────
 BUNDLE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
 BUNDLE_REPORT="$BUNDLE_DIR/ecosystem-bundle.json"
 mkdir -p "$BUNDLE_DIR"
 if "$DEST_PATH" ecosystem verify --json >"$BUNDLE_REPORT" 2>/dev/null; then
-  ok "bundle nativo registrado em $BUNDLE_REPORT"
+  ok "bundle Python registrado em $BUNDLE_REPORT"
 else
   rm -f "$BUNDLE_REPORT"
-  err "o binário não passou na verificação do bundle nativo; instalação interrompida"
+  err "o binário não passou na verificação do bundle Python; instalação interrompida"
 fi
 
 # ─── 4. Mensagem final ───────────────────────────────────────────────────────
@@ -283,8 +308,9 @@ printf "${GREEN}╔════════════════════�
 printf "${GREEN}║                                                          ║${NC}\n"
 printf "${GREEN}║   Simplicio Runtime instalado com sucesso!              ║${NC}\n"
 printf "${GREEN}║                                                          ║${NC}\n"
-printf "${GREEN}║   ✓ Ecossistema nativo dentro do binário                 ║${NC}\n"
-printf "${GREEN}║   ✓ Sem pip, clones ou adaptadores externos               ║${NC}\n"
+printf "${GREEN}║   ✓ Fontes Python reais dentro do binário                ║${NC}\n"
+printf "${GREEN}║   ✓ Sem pip, clones ou downloads de simplicio-*          ║${NC}\n"
+printf "${GREEN}║   ✓ Login Google ativo                                   ║${NC}\n"
 printf "${GREEN}║   🩺 Doctor: sh install.sh --doctor                     ║${NC}\n"
 printf "${GREEN}║                                                          ║${NC}\n"
 printf "${GREEN}╚══════════════════════════════════════════════════════════╝${NC}\n"


### PR DESCRIPTION
## Summary

This public PR contains only the public installer and distribution surface.

- Verifies the downloaded Runtime and its embedded Python source bundle.
- Does not install sibling repositories or Python packages in the normal path.
- Requires the Runtime's Google-backed login and active entitlement before installation completes.
- Keeps checksum, target-selection, doctor, and data-preserving uninstall behavior.

Runtime implementation details and release evidence are maintained in the private Runtime repository and are not part of this public planning surface.

## Verification

- `sh -n install.sh`: passed.
- `python3 -m pytest -q tests/test_distribution_consistency.py tests/unit/test_verify_distribution_consistency.py`: 37 passed, 18 subtests passed.
- PowerShell parser: not run; `pwsh` is unavailable on this macOS host.

## Release residual

The current public manifest is legacy and incomplete for the target matrix. Merge remains blocked until a compatible Runtime release is built, verified, and published for every supported target.