### PR TITLE
fix(windows): migrate legacy Codex bash hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   `~/.codex/hooks.json` without replacing unrelated user configuration.
 - Added cross-platform Codex routing hooks for macOS/Linux and Windows, with a
   documented `SIMPLICIO_MCP_ROUTE=0` escape hatch and first-write backups.
+- Windows installation now migrates legacy global hooks that invoke
+  `/bin/bash` or `mcp-route.sh`, preventing stale Unix commands from failing
+  after an update.
 
 ## [3.8.11] - 2026-08-14
 

--- a/install.ps1
+++ b/install.ps1
@@ -123,6 +123,44 @@ function Write-AtomicText([string]$Path, [string]$Content) {
   Move-Item -Force -LiteralPath $temp -Destination $Path
 }
 
+function Remove-Legacy-CodexHooks([object]$Root) {
+  if ($null -eq $Root -or -not $Root.PSObject.Properties["hooks"]) { return }
+  $hooks = $Root.hooks
+  if ($null -eq $hooks -or -not $hooks.PSObject) { return }
+  $eventNames = @($hooks.PSObject.Properties | ForEach-Object { $_.Name })
+  foreach ($eventName in $eventNames) {
+    $eventProperty = $hooks.PSObject.Properties[$eventName]
+    if ($null -eq $eventProperty) { continue }
+    $items = @($eventProperty.Value)
+    $keptItems = @()
+    foreach ($item in $items) {
+      if ($null -eq $item -or -not $item.PSObject.Properties["hooks"]) {
+        $keptItems += $item
+        continue
+      }
+      $keptHooks = @()
+      foreach ($legacyHook in @($item.hooks)) {
+        $command = [string]$legacyHook.command
+        $isLegacySimplicio = (
+          $command -match '(?i)mcp-route\.sh|simplicio-mcp-route' -or
+          (($command -match '(?i)/bin/bash') -and ($command -match '(?i)simplicio'))
+        )
+        if (-not $isLegacySimplicio) { $keptHooks += $legacyHook }
+      }
+      if ($keptHooks.Count -gt 0) {
+        $item.hooks = $keptHooks
+        $keptItems += $item
+      }
+    }
+    if ($keptItems.Count -gt 0) {
+      $hooks | Add-Member -MemberType NoteProperty -Name $eventName -Value $keptItems -Force
+    } else {
+      $hooks.PSObject.Properties.Remove($eventName)
+    }
+  }
+}
+
+
 function Install-CodexIntegration {
   $codexDir = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE ".codex" }
   $codexConfig = Join-Path $codexDir "config.toml"
@@ -169,6 +207,7 @@ function Install-CodexIntegration {
     throw "hooks.json is invalid and was preserved: $($_.Exception.Message)"
   }
   if ($null -eq $root) { $root = [pscustomobject]@{} }
+  Remove-Legacy-CodexHooks $root
   if (-not $root.PSObject.Properties["hooks"]) {
     $root | Add-Member -MemberType NoteProperty -Name hooks -Value ([pscustomobject]@{})
   }

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -25,6 +25,17 @@ def test_installers_preserve_existing_codex_state():
     assert "Write-AtomicText" in powershell
 
 
+def test_windows_installer_migrates_legacy_unix_hooks():
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    # Existing Windows users may have the old global hook, which invokes
+    # /bin/bash against a .sh path. The installer must remove only that legacy
+    # Simplicio entry before adding the PowerShell hook.
+    assert "mcp-route\\.sh" in powershell
+    assert "/bin/bash" in powershell
+    assert "Remove-Legacy-CodexHooks" in powershell
+    assert "mcp-route.ps1" in powershell
+
+
 def test_codex_hooks_have_all_required_lifecycle_events():
     shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Update the public Windows and Unix installers in `/simplicio` to migrate stale global Simplicio Codex hooks that invoke `/bin/bash` or `mcp-route.sh`.
- Handle legacy event names such as `pre_tool_use` while preserving unrelated hooks.
- Install the platform-correct hook (`mcp-route.ps1` on Windows, `mcp-route.sh` on Unix) and keep the migration idempotent.

## User-visible failure

Existing Windows customers saw errors such as:

```text
/bin/bash: C:\Users\...\.simplicio\hooks\mcp-route.sh: No such file or directory
execvp(/bin/bash) failed
```

The old Unix hook remained in the global Codex configuration after the installer switched to the Windows PowerShell hook.

## Scope

This is intentionally a change only to the public installation repository `wesleysimplicio/simplicio`. The MCP server implementation remains in the `simplicio-runtime` repository.

## Validation

- `python3 -m pytest -q tests/test_codex_install_contract.py tests/test_auth_install_contract.py` — 10 passed
- `sh -n install.sh`
- `bash tests/test_codex_hooks.sh` — 4 passed
- `node --test tests/node/installer-unit.test.cjs` — 12 passed
- Embedded shell-installer migration smoke test removed the stale Windows-style `/bin/bash` hook while preserving an unrelated hook.
- PowerShell execution was unavailable on this macOS host; the Windows migration is covered by the regression contract and reviewed statically.