### PR TITLE
fix(public): accept Ed25519 manifest signature field

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -228,7 +228,7 @@ if ($Manifest) {
   $artifact = $Manifest.artifacts | Where-Object { $_.target -eq $Target } | Select-Object -First 1
   if ($artifact) {
     $ExpectedSha256 = $artifact.sha256
-    $ExpectedSigned = [bool]$artifact.signed
+    $ExpectedSigned = [bool]$artifact.signed -or ([string]$artifact.signature).StartsWith("ed25519:")
     $ExpectedSignature = $artifact.signature
   }
   $SignatureRequired = [bool]$Manifest.security.signature_required

--- a/install.sh
+++ b/install.sh
@@ -305,7 +305,7 @@ try:
     for a in m.get('artifacts', []):
         if a.get('target') == '$TARGET_ID':
             print(a.get('sha256') or '')
-            print('true' if a.get('signed') else 'false')
+            print('true' if a.get('signed') or str(a.get('signature') or '').startswith('ed25519:') else 'false')
             break
 except Exception:
     pass
@@ -316,7 +316,7 @@ try:
     m = json.load(open('$MANIFEST_TMP'))
     for a in m.get('artifacts', []):
         if a.get('target') == '$TARGET_ID':
-            print('true' if a.get('signed') else 'false')
+            print('true' if a.get('signed') or str(a.get('signature') or '').startswith('ed25519:') else 'false')
             break
 except Exception:
     pass

--- a/tests/test_auth_install_contract.py
+++ b/tests/test_auth_install_contract.py
@@ -24,6 +24,11 @@ def installer_active(payload):
     )
 
 
+def manifest_signature_present(payload):
+    artifact = next(item for item in payload["artifacts"] if item["target"] == "windows-x64")
+    return bool(artifact.get("signed")) or str(artifact.get("signature") or "").startswith("ed25519:")
+
+
 def test_legacy_identity_shape_is_accepted_after_successful_login():
     payload = {
         "active": True,
@@ -53,3 +58,20 @@ def test_both_published_installers_include_legacy_email_fallback():
     shell = (ROOT / "install.sh").read_text(encoding="utf-8")
     assert "$status.user.email" in powershell
     assert "payload.get(\"user\")" in shell
+
+
+def test_manifest_signature_field_is_accepted_without_signed_boolean():
+    payload = {
+        "artifacts": [{
+            "target": "windows-x64",
+            "signature": "ed25519:valid-signature",
+        }]
+    }
+    assert manifest_signature_present(payload)
+
+
+def test_installers_use_ed25519_signature_when_signed_boolean_is_absent():
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    assert 'StartsWith("ed25519:")' in powershell
+    assert "startswith('ed25519:')" in shell


### PR DESCRIPTION
## Fix
The v3.8.15 manifest publishes the Ed25519 value in  but does not include the optional boolean . The installers previously treated that as unsigned and blocked Windows installation.

Use the Ed25519 signature prefix as the signed predicate while preserving fail-closed behavior when it is absent.

## Verification
- 27 pytest tests passed
- 12 Node installer tests passed
-  passed
- distribution audit: 8 OK, 0 warnings/errors
- remote v3.8.15 Windows asset and signature independently verified