### PR TITLE
fix(install): migrate legacy Codex hooks on Unix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,6 +152,43 @@ hooks = root.setdefault("hooks", {})
 if not isinstance(hooks, dict):
     raise SystemExit("hooks.json: campo hooks inválido; preservado sem alteração")
 
+def remove_legacy_hooks() -> None:
+    for event in list(hooks):
+        items = hooks.get(event, [])
+        if isinstance(items, dict):
+            items = [items]
+        if not isinstance(items, list):
+            raise SystemExit(f"hooks.json: evento {event} inválido; preservado sem alteração")
+        kept_items = []
+        for item in items:
+            if not isinstance(item, dict):
+                kept_items.append(item)
+                continue
+            existing_hooks = item.get("hooks")
+            if not isinstance(existing_hooks, list):
+                kept_items.append(item)
+                continue
+            kept_hooks = []
+            for legacy_hook in existing_hooks:
+                command_text = str(legacy_hook.get("command", "")) if isinstance(legacy_hook, dict) else ""
+                lowered = command_text.lower()
+                is_legacy_simplicio = (
+                    re.search(r"mcp-route\.sh|simplicio-mcp-route", command_text, re.I)
+                    or ("/bin/bash" in lowered and "simplicio" in lowered)
+                )
+                if not is_legacy_simplicio:
+                    kept_hooks.append(legacy_hook)
+            if kept_hooks:
+                item["hooks"] = kept_hooks
+                kept_items.append(item)
+        if kept_items:
+            hooks[event] = kept_items
+        else:
+            del hooks[event]
+
+
+remove_legacy_hooks()
+
 command = f"bash {shlex.quote(str(hook_path))}"
 hook_command = {
     "command": command,

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -36,6 +36,17 @@ def test_windows_installer_migrates_legacy_unix_hooks():
     assert "mcp-route.ps1" in powershell
 
 
+def test_unix_installer_migrates_legacy_hook_events():
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    # The same stale global entry can survive under a legacy snake_case event
+    # on macOS/Linux; the shell installer must remove it before upserting the
+    # current command.
+    assert "def remove_legacy_hooks" in shell
+    assert "simplicio-mcp-route" in shell
+    assert "list(hooks)" in shell
+    assert "del hooks[event]" in shell
+
+
 def test_codex_hooks_have_all_required_lifecycle_events():
     shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Update the public Unix installer in `/simplicio` to migrate stale Simplicio Codex hooks under any event name, including legacy `pre_tool_use`.
- Remove old `mcp-route.sh` / `simplicio-mcp-route` entries before installing the current Unix hook.
- Preserve unrelated hooks and keep the operation idempotent.

## User-visible failure

The same stale global hook configuration can survive on macOS/Linux after an installer update and continue invoking an obsolete Simplicio hook path.

## Scope

This change is only in the public installation repository `wesleysimplicio/simplicio`. The MCP server remains implemented by `simplicio-runtime`.

## Validation

- `python3 -m pytest -q tests/test_codex_install_contract.py tests/test_auth_install_contract.py` — 11 passed
- `sh -n install.sh`
- `bash tests/test_codex_hooks.sh` — 4 passed
- Embedded shell-installer migration smoke test removed a stale legacy entry while preserving an unrelated hook.
