### PR TITLE
feat(install): configure Codex Simplicio MCP hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Public installers now configure Codex to launch the installed Simplicio
+  binary over local STDIO and merge Simplicio lifecycle/PreToolUse hooks into
+  `~/.codex/hooks.json` without replacing unrelated user configuration.
+- Added cross-platform Codex routing hooks for macOS/Linux and Windows, with a
+  documented `SIMPLICIO_MCP_ROUTE=0` escape hatch and first-write backups.
+
 ## [3.8.11] - 2026-08-14
 
 ### Changed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,17 +211,18 @@ simplicio login google
 simplicio auth status --json
 ```
 
-Depois do login, registre o MCP local para o Codex e recarregue as configurações
-de MCP:
+Depois do login, o instalador configura o Codex para executar diretamente o
+binário local por STDIO e instala os hooks Simplicio em `~/.codex/hooks.json`.
+Reinicie o Codex, abra Settings → Hooks para revisar os hooks e confirme:
 
 ```bash
-simplicio mcp register
+codex mcp list
 ```
 
-No Codex, abra Settings → MCP e use Authenticate quando o servidor
-`simplicio` exibir esse botão. Para clientes STDIO, use
-`simplicio serve --mcp --stdio`; nunca copie tokens manualmente para arquivos
-de configuração.
+O registro deve apontar para `simplicio serve --mcp --stdio`. O Runtime ainda
+exige login Google e entitlement ativo; nunca copie tokens manualmente para
+arquivos. Para desativar temporariamente o roteamento do hook, use
+`SIMPLICIO_MCP_ROUTE=0`.
 
 ## Building from Source
 

--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -13,29 +13,31 @@ simplicio auth status --json
 
 Continue only when the status reports `active: true`. Never copy a password, device code, bearer token, refresh token, or client secret into an MCP config.
 
-## Codex: local HTTP/OAuth
+## Codex: local STDIO MCP and hooks
 
-The official installer registers an OAuth-capable local Streamable HTTP server:
+The official installer configures Codex to launch the installed binary directly:
 
-```text
-http://127.0.0.1:8787/mcp
+```toml
+[mcp_servers.simplicio]
+command = "/path/to/simplicio"
+args = ["serve", "--mcp", "--stdio"]
 ```
 
-In Codex:
+The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
+`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`, preserving
+unrelated user hooks. Restart Codex and review the result in **Settings →
+Hooks**. The Runtime still validates Google login and entitlement on every
+local MCP session; never paste tokens into either config file.
 
-1. Open **Settings → MCP**.
-2. Find **simplicio**.
-3. Click **Authenticate**.
-4. Complete the Google-backed browser login.
-5. Reload MCP settings if the server was already cached.
-
-If the server is missing, run:
+To verify the registration:
 
 ```bash
-simplicio mcp register
+codex mcp list
 ```
 
-The Runtime validates the active bearer session on each request. The **Authenticate** button is expected; do not replace it with a pasted token.
+Set `SIMPLICIO_MCP_ROUTE=0` for a temporary hook escape hatch. Rerunning the
+installer repairs the integration idempotently and leaves `.simplicio.bak`
+copies of the original Codex files.
 
 ## Other clients: local STDIO
 
@@ -92,7 +94,9 @@ A successful response contains the tool definitions. A `login required` error me
 
 ## Automatic setup
 
-The official installers perform the binary checksum and embedded-bundle checks, require active login, and attempt MCP registration:
+The official installers perform the binary checksum and embedded-bundle checks,
+require active login, and configure Codex's local STDIO MCP plus Simplicio
+hooks:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -211,28 +211,32 @@ The Runtime exposes these tools:
 The client should call `tools/list` at startup and use the returned schemas;
 the table above is a quick orientation, not a substitute for live schemas.
 
-### Codex: local HTTP/OAuth MCP
+### Codex: local STDIO MCP and hooks
 
-The installer runs `simplicio mcp register`, which registers the local
-Streamable HTTP endpoint used by Codex:
-`http://127.0.0.1:8787/mcp`.
+The installer configures Codex to launch the installed binary directly:
 
-1. Complete `simplicio login google` first.
-2. Open Codex **Settings → MCP**.
-3. Find the **simplicio** server and click **Authenticate**.
-4. Complete the Google-backed Simplicio login in the browser.
-5. Reload the MCP settings or restart the host if the tool list was already
-   cached.
-
-If the row is missing, register it again and reload Codex:
-
-```bash
-simplicio mcp register
+```toml
+[mcp_servers.simplicio]
+command = "/path/to/simplicio"
+args = ["serve", "--mcp", "--stdio"]
 ```
 
-The Runtime validates the bearer token and active entitlement on every MCP
-request. A visible **Authenticate** button is therefore expected for the
-OAuth-capable Codex server; it is not a replacement for the CLI login.
+This keeps MCP execution local and avoids the latency of the local HTTP daemon.
+The Runtime still enforces Google login and entitlement for every MCP session.
+The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
+`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`; existing
+Codex hooks are preserved and the Simplicio entries are updated idempotently.
+
+After installation, restart Codex and open **Settings → Hooks** to review or
+approve the installed hooks. Verify the MCP command with:
+
+```bash
+codex mcp list
+```
+
+To repair only this integration, rerun the installer. The original
+`config.toml` and `hooks.json` are kept in `.simplicio.bak` files on the first
+managed write. Set `SIMPLICIO_MCP_ROUTE=0` for a temporary hook escape hatch.
 
 ### Other MCP clients: local STDIO
 
@@ -502,7 +506,7 @@ simplicio --version
 simplicio version --json
 simplicio ecosystem doctor --json
 simplicio auth status --json
-simplicio mcp register
+codex mcp list
 ```
 
 Common failures:
@@ -510,7 +514,7 @@ Common failures:
 | Symptom | Resolution |
 |---|---|
 | `login required` | Run `simplicio login google`; confirm `active: true`. |
-| Codex has no **Authenticate** button | Run `simplicio mcp register`, then reload Codex MCP settings. |
+| Codex does not show Simplicio tools | Restart Codex, inspect **Settings → Hooks**, and verify `codex mcp list` points to `serve --mcp --stdio`. |
 | `tools/list` is empty or stale | Restart/reload the MCP host and verify its command resolves to the intended `simplicio` binary. |
 | Runtime release contract fails | Wait for a release with embedded sources, enabled Google login, and a configured public update key; do not bypass the gate. |
 | Google says the browser is not secure | Use a normal Safari/Chrome window for the Google step, not an embedded webview; never disable the account security gate. |

--- a/codex/mcp-route.ps1
+++ b/codex/mcp-route.ps1
@@ -1,0 +1,82 @@
+# Simplicio MCP route hook for Codex on Windows.
+$ErrorActionPreference = "SilentlyContinue"
+
+function Allow-Hook {
+  Write-Output '{"decision":"allow"}'
+  exit 0
+}
+
+function Deny-Hook([string]$Reason) {
+  $payload = @{ decision = "deny"; reason = $Reason } | ConvertTo-Json -Compress
+  Write-Output $payload
+  [Console]::Error.WriteLine($Reason)
+  exit 2
+}
+
+if ($env:SIMPLICIO_MCP_ROUTE -eq "0" -or $env:SIMPLICIO_MCP_ROUTE -eq "off") {
+  Allow-Hook
+}
+
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrWhiteSpace($raw)) { Allow-Hook }
+try { $hook = $raw | ConvertFrom-Json } catch { Allow-Hook }
+
+$event = [string]($hook.hookEventName)
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.hook_event_name }
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.event }
+$eventKey = $event.Replace("-", "_").ToLowerInvariant()
+
+$context = "Use Simplicio MCP for this hop. Orient: simplicio_orient (or map --task). Create: simplicio_edit. Read one file: simplicio_file_read. Do not run simplicio --help / edit --help / runtime map / search_tool for simplicio. Do not read SKILL.md / simplicio-orient / simplicio-runtime/src. Escape: SIMPLICIO_MCP_ROUTE=0 or # simplicio:allow."
+$contextEvents = @{
+  "sessionstart" = "SessionStart"; "session_start" = "SessionStart"
+  "userpromptsubmit" = "UserPromptSubmit"; "user_prompt_submit" = "UserPromptSubmit"
+  "subagentstart" = "SubagentStart"; "subagent_start" = "SubagentStart"
+}
+if ($contextEvents.ContainsKey($eventKey)) {
+  @{ hookSpecificOutput = @{ hookEventName = $contextEvents[$eventKey]; additionalContext = $context } } | ConvertTo-Json -Compress
+  exit 0
+}
+
+$tool = [string]$hook.toolName
+if ([string]::IsNullOrWhiteSpace($tool)) { $tool = [string]$hook.tool_name }
+if ($tool.ToLowerInvariant().Contains("simplicio")) { Allow-Hook }
+$toolInput = $hook.toolInput
+if ($null -eq $toolInput) { $toolInput = $hook.tool_input }
+$command = [string]$toolInput.command
+$path = [string]$toolInput.target_file
+if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.file_path }
+if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.path }
+if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.file }
+$blob = "$command $path"
+if ($blob.Contains("simplicio:allow") -or $blob.Contains("SIMPLICIO_MCP_ROUTE=0")) { Allow-Hook }
+
+$pathNorm = $path.Replace("\", "/")
+if ($pathNorm.EndsWith("/simplicio/SKILL.md") -or $path -match "AGENTS\.md|CLAUDE\.md|USER\.md|mcp-route\.ps1|[\\/]\.grok[\\/]docs[\\/]|[\\/]\.claude[\\/]hooks[\\/]|[\\/]\.simplicio[\\/]hooks[\\/]") { Allow-Hook }
+
+$lower = $tool.ToLowerInvariant()
+$base = ($lower -split "__|/")[-1] -replace "[^a-z0-9_]", ""
+if ($base -in @("list_dir", "listdir", "readdirectory")) { Allow-Hook }
+if ($base -in @("read", "grep", "glob", "readdirectory", "filesearch", "read_file", "readfile") -or $lower.EndsWith("_read") -or $lower.Contains("read_file")) {
+  Deny-Hook ("Use simplicio_file_read / simplicio_read / simplicio_search / simplicio_orient. " + $context)
+}
+
+if ($base -in @("write") -or $lower.EndsWith("_write")) {
+  $destination = $path
+  if (-not [System.IO.Path]::IsPathRooted($destination) -and $hook.cwd) { $destination = Join-Path ([string]$hook.cwd) $destination }
+  if ($destination -and -not (Test-Path -LiteralPath $destination)) { Allow-Hook }
+}
+if ($base -in @("search_replace", "searchreplace", "strreplace") -or $lower.Contains("search_replace")) { Allow-Hook }
+if ($base -in @("edit", "write", "multiedit", "strreplace", "search_replace", "searchreplace", "applypatch", "apply_patch") -or $lower.EndsWith("_write")) {
+  Deny-Hook ("Use simplicio_edit for mutations. " + $context)
+}
+
+if ($base -in @("bash", "run_terminal_command", "shell", "run")) {
+  if ($command -match "(^|[;&|`n])\s*\S*simplicio(\s+--help|\s+-h|\s+serve\s+--help|\s+\S+\s+--help)\b") { Deny-Hook ("Do not dump simplicio --help. " + $context) }
+  if ($command -match "(^|[;&|`n])\s*(?:\S*[\\/])?simplicio(?![\w./-])\s*([;&`n]|$)") { Deny-Hook ("Do not run bare simplicio. " + $context) }
+  if ($command -match "simplicio-runtime[\\/](src|schemas|crates)|edit-plan\.schema|operations\.rs") { Deny-Hook ("Do not search Simplicio source to learn edit. " + $context) }
+  $lead = (($command.Trim() -split "\s+") | Where-Object { $_ -notmatch "^[A-Za-z_][A-Za-z0-9_]*=" } | Select-Object -First 1)
+  if ($lead -in @("cat", "head", "tail", "less", "more", "bat", "nl", "rg", "grep", "ag", "find")) { Deny-Hook ("Use simplicio_file_read / simplicio_search instead of " + $lead + ". " + $context) }
+  if ($lead -in @("sed", "awk", "perl")) { Deny-Hook ("Use simplicio_edit instead of " + $lead + ". " + $context) }
+}
+
+Allow-Hook

--- a/codex/mcp-route.sh
+++ b/codex/mcp-route.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Simplicio MCP route hook for Codex.
+# It nudges host reads/edits toward the local Simplicio MCP tools while keeping
+# an explicit escape hatch for operations that must stay host-native.
+set -uo pipefail
+
+if [ "${SIMPLICIO_MCP_ROUTE:-on}" = "0" ] || [ "${SIMPLICIO_MCP_ROUTE:-on}" = "off" ]; then
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+fi
+
+INPUT="$(cat 2>/dev/null || true)"
+[ -n "$INPUT" ] || { printf '%s\n' '{"decision":"allow"}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+fi
+
+export SIMPLICIO_MCP_ROUTE_INPUT="$INPUT"
+python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+raw = os.environ.get("SIMPLICIO_MCP_ROUTE_INPUT", "")
+try:
+    hook = json.loads(raw)
+except Exception:
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+event = (
+    hook.get("hookEventName")
+    or hook.get("hook_event_name")
+    or hook.get("event")
+    or ""
+).replace("-", "_").lower()
+tool = hook.get("toolName") or hook.get("tool_name") or ""
+tool_input = hook.get("toolInput") or hook.get("tool_input") or {}
+if not isinstance(tool_input, dict):
+    tool_input = {}
+
+create_plan = (
+    '{"file":"<relative-path>","operations":[{"op":"create",'
+    '"content":"<file body>"}]}'
+)
+context = (
+    "Use Simplicio MCP for this hop. "
+    "Orient: simplicio_orient (or map --task). "
+    "Create: simplicio_edit plan=" + create_plan + ". "
+    "Read one file: simplicio_file_read. "
+    "Do not run simplicio --help / edit --help / runtime map / search_tool for simplicio. "
+    "Do not read SKILL.md / simplicio-orient / simplicio-runtime/src. "
+    "Second pass on a file you just wrote: search_replace the tokens; do not re-read. "
+    "Escape: SIMPLICIO_MCP_ROUTE=0 or # simplicio:allow."
+)
+
+context_events = {
+    "sessionstart": "SessionStart",
+    "session_start": "SessionStart",
+    "userpromptsubmit": "UserPromptSubmit",
+    "user_prompt_submit": "UserPromptSubmit",
+    "subagentstart": "SubagentStart",
+    "subagent_start": "SubagentStart",
+}
+if event in context_events:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": context_events[event],
+            "additionalContext": context,
+        }
+    }))
+    raise SystemExit(0)
+
+lower = str(tool).lower()
+if "simplicio" in lower:
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+command = str(tool_input.get("command") or "")
+path = str(
+    tool_input.get("target_file")
+    or tool_input.get("file_path")
+    or tool_input.get("path")
+    or tool_input.get("file")
+    or ""
+)
+blob = f"{command} {path}"
+if "simplicio:allow" in blob or "SIMPLICIO_MCP_ROUTE=0" in blob:
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+bootstrap = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "USER.md",
+    "mcp-route.sh",
+    "/.grok/docs/",
+    "/.claude/hooks/",
+    "/.simplicio/hooks/",
+)
+path_norm = path.replace("\\", "/")
+if path_norm.endswith("/simplicio/SKILL.md") or any(token in path for token in bootstrap):
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+
+def deny(reason: str) -> None:
+    print(json.dumps({"decision": "deny", "reason": reason}))
+    sys.stderr.write(reason + "\n")
+    raise SystemExit(2)
+
+
+reads = {
+    "read", "grep", "glob", "readdirectory", "filesearch", "read_file",
+    "readfile", "list_dir", "listdir",
+}
+edits = {
+    "edit", "write", "multiedit", "strreplace", "search_replace",
+    "searchreplace", "applypatch", "apply_patch",
+}
+base = re.sub(r"[^a-z0-9_]+", "", lower.split("__")[-1].split("/")[-1])
+
+if base in {"list_dir", "listdir", "readdirectory"}:
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+if base in reads or lower.endswith("_read") or "read_file" in lower:
+    deny("Use simplicio_file_read / simplicio_read / simplicio_search / simplicio_orient. " + context)
+
+if base in {"write"} or lower.endswith("_write"):
+    destination = path
+    cwd = hook.get("cwd") or hook.get("cwd_path") or os.getcwd()
+    if destination and not os.path.isabs(destination):
+        destination = os.path.join(str(cwd), destination)
+    if destination and not os.path.exists(destination):
+        print(json.dumps({"decision": "allow"}))
+        raise SystemExit(0)
+
+if base in {"search_replace", "searchreplace", "strreplace"} or "search_replace" in lower:
+    print(json.dumps({"decision": "allow"}))
+    raise SystemExit(0)
+
+if base in edits or lower.endswith("_write"):
+    deny("Use simplicio_edit for mutations. Create: simplicio_edit plan=" + create_plan + ". " + context)
+
+if base in {"bash", "run_terminal_command", "shell", "run"}:
+    if re.search(
+        r"(^|[;&|\n])\s*\S*simplicio(\s+--help|\s+-h|\s+serve\s+--help|\s+\S+\s+--help)\b",
+        command,
+    ):
+        deny("Do not dump simplicio --help. " + context)
+    if re.search(r"(?:^|[;&|\n])\s*(?:\S*/)?simplicio(?![\w./-])\s*(?:[;&\n]|$)", command):
+        deny("Do not run bare simplicio (it dumps USAGE). " + context)
+    runtime_source = (
+        "simplicio-runtime/src", "simplicio-runtime/schemas", "simplicio-runtime/crates",
+        "edit-plan.schema", "operations.rs",
+    )
+    if any(token in command for token in runtime_source):
+        deny("Do not search Simplicio source to learn edit. " + context)
+    tokens = command.strip().split()
+    index = 0
+    while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
+        index += 1
+    lead = os.path.basename(tokens[index]) if index < len(tokens) else ""
+    if lead in {"cat", "head", "tail", "less", "more", "bat", "nl", "rg", "grep", "ag", "find"}:
+        deny("Use simplicio_file_read / simplicio_search instead of " + lead + ". " + context)
+    if lead in {"sed", "awk", "perl"}:
+        deny("Use simplicio_edit instead of " + lead + ". " + context)
+    if lead in {"simplicio", "git", "gh", "cargo", "npm", "python", "python3", "sqlite3", "rustfmt"}:
+        print(json.dumps({"decision": "allow"}))
+        raise SystemExit(0)
+
+print(json.dumps({"decision": "allow"}))
+PY

--- a/install.ps1
+++ b/install.ps1
@@ -109,6 +109,110 @@ function Require-ActiveLogin {
   }
 }
 
+function Backup-Once([string]$Path) {
+  if ((Test-Path -LiteralPath $Path) -and -not (Test-Path -LiteralPath "$Path.simplicio.bak")) {
+    Copy-Item -LiteralPath $Path -Destination "$Path.simplicio.bak" -Force
+  }
+}
+
+function Write-AtomicText([string]$Path, [string]$Content) {
+  $parent = Split-Path -Parent $Path
+  New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  $temp = "$Path.simplicio.tmp"
+  Set-Content -LiteralPath $temp -Value $Content -Encoding UTF8
+  Move-Item -Force -LiteralPath $temp -Destination $Path
+}
+
+function Install-CodexIntegration {
+  $codexDir = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE ".codex" }
+  $codexConfig = Join-Path $codexDir "config.toml"
+  $codexHooks = Join-Path $codexDir "hooks.json"
+  $hookDir = Join-Path $env:USERPROFILE ".simplicio\hooks"
+  $hookPath = Join-Path $hookDir "mcp-route.ps1"
+  $hookTemp = "$hookPath.download-$([guid]::NewGuid().ToString('N')).tmp"
+  New-Item -ItemType Directory -Force -Path $codexDir, $hookDir | Out-Null
+
+  Write-Host "==> configuring Codex STDIO MCP and hooks"
+  $hookRef = if ($env:SIMPLICIO_CODEX_HOOK_REF) { $env:SIMPLICIO_CODEX_HOOK_REF } else { "master" }
+  $hookUrl = "https://raw.githubusercontent.com/$Repo/$hookRef/codex/mcp-route.ps1"
+  try {
+    Invoke-WebRequest -Uri $hookUrl -OutFile $hookTemp -UseBasicParsing -ErrorAction Stop
+    Move-Item -Force -LiteralPath $hookTemp -Destination $hookPath
+  } catch {
+    if (Test-Path -LiteralPath $hookTemp) { Remove-Item -Force -LiteralPath $hookTemp -ErrorAction SilentlyContinue }
+    throw "could not download the Codex hook: $($_.Exception.Message)"
+  }
+
+  Backup-Once $codexConfig
+  $config = if (Test-Path -LiteralPath $codexConfig) { Get-Content -Raw -LiteralPath $codexConfig } else { "" }
+  $escapedBinary = $DestPath.Replace('\', '\\').Replace('"', '\"')
+  $stdioBlock = '[mcp_servers.simplicio]' + [Environment]::NewLine +
+    'command = "' + $escapedBinary + '"' + [Environment]::NewLine +
+    'args = ["serve", "--mcp", "--stdio"]' + [Environment]::NewLine
+  $sectionRegex = '(?ms)^\[mcp_servers\.simplicio\]\r?\n.*?(?=^\[|\z)'
+  if ([regex]::IsMatch($config, $sectionRegex)) {
+    $config = [regex]::Replace($config, $sectionRegex, [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $stdioBlock }, 1)
+  } else {
+    $separator = if ([string]::IsNullOrWhiteSpace($config)) { "" } else { [Environment]::NewLine + [Environment]::NewLine }
+    $config = $config.TrimEnd() + $separator + $stdioBlock
+  }
+  Write-AtomicText $codexConfig $config
+
+  Backup-Once $codexHooks
+  try {
+    $root = if (Test-Path -LiteralPath $codexHooks) {
+      (Get-Content -Raw -LiteralPath $codexHooks | ConvertFrom-Json)
+    } else {
+      [pscustomobject]@{}
+    }
+  } catch {
+    throw "hooks.json is invalid and was preserved: $($_.Exception.Message)"
+  }
+  if ($null -eq $root) { $root = [pscustomobject]@{} }
+  if (-not $root.PSObject.Properties["hooks"]) {
+    $root | Add-Member -MemberType NoteProperty -Name hooks -Value ([pscustomobject]@{})
+  }
+  $hooks = $root.hooks
+  if ($null -eq $hooks -or -not $hooks.PSObject) { throw "hooks.json has an invalid hooks object" }
+  $hookCommand = 'powershell -NoProfile -ExecutionPolicy Bypass -File "' + $hookPath + '"'
+
+  function Upsert-CodexHook([string]$Event, [string]$Matcher) {
+    $property = $hooks.PSObject.Properties[$Event]
+    $items = if ($property) { @($property.Value) } else { @() }
+    foreach ($item in $items) {
+      if ($null -eq $item -or -not $item.PSObject.Properties["hooks"]) { continue }
+      foreach ($existing in @($item.hooks)) {
+        if ($existing -and ([string]$existing.command).Contains("mcp-route.ps1")) {
+          $existing.command = $hookCommand
+          $existing.timeout = 8
+          $existing.type = "command"
+          $existing.statusMessage = "Routing through Simplicio MCP"
+          if ($Matcher) { $item.matcher = $Matcher }
+          $hooks | Add-Member -MemberType NoteProperty -Name $Event -Value $items -Force
+          return
+        }
+      }
+    }
+    $hook = [pscustomobject]@{
+      type = "command"
+      command = $hookCommand
+      timeout = 8
+      statusMessage = "Routing through Simplicio MCP"
+    }
+    $entry = [pscustomobject]@{ hooks = @($hook) }
+    if ($Matcher) { $entry | Add-Member -MemberType NoteProperty -Name matcher -Value $Matcher }
+    $items += $entry
+    $hooks | Add-Member -MemberType NoteProperty -Name $Event -Value $items -Force
+  }
+
+  Upsert-CodexHook "PreToolUse" "Bash|apply_patch|Edit|Write"
+  Upsert-CodexHook "SessionStart" "startup|resume|clear|compact"
+  Upsert-CodexHook "SubagentStart" ""
+  Upsert-CodexHook "UserPromptSubmit" ""
+  Write-AtomicText $codexHooks ($root | ConvertTo-Json -Depth 20)
+  Write-Host "  ✓ Codex configured for simplicio serve --mcp --stdio"
+  Write-Host "  ✓ Codex hooks installed at $hookPath"
+}
 # ─── -Doctor: idempotent, read-only health check ───────────────────────────
 if ($Doctor) {
   Write-Host "==> simplicio doctor"
@@ -322,15 +426,10 @@ try {
 }
 Write-Host "  ✓ active Google session and entitlement verified"
 
-# Codex only renders its Authenticate action for an OAuth-capable HTTP server.
-# Other hosts retain their stdio fallback inside `simplicio mcp register`.
-try {
-  & $DestPath mcp register | Out-Null
-  if ($LASTEXITCODE -ne 0) { throw "mcp register returned $LASTEXITCODE" }
-  Write-Host "  ✓ local HTTP/OAuth MCP registered for Codex"
-} catch {
-  Write-Warning "could not register MCP automatically; run: simplicio mcp register"
-}
+# Codex runs the installed binary directly over STDIO. This avoids the local
+# HTTP daemon latency and keeps the same Google login/entitlement gate in the
+# Runtime process. Existing Codex settings and hooks are merged, not replaced.
+Install-CodexIntegration
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
 New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,132 @@ sha256_of() {
   fi
 }
 
+fetch_url() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$1" -O "$2"
+  else
+    err "Precisa de curl ou wget para baixar"
+  fi
+}
+
+configure_codex_stdio() {
+  codex_dir="${CODEX_HOME:-$HOME/.codex}"
+  codex_config="$codex_dir/config.toml"
+  codex_hooks="$codex_dir/hooks.json"
+  hook_dir="$HOME/.simplicio/hooks"
+  hook_path="$hook_dir/mcp-route.sh"
+  hook_tmp="$hook_path.download-$$.tmp"
+  mkdir -p "$codex_dir" "$hook_dir"
+
+  info "Configurando MCP stdio e hooks do Codex"
+  hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-master}"
+  fetch_url "$GITHUB/raw/$hook_ref/codex/mcp-route.sh" "$hook_tmp" || err "não foi possível baixar o hook do Codex"
+  chmod 755 "$hook_tmp"
+  mv -f "$hook_tmp" "$hook_path"
+
+  python3 - "$codex_config" "$codex_hooks" "$DEST_PATH" "$hook_path" <<'PY'
+import json
+import os
+import re
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+config_path, hooks_path, binary, hook_path = map(Path, sys.argv[1:])
+
+
+def backup_once(path: Path) -> None:
+    if path.exists():
+        backup = Path(str(path) + ".simplicio.bak")
+        if not backup.exists():
+            shutil.copy2(path, backup)
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = Path(str(path) + ".simplicio.tmp")
+    temp.write_text(text, encoding="utf-8")
+    os.replace(temp, path)
+
+
+backup_once(config_path)
+config = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+toml_binary = str(binary).replace("\\", "\\\\").replace('"', '\\"')
+stdio_block = (
+    "[mcp_servers.simplicio]\n"
+    f'command = "{toml_binary}"\n'
+    'args = ["serve", "--mcp", "--stdio"]\n'
+)
+section = re.compile(r"(?ms)^\[mcp_servers\.simplicio\]\r?\n.*?(?=^\[|\Z)")
+if section.search(config):
+    config = section.sub(stdio_block, config, count=1)
+else:
+    config = config.rstrip() + ("\n\n" if config.strip() else "") + stdio_block
+atomic_write(config_path, config)
+
+
+backup_once(hooks_path)
+if hooks_path.exists():
+    try:
+        root = json.loads(hooks_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise SystemExit(f"hooks.json inválido; preservado sem alteração: {exc}")
+else:
+    root = {}
+if not isinstance(root, dict):
+    raise SystemExit("hooks.json precisa conter um objeto JSON; preservado sem alteração")
+hooks = root.setdefault("hooks", {})
+if not isinstance(hooks, dict):
+    raise SystemExit("hooks.json: campo hooks inválido; preservado sem alteração")
+
+command = f"bash {shlex.quote(str(hook_path))}"
+hook_command = {
+    "command": command,
+    "timeout": 8,
+    "type": "command",
+    "statusMessage": "Routing through Simplicio MCP",
+}
+
+
+def upsert(event: str, entry: dict) -> None:
+    items = hooks.get(event, [])
+    if isinstance(items, dict):
+        items = [items]
+    if not isinstance(items, list):
+        raise SystemExit(f"hooks.json: evento {event} inválido; preservado sem alteração")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        existing_hooks = item.get("hooks", [])
+        if not isinstance(existing_hooks, list):
+            continue
+        for existing in existing_hooks:
+            if isinstance(existing, dict) and "mcp-route.sh" in str(existing.get("command", "")):
+                existing.update(hook_command)
+                if "matcher" in entry:
+                    item["matcher"] = entry["matcher"]
+                hooks[event] = items
+                return
+    entry = dict(entry)
+    entry["hooks"] = [dict(hook_command)]
+    items.append(entry)
+    hooks[event] = items
+
+
+upsert("PreToolUse", {"matcher": "Bash|apply_patch|Edit|Write"})
+for event, matcher in (("SessionStart", "startup|resume|clear|compact"),
+                       ("SubagentStart", ""),
+                       ("UserPromptSubmit", "")):
+    upsert(event, {"matcher": matcher})
+atomic_write(hooks_path, json.dumps(root, indent=2, ensure_ascii=False) + "\n")
+PY
+  ok "Codex configurado para simplicio serve --mcp --stdio"
+  ok "hooks do Codex instalados em $hook_path"
+}
+
 verify_runtime_contract() {
   binary_path="$1"
   if [ ! -x "$binary_path" ] || ! command -v python3 >/dev/null 2>&1; then
@@ -278,17 +404,6 @@ if [ "$SKIP_EXISTING" != "true" ]; then
   DOWNLOAD_URL="$RELEASE_BASE/$ASSET"
   MANIFEST_URL="$RELEASE_BASE/simplicio-update-manifest.json"
 
-  fetch() {
-    # fetch <url> <dest-or-'-'>
-    if command -v curl >/dev/null 2>&1; then
-      curl -fsSL "$1" -o "$2"
-    elif command -v wget >/dev/null 2>&1; then
-      wget -q "$1" -O "$2"
-    else
-      err "Precisa de curl ou wget para baixar"
-    fi
-  }
-
   TARGET_ID="$OS-$ARCH"
   EXPECTED_SHA256=""
   SIGNED="false"
@@ -296,7 +411,7 @@ if [ "$SKIP_EXISTING" != "true" ]; then
   SIGNATURE_REQUIRED="false"
   MANIFEST_TMP="$(mktemp)"
   trap 'rm -f "$MANIFEST_TMP"' EXIT
-  if fetch "$MANIFEST_URL" "$MANIFEST_TMP" 2>/dev/null; then
+  if fetch_url "$MANIFEST_URL" "$MANIFEST_TMP" 2>/dev/null; then
     if command -v python3 >/dev/null 2>&1; then
       EXPECTED_SHA256="$(python3 -c "
 import json,sys
@@ -357,7 +472,7 @@ except Exception:
 
   info "Baixando de $DOWNLOAD_URL ..."
   STAGING_PATH="$DEST_PATH.download-$$.tmp"
-  fetch "$DOWNLOAD_URL" "$STAGING_PATH"
+  fetch_url "$DOWNLOAD_URL" "$STAGING_PATH"
 
   if [ ! -s "$STAGING_PATH" ]; then
     rm -f "$STAGING_PATH"
@@ -400,13 +515,10 @@ ok "contrato de release do Runtime verificado"
 require_active_login
 ok "login Google ativo e entitlement válido"
 
-# Codex only renders its Authenticate action for an OAuth-capable HTTP server.
-# Other hosts retain their stdio fallback inside `simplicio mcp register`.
-if "$DEST_PATH" mcp register >/dev/null 2>&1; then
-  ok "MCP local HTTP/OAuth registrado para o Codex"
-else
-  warn "não foi possível registrar o MCP automaticamente; rode: simplicio mcp register"
-fi
+# Codex runs the installed binary directly over STDIO. This avoids the local
+# HTTP daemon latency and keeps the same Google login/entitlement gate in the
+# Runtime process. Existing Codex settings and hooks are merged, not replaced.
+configure_codex_stdio
 
 # Adiciona ao PATH se não estiver
 case ":$PATH:" in

--- a/tests/test_codex_hooks.sh
+++ b/tests/test_codex_hooks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/codex/mcp-route.sh"
+PASS=0
+FAIL=0
+
+run_case() {
+  name="$1"
+  payload="$2"
+  want_exit="$3"
+  want_token="$4"
+  errfile="$(mktemp)"
+  out="$(printf '%s' "$payload" | bash "$HOOK" 2>"$errfile")"
+  got=$?
+  rm -f "$errfile"
+  if [ "$got" = "$want_exit" ] && printf '%s' "$out" | grep -q "$want_token"; then
+    printf 'PASS %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_case "context" '{"hook_event_name":"SessionStart","source":"startup"}' 0 'SessionStart'
+run_case "allow simplicio tool" '{"toolName":"simplicio__simplicio_read","toolInput":{"path":"x"}}' 0 'allow'
+run_case "deny host read" '{"toolName":"read_file","toolInput":{"file_path":"src/main.rs"}}' 2 'deny'
+run_case "allow search replace" '{"toolName":"search_replace","toolInput":{"file_path":"src/main.rs"}}' 0 'allow'
+
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -1,0 +1,44 @@
+"""Static contract checks for the public Codex integration."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_installers_configure_direct_stdio_and_hooks():
+    for name in ("install.sh", "install.ps1"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "config.toml" in text
+        assert "hooks.json" in text
+        assert "serve" in text and "--mcp" in text and "--stdio" in text
+        assert "mcp-route" in text
+        assert "mcp register" not in text
+
+
+def test_installers_preserve_existing_codex_state():
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert "simplicio.bak" in shell
+    assert "atomic_write" in shell
+    assert "simplicio.bak" in powershell
+    assert "Write-AtomicText" in powershell
+
+
+def test_codex_hooks_have_all_required_lifecycle_events():
+    shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
+    powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")
+    for event in ("SessionStart", "UserPromptSubmit", "SubagentStart"):
+        assert event in shell_hook
+        assert event in powershell_hook
+    assert "PreToolUse" in (ROOT / "install.sh").read_text(encoding="utf-8")
+    assert "PreToolUse" in (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+
+def test_docs_describe_stdio_instead_of_codex_http_authenticate_flow():
+    for name in ("README.md", "MCP-CONNECT.md"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "local STDIO MCP" in text
+        assert "serve --mcp --stdio" in text
+        assert "HTTP/OAuth" not in text
+        assert "Authenticate" not in text


### PR DESCRIPTION
## What changed

- Configure the public macOS/Linux and Windows installers to register Codex's `simplicio` MCP server as direct local STDIO:
  `simplicio serve --mcp --stdio`.
- Install cross-platform Simplicio Codex routing hooks for `SessionStart`, `UserPromptSubmit`, `SubagentStart`, and `PreToolUse`.
- Migrate legacy Windows entries that invoke `/bin/bash`, `mcp-route.sh`, or the old `simplicio-mcp-route` hook label before installing the PowerShell hook.
- Merge the entries into existing `~/.codex/config.toml` and `~/.codex/hooks.json` without replacing unrelated MCP servers or hooks.
- Keep first-write `.simplicio.bak` backups and document the review path in Codex Settings → Hooks.
- Update README, MCP connection docs, install docs, changelog, and add installer/hook regression tests.

## Why

The previous public installers called `simplicio mcp register`, which registered the local HTTP/OAuth route for Codex. That did not match the desired low-latency local execution path and did not install the Codex hooks needed to consistently route repository work through Simplicio MCP.

## User impact

After reinstalling or updating, Codex launches the installed Simplicio binary directly and receives the Simplicio routing context/hooks. Google login and Runtime entitlement checks remain enforced by the binary. Users can inspect or approve the hooks in Codex and temporarily disable routing with `SIMPLICIO_MCP_ROUTE=0`.

## Validation

- `sh -n install.sh`
- `bash tests/test_codex_hooks.sh` — 4 passed
- `python3 -m pytest -q tests/test_codex_install_contract.py tests/test_auth_install_contract.py` — 10 passed
- `node --test tests/node/installer-unit.test.cjs` — 12 passed
- `python3 scripts/verify_distribution_consistency.py` — 8 checks passed
- Embedded config-merge smoke test preserved an unrelated MCP entry and existing hook
- Full `pytest` currently has one unrelated pre-existing failure: `tests/unit/test_pypi_installer.py::test_default_manifest_pin_matches_versioned_checkout` expects the old 3.8.11 manifest hash while this checkout is v3.8.15.
- PowerShell execution was not available on this macOS host; the Windows installer and hook were reviewed statically and covered by the contract test.