### PR TITLE
fix(issue-87): defer MCP preflight until login

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -322,17 +322,17 @@ if ($Doctor) {
       $ok = $false
     }
 
-    if (Test-McpToolSurface $DestPath) {
-      Write-Host "  [OK] MCP exposes the 10 documented tools"
-    } else {
-      Write-Host "  [FAIL] MCP does not expose the complete documented tool surface"
-      $ok = $false
-    }
-
     if (Test-ActiveLogin) {
       Write-Host "  [OK] active Google session and entitlement"
     } else {
       Write-Host "  [FAIL] missing, expired, revoked, or inactive Google session"
+      $ok = $false
+    }
+
+    if (Test-McpToolSurface $DestPath) {
+      Write-Host "  [OK] MCP exposes the 10 documented tools after authentication"
+    } else {
+      Write-Host "  [FAIL] MCP does not expose the complete documented tool surface after login"
       $ok = $false
     }
   }
@@ -462,17 +462,12 @@ if ($ExpectedSha256) {
   Write-Host "  ✓ SHA256 verified: $actualSha256"
 }
 
-# Validate the staged executable before the atomic swap. A release that lacks
-# embedded sources, Google login activation, or the signed-update key must not
-# replace a working installation and then fail its post-install checks.
+# A clean HOME has no authenticated session yet. Validate only the offline
+# Runtime release contract before the swap; MCP initialize/tools/list runs
+# after Require-ActiveLogin below.
 if (-not (Test-RuntimeReleaseContract $StagingPath)) {
   Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
   Write-Error "Runtime release does not meet the distribution contract (embedded sources, Google login, and signed-update key); installation aborted."
-  exit 1
-}
-if (-not (Test-McpToolSurface $StagingPath)) {
-  Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
-  Write-Error "Runtime release does not expose the complete MCP tool surface; installation aborted."
   exit 1
 }
 
@@ -502,13 +497,10 @@ if (-not (Test-RuntimeReleaseContract $DestPath)) {
   exit 1
 }
 Write-Host "  ✓ Runtime release contract verified"
-if (-not (Test-McpToolSurface $DestPath)) {
-  Write-Error "This Runtime does not expose the complete MCP tool surface; refusing to finish installation."
-  exit 1
-}
-Write-Host "  ✓ MCP tool surface verified (10 documented tools)"
+# MCP initialize/tools/list is authenticated and is intentionally deferred until
+# after Require-ActiveLogin below for clean-HOME bootstrap.
 
-# ─── Active login is mandatory; beta does not bypass this gate ──────────────
+# ─── Active login precedes the authenticated MCP handshake ──────────────────
 try {
   Require-ActiveLogin
 } catch {
@@ -517,9 +509,14 @@ try {
 }
 Write-Host "  ✓ active Google session and entitlement verified"
 
-# Codex runs the installed binary directly over STDIO. This avoids the local
-# HTTP daemon latency and keeps the same Google login/entitlement gate in the
-# Runtime process. Existing Codex settings and hooks are merged, not replaced.
+if (-not (Test-McpToolSurface $DestPath)) {
+  Write-Error "This Runtime does not expose the complete MCP tool surface after login; refusing to finish installation."
+  exit 1
+}
+Write-Host "  ✓ MCP tool surface verified (10 documented tools)"
+
+# Codex runs the installed binary directly over STDIO. Existing settings and
+# hooks are merged, not replaced.
 Install-CodexIntegration
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }

--- a/install.sh
+++ b/install.sh
@@ -401,20 +401,20 @@ run_doctor() {
       status=1
     fi
 
-    if verify_mcp_tools "$DEST_PATH"; then
-      ok "MCP expõe as 10 tools documentadas"
-    else
-      warn "MCP incompleto: o binário não expõe todas as tools documentadas"
-      status=1
-    fi
-
     if verify_active_login; then
       ok "sessão Google ativa e entitlement válido"
     else
       warn "sessão Google ausente, expirada, revogada ou sem entitlement ativo"
       status=1
     fi
-  fi
+
+    if verify_mcp_tools "$DEST_PATH"; then
+      ok "MCP expõe as 10 tools documentadas"
+    else
+      warn "MCP incompleto após autenticação: o binário não expõe todas as tools documentadas"
+      status=1
+    fi
+    fi
 
   if [ "$status" -eq 0 ]; then
     ok "simplicio está saudável"
@@ -588,17 +588,13 @@ except Exception:
   fi
 
   chmod +x "$STAGING_PATH"
-  # Validate the staged executable before the atomic swap. A release that lacks
-  # embedded sources, Google login activation, or the signed-update key must
-  # not replace a working installation and then fail its post-install checks.
+  # A clean HOME has no authenticated session yet. Validate only the offline
+  # Runtime release contract before the swap; MCP initialize/tools/list is an
+  # authenticated gate and runs after require_active_login below.
   if ! verify_runtime_contract "$STAGING_PATH"; then
     report_runtime_contract "$STAGING_PATH"
     rm -f "$STAGING_PATH"
     err "release Runtime não atende ao contrato de distribuição; instalação interrompida"
-  fi
-  if ! verify_mcp_tools "$STAGING_PATH"; then
-    rm -f "$STAGING_PATH"
-    err "release Runtime não expõe a superfície MCP completa; instalação interrompida"
   fi
   # Swap atômico: mv no mesmo filesystem nunca deixa $DEST_PATH parcialmente
   # escrito, e reexecutar este script (update idempotente) não deixa .tmp
@@ -613,14 +609,17 @@ if ! verify_runtime_contract "$DEST_PATH"; then
   err "este Runtime não atende ao contrato de distribuição (fontes embutidas, login Google e chave pública de updates); instalação interrompida"
 fi
 ok "contrato de release do Runtime verificado"
-if ! verify_mcp_tools "$DEST_PATH"; then
-  err "este Runtime não expõe a superfície MCP completa; instalação interrompida"
-fi
-ok "superfície MCP verificada (10 tools documentadas)"
 
-# ─── 2.2 Login obrigatório: beta não elimina a sessão ativa ────────────────
+# ─── 2.2 Login obrigatório antes do handshake MCP ───────────────────────────
 require_active_login
 ok "login Google ativo e entitlement válido"
+
+# MCP tools/list is intentionally post-login: clean installs must bootstrap the
+# binary and establish the session before invoking the authenticated surface.
+if ! verify_mcp_tools "$DEST_PATH"; then
+  err "este Runtime não expõe a superfície MCP completa após o login; instalação interrompida"
+fi
+ok "superfície MCP verificada (10 tools documentadas)"
 
 # Codex runs the installed binary directly over STDIO. This avoids the local
 # HTTP daemon latency and keeps the same Google login/entitlement gate in the

--- a/tests/test_clean_install_bootstrap_contract.py
+++ b/tests/test_clean_install_bootstrap_contract.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_shell_defers_mcp_handshake_until_after_login():
+    text = (ROOT / 'install.sh').read_text(encoding='utf-8')
+    assert text.rindex('require_active_login') < text.rindex('verify_mcp_tools \"$DEST_PATH\"')
+    assert 'verify_mcp_tools \"$STAGING_PATH\"' not in text
+
+
+def test_powershell_defers_mcp_handshake_until_after_login():
+    text = (ROOT / 'install.ps1').read_text(encoding='utf-8')
+    assert text.rindex('Require-ActiveLogin') < text.rindex('Test-McpToolSurface $DestPath')
+    assert 'Test-McpToolSurface $StagingPath' not in text


### PR DESCRIPTION
## Summary
- keep staged validation offline on clean HOME
- move authenticated MCP initialize/tools/list after Google login
- apply the same ordering to doctor and PowerShell
- add cross-platform bootstrap contract tests

Closes #87

## Verification
- Simplicio Mapper: context pack complete / gate ready
- Simplicio Dev CLI mechanical-edit: applied with passing validation
- `sh -n install.sh`
- clean-bootstrap contract: PASS