### PR TITLE
fix(installer): accept release manifest target aliases

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,9 +22,11 @@
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem): id "macos-arm64" -> asset
 # "simplicio-macos-arm64", id "macos-x64" -> "simplicio-macos-x64", id
-# "linux-x64" -> "simplicio-linux-x64". Drift between this script, the
-# release workflow and simplicio-update-manifest.json is caught by
-# scripts/verify_distribution_consistency.py in CI.
+# "linux-x64" -> "simplicio-linux-x64". Published manifests from older
+# release tooling may use Rust-style aliases (macos-aarch64, macos-x86_64,
+# linux-x86_64); the lookup below accepts both without changing asset URLs.
+# Drift between this script, the release workflow and
+# simplicio-update-manifest.json is caught by CI.
 
 set -eu
 
@@ -442,6 +444,15 @@ if [ "$SKIP_EXISTING" != "true" ]; then
   MANIFEST_URL="$RELEASE_BASE/simplicio-update-manifest.json"
 
   TARGET_ID="$OS-$ARCH"
+  # Keep installer/distribution IDs stable while accepting aliases emitted by
+  # the v3.8.15 release manifest. A valid signed artifact must not be treated
+  # as unsigned merely because the manifest uses a Rust-style target name.
+  MANIFEST_TARGET_ID="$TARGET_ID"
+  case "$TARGET_ID" in
+    macos-arm64) MANIFEST_TARGET_ID="macos-aarch64" ;;
+    macos-x64) MANIFEST_TARGET_ID="macos-x86_64" ;;
+    linux-x64) MANIFEST_TARGET_ID="linux-x86_64" ;;
+  esac
   EXPECTED_SHA256=""
   SIGNED="false"
   SIGNATURE=""
@@ -455,7 +466,7 @@ import json,sys
 try:
     m = json.load(open('$MANIFEST_TMP'))
     for a in m.get('artifacts', []):
-        if a.get('target') == '$TARGET_ID':
+        if a.get('target') in {'$MANIFEST_TARGET_ID', '$TARGET_ID'}:
             print(a.get('sha256') or '')
             print('true' if a.get('signed') or str(a.get('signature') or '').startswith('ed25519:') else 'false')
             break
@@ -467,7 +478,7 @@ import json
 try:
     m = json.load(open('$MANIFEST_TMP'))
     for a in m.get('artifacts', []):
-        if a.get('target') == '$TARGET_ID':
+        if a.get('target') in {'$MANIFEST_TARGET_ID', '$TARGET_ID'}:
             print('true' if a.get('signed') or str(a.get('signature') or '').startswith('ed25519:') else 'false')
             break
 except Exception:
@@ -478,7 +489,7 @@ import json
 try:
     m = json.load(open('$MANIFEST_TMP'))
     for a in m.get('artifacts', []):
-        if a.get('target') == '$TARGET_ID':
+        if a.get('target') in {'$MANIFEST_TARGET_ID', '$TARGET_ID'}:
             print(a.get('signature') or '')
             break
 except Exception:

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -47,6 +47,18 @@ def test_unix_installer_migrates_legacy_hook_events():
     assert "del hooks[event]" in shell
 
 
+def test_unix_installer_accepts_release_manifest_target_aliases():
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    # The v3.8.15 manifest uses Rust-style target names while the public
+    # distribution table uses stable installer IDs. Keep signature lookup
+    # fail-closed, but accept both names.
+    assert 'MANIFEST_TARGET_ID="$TARGET_ID"' in shell
+    assert 'macos-arm64) MANIFEST_TARGET_ID="macos-aarch64"' in shell
+    assert 'macos-x64) MANIFEST_TARGET_ID="macos-x86_64"' in shell
+    assert 'linux-x64) MANIFEST_TARGET_ID="linux-x86_64"' in shell
+    assert "a.get('target') in {'$MANIFEST_TARGET_ID', '$TARGET_ID'}" in shell
+
+
 def test_codex_hooks_have_all_required_lifecycle_events():
     shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed
- Accept Rust-style target aliases emitted by the v3.8.15 release manifest.
- Keep the public installer IDs and asset URLs unchanged.
- Add a regression contract test for macOS and Linux lookup.

## Root cause
The manifest uses macos-aarch64, macos-x86_64, and linux-x86_64 while install.sh looked up only macos-arm64, macos-x64, and linux-x64. The installer therefore rejected valid signed artifacts as unsigned before configuring Codex.

## Validation
- sh -n install.sh
- python3 -m pytest -q tests/test_codex_install_contract.py tests/test_auth_install_contract.py (12 passed)
- bash tests/test_codex_hooks.sh (4 passed)
- git diff --check