### PR TITLE
docs(install): register Codex OAuth MCP after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Python package manager or sibling checkout. A Google login with an active
 entitlement is mandatory before product commands run; public beta access may
 be free, but it does not bypass login.
 
+### Codex MCP authentication
+
+After login, the installer registers Simplicio as a local Streamable HTTP MCP
+server at `http://127.0.0.1:8787/mcp`. Open Codex MCP settings: the Simplicio
+row will show **Authenticate**. Click it to use the Google-backed login at
+`simpleti.com.br/simplicio/login`. The Runtime validates the bearer token and
+active entitlement on each MCP request; beta access does not bypass this gate.
+
+Other MCP hosts keep the local `stdio` fallback. If the host was configured
+before this release, run `simplicio mcp register` and reload its MCP settings.
+
 ### Python projects embedded in the Runtime
 
 The Runtime release is the distribution boundary. The generated binary carries

--- a/install.ps1
+++ b/install.ps1
@@ -271,6 +271,16 @@ try {
 }
 Write-Host "  ✓ active Google session and entitlement verified"
 
+# Codex only renders its Authenticate action for an OAuth-capable HTTP server.
+# Other hosts retain their stdio fallback inside `simplicio mcp register`.
+try {
+  & $DestPath mcp register | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "mcp register returned $LASTEXITCODE" }
+  Write-Host "  ✓ local HTTP/OAuth MCP registered for Codex"
+} catch {
+  Write-Warning "could not register MCP automatically; run: simplicio mcp register"
+}
+
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
 New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null
 $BundleReport = Join-Path $BundleDir "ecosystem-bundle.json"

--- a/install.sh
+++ b/install.sh
@@ -283,6 +283,14 @@ ok "fontes Python reais do ecossistema verificadas no binário"
 require_active_login
 ok "login Google ativo e entitlement válido"
 
+# Codex only renders its Authenticate action for an OAuth-capable HTTP server.
+# Other hosts retain their stdio fallback inside `simplicio mcp register`.
+if "$DEST_PATH" mcp register >/dev/null 2>&1; then
+  ok "MCP local HTTP/OAuth registrado para o Codex"
+else
+  warn "não foi possível registrar o MCP automaticamente; rode: simplicio mcp register"
+fi
+
 # Adiciona ao PATH se não estiver
 case ":$PATH:" in
   *":$BIN_DIR:"*) ;;


### PR DESCRIPTION
## O que muda

- Documenta que o Runtime embute as fontes Python e exige login Google com entitlement ativo.
- Explica que o Codex deve receber um MCP Streamable HTTP e exibir Authenticate.
- Faz os instaladores sh/PowerShell registrar `simplicio mcp register` depois de validar login.
- Mantém o fallback stdio para os demais hosts e não baixa repositórios `simplicio-*`.

Validação: `sh -n install.sh` e `git diff --check`. A branch parte do `master` atual e contém somente estes 3 arquivos.