### PR TITLE
installer: reject incomplete MCP tool surfaces

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -73,6 +73,41 @@ function Test-RuntimeReleaseContract([string]$BinaryPath) {
   )
 }
 
+function Test-McpToolSurface([string]$BinaryPath) {
+  if (-not (Test-Path $BinaryPath)) { return $false }
+  $required = @(
+    "simplicio_map", "simplicio_memory", "simplicio_edit", "simplicio_gate",
+    "simplicio_validate", "simplicio_run", "simplicio_symbol", "simplicio_search",
+    "simplicio_read", "simplicio_exec"
+  )
+  $payload = @(
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+  ) -join [Environment]::NewLine
+  try {
+    $raw = $payload | & $BinaryPath serve --mcp --stdio --json 2>$null | Out-String
+    if ($LASTEXITCODE -ne 0) { return $false }
+    $response = $null
+    foreach ($line in ($raw -split "\r?\n")) {
+      if ([string]::IsNullOrWhiteSpace($line)) { continue }
+      try {
+        $candidate = $line | ConvertFrom-Json
+        if ($candidate.id -eq 2) { $response = $candidate }
+      } catch { continue }
+    }
+    if ($null -eq $response -or $null -eq $response.result) { return $false }
+    $names = @($response.result.tools | ForEach-Object { [string]$_.name })
+    $missing = @($required | Where-Object { $_ -notin $names })
+    if ($missing.Count -gt 0) {
+      Write-Host "  [FAIL] MCP tool surface incomplete; missing: $($missing -join ', ')"
+      return $false
+    }
+    return $true
+  } catch {
+    return $false
+  }
+}
+
 function Test-ActiveLogin {
   if (-not (Test-Path $DestPath)) { return $false }
   try {
@@ -287,6 +322,13 @@ if ($Doctor) {
       $ok = $false
     }
 
+    if (Test-McpToolSurface $DestPath) {
+      Write-Host "  [OK] MCP exposes the 10 documented tools"
+    } else {
+      Write-Host "  [FAIL] MCP does not expose the complete documented tool surface"
+      $ok = $false
+    }
+
     if (Test-ActiveLogin) {
       Write-Host "  [OK] active Google session and entitlement"
     } else {
@@ -428,6 +470,11 @@ if (-not (Test-RuntimeReleaseContract $StagingPath)) {
   Write-Error "Runtime release does not meet the distribution contract (embedded sources, Google login, and signed-update key); installation aborted."
   exit 1
 }
+if (-not (Test-McpToolSurface $StagingPath)) {
+  Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
+  Write-Error "Runtime release does not expose the complete MCP tool surface; installation aborted."
+  exit 1
+}
 
 # Atomic swap: rename into place on the same volume so there is never a
 # window where $DestPath is a half-written file, and re-running this script
@@ -455,6 +502,11 @@ if (-not (Test-RuntimeReleaseContract $DestPath)) {
   exit 1
 }
 Write-Host "  ✓ Runtime release contract verified"
+if (-not (Test-McpToolSurface $DestPath)) {
+  Write-Error "This Runtime does not expose the complete MCP tool surface; refusing to finish installation."
+  exit 1
+}
+Write-Host "  ✓ MCP tool surface verified (10 documented tools)"
 
 # ─── Active login is mandatory; beta does not bypass this gate ──────────────
 try {

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,50 @@ raise SystemExit(0 if ready else 1)
 ' >/dev/null 2>&1
 }
 
+verify_mcp_tools() {
+  binary_path="$1"
+  if [ ! -x "$binary_path" ] || ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  python3 - "$binary_path" <<'PY'
+import json
+import subprocess
+import sys
+
+required = {
+    "simplicio_map", "simplicio_memory", "simplicio_edit", "simplicio_gate",
+    "simplicio_validate", "simplicio_run", "simplicio_symbol", "simplicio_search",
+    "simplicio_read", "simplicio_exec",
+}
+payload = "".join(json.dumps(request) + "\n" for request in (
+    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+))
+try:
+    result = subprocess.run(
+        [sys.argv[1], "serve", "--mcp", "--stdio", "--json"],
+        input=payload, capture_output=True, text=True, timeout=30, check=False,
+    )
+    responses = []
+    for line in result.stdout.splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            responses.append(value)
+    tools_result = next((r.get("result") for r in responses if r.get("id") == 2), {})
+    names = {t.get("name") for t in (tools_result or {}).get("tools", []) if isinstance(t, dict)}
+    missing = sorted(required - names)
+    if result.returncode != 0 or missing:
+        print("MCP tool surface incomplete: missing=" + ",".join(missing), file=sys.stderr)
+        raise SystemExit(1)
+except (OSError, subprocess.TimeoutExpired) as exc:
+    print("MCP tools/list failed: " + str(exc), file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
 report_runtime_contract() {
   binary_path="$1"
   if [ ! -x "$binary_path" ] || ! command -v python3 >/dev/null 2>&1; then
@@ -354,6 +398,13 @@ run_doctor() {
     else
       warn "release não está pronta para distribuição (bundle/login/chave de updates)"
       report_runtime_contract "$DEST_PATH"
+      status=1
+    fi
+
+    if verify_mcp_tools "$DEST_PATH"; then
+      ok "MCP expõe as 10 tools documentadas"
+    else
+      warn "MCP incompleto: o binário não expõe todas as tools documentadas"
       status=1
     fi
 
@@ -545,6 +596,10 @@ except Exception:
     rm -f "$STAGING_PATH"
     err "release Runtime não atende ao contrato de distribuição; instalação interrompida"
   fi
+  if ! verify_mcp_tools "$STAGING_PATH"; then
+    rm -f "$STAGING_PATH"
+    err "release Runtime não expõe a superfície MCP completa; instalação interrompida"
+  fi
   # Swap atômico: mv no mesmo filesystem nunca deixa $DEST_PATH parcialmente
   # escrito, e reexecutar este script (update idempotente) não deixa .tmp
   # órfãos em caso de sucesso.
@@ -558,6 +613,10 @@ if ! verify_runtime_contract "$DEST_PATH"; then
   err "este Runtime não atende ao contrato de distribuição (fontes embutidas, login Google e chave pública de updates); instalação interrompida"
 fi
 ok "contrato de release do Runtime verificado"
+if ! verify_mcp_tools "$DEST_PATH"; then
+  err "este Runtime não expõe a superfície MCP completa; instalação interrompida"
+fi
+ok "superfície MCP verificada (10 tools documentadas)"
 
 # ─── 2.2 Login obrigatório: beta não elimina a sessão ativa ────────────────
 require_active_login


### PR DESCRIPTION
## What changed

- Add a fail-closed `tools/list` check to the macOS/Linux installer and `--doctor`.
- Add the equivalent check to the Windows PowerShell installer and `-Doctor`.
- Validate the staged binary before atomic replacement, so an incomplete MCP release cannot replace a working install.

## Why

The public v3.8.15 Runtime starts successfully but advertises only the three optional Headroom tools. It must expose the ten documented Simplicio tools (`simplicio_map`, `simplicio_memory`, `simplicio_edit`, `simplicio_gate`, `simplicio_validate`, `simplicio_run`, `simplicio_symbol`, `simplicio_search`, `simplicio_read`, `simplicio_exec`).

## Validation

- `sh -n install.sh` passed.
- `python3 -m pytest -q tests/test_auth_install_contract.py tests/test_codex_install_contract.py tests/test_verify_distribution_consistency.py` passed: 18/18.
- Existing `.simplicio/` generated state was not staged.