### PR TITLE
fix(issue-88): verify Ed25519 signatures in installers

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -34,7 +34,9 @@ $Repo = "wesleysimplicio/simplicio"
 $BinName = "simplicio.exe"
 $Target = "windows-x64"
 $Asset = "simplicio-windows-x64.exe"
-
+$Ed25519PublicKey = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
+$Ed25519HelperUrl = "https://raw.githubusercontent.com/$Repo/master/scripts/verify_ed25519.py"
+$Ed25519HelperSha256 = "6d25fed7ea3d45db4a184d0c499511d235931b2693e5d8369851d27b349d932b"
 if ($env:SIMPLICIO_BIN_DIR) {
   $InstallDir = $env:SIMPLICIO_BIN_DIR
 } else {
@@ -73,6 +75,25 @@ function Test-RuntimeReleaseContract([string]$BinaryPath) {
   )
 }
 
+function Test-Ed25519Signature([string]$BinaryPath, [string]$Signature, [string]$PublicKey, [string]$Digest) {
+  $helperPath = Join-Path ([IO.Path]::GetTempPath()) ("simplicio-verify-$([guid]::NewGuid().ToString('N')).py")
+  try {
+    $python = $null
+    $pythonArgs = @()
+    if (Get-Command python3 -ErrorAction SilentlyContinue) { $python = "python3" }
+    elseif (Get-Command py -ErrorAction SilentlyContinue) { $python = "py"; $pythonArgs = @('-3') }
+    if (-not $python) { return $false }
+    Invoke-WebRequest -Uri $Ed25519HelperUrl -OutFile $helperPath -UseBasicParsing -ErrorAction Stop
+    $helperHash = (Get-FileHash -Path $helperPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($helperHash -ne $Ed25519HelperSha256.ToLowerInvariant()) { return $false }
+    & $python @pythonArgs $helperPath --public-key $PublicKey --signature $Signature --sha256 $Digest
+    return ($LASTEXITCODE -eq 0)
+  } catch {
+    return $false
+  } finally {
+    Remove-Item -Force $helperPath -ErrorAction SilentlyContinue
+  }
+}
 function Test-McpToolSurface([string]$BinaryPath) {
   if (-not (Test-Path $BinaryPath)) { return $false }
   $required = @(
@@ -408,6 +429,7 @@ try {
 $ExpectedSha256 = $null
 $ExpectedSigned = $false
 $ExpectedSignature = $null
+$ExpectedPublicKey = $null
 $SignatureRequired = $false
 if ($Manifest) {
   $artifact = $Manifest.artifacts | Where-Object { $_.target -eq $Target } | Select-Object -First 1
@@ -416,14 +438,21 @@ if ($Manifest) {
     $ExpectedSigned = [bool]$artifact.signed -or ([string]$artifact.signature).StartsWith("ed25519:")
     $ExpectedSignature = $artifact.signature
   }
+  $ExpectedPublicKey = [string]$Manifest.signing_pubkey
   $SignatureRequired = [bool]$Manifest.security.signature_required
 }
 
 if ($SignatureRequired -and (-not $ExpectedSigned -or [string]::IsNullOrWhiteSpace([string]$ExpectedSignature))) {
   Write-Error "Refusing to install: the manifest requires an Ed25519 signature, but target '$Target' has no published signature."
   exit 1
+} elseif ($SignatureRequired -and $ExpectedPublicKey -ne $Ed25519PublicKey) {
+  Write-Error "Refusing to install: manifest Ed25519 public key does not match the pinned installer key."
+  exit 1
 } elseif (-not $ExpectedSha256) {
-  if ($env:SIMPLICIO_ALLOW_UNVERIFIED -eq "1") {
+  if ($ExpectedSigned) {
+    Write-Error "Refusing to install: published Ed25519 signature has no verifiable SHA256 digest."
+    exit 1
+  } elseif ($env:SIMPLICIO_ALLOW_UNVERIFIED -eq "1") {
     Write-Host "  ! no published checksum for target '$Target' — proceeding UNVERIFIED (SIMPLICIO_ALLOW_UNVERIFIED=1)"
   } else {
     Write-Error "Refusing to install: no published SHA256 checksum for target '$Target' in the update manifest. Set SIMPLICIO_ALLOW_UNVERIFIED=1 to override at your own risk."
@@ -462,6 +491,14 @@ if ($ExpectedSha256) {
   Write-Host "  ✓ SHA256 verified: $actualSha256"
 }
 
+if ($ExpectedSigned) {
+  if ($ExpectedPublicKey -ne $Ed25519PublicKey -or -not (Test-Ed25519Signature $StagingPath ([string]$ExpectedSignature) $Ed25519PublicKey ([string]$ExpectedSha256))) {
+    Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
+    Write-Error "Ed25519 signature verification failed; refusing to install."
+    exit 1
+  }
+  Write-Host "  ✓ Ed25519 signature verified over SHA256 digest"
+}
 # A clean HOME has no authenticated session yet. Validate only the offline
 # Runtime release contract before the swap; MCP initialize/tools/list runs
 # after Require-ActiveLogin below.

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,9 @@ set -eu
 
 REPO="wesleysimplicio/simplicio"
 GITHUB="https://github.com/$REPO"
+ED25519_PUBLIC_KEY="2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
+ED25519_HELPER_URL="https://raw.githubusercontent.com/$REPO/master/scripts/verify_ed25519.py"
+ED25519_HELPER_SHA256="6d25fed7ea3d45db4a184d0c499511d235931b2693e5d8369851d27b349d932b"
 BIN_NAME="simplicio"
 
 GREEN='\033[0;32m'
@@ -83,6 +86,20 @@ fetch_url() {
   fi
 }
 
+verify_ed25519_signature() {
+  binary_path="$1"
+  signature="$2"
+  public_key="$3"
+  digest="$4"
+  helper_path="$5"
+  if ! command -v python3 >/dev/null 2>&1 || ! fetch_url "$ED25519_HELPER_URL" "$helper_path" 2>/dev/null; then
+    return 1
+  fi
+  if [ "$(sha256_of "$helper_path")" != "$ED25519_HELPER_SHA256" ]; then
+    return 1
+  fi
+  python3 "$helper_path" --public-key "$public_key" --signature "$signature" --sha256 "$digest" >/dev/null 2>&1
+}
 configure_codex_stdio() {
   codex_dir="${CODEX_HOME:-$HOME/.codex}"
   codex_config="$codex_dir/config.toml"
@@ -507,6 +524,7 @@ if [ "$SKIP_EXISTING" != "true" ]; then
   EXPECTED_SHA256=""
   SIGNED="false"
   SIGNATURE=""
+  SIGNING_PUBKEY=""
   SIGNATURE_REQUIRED="false"
   MANIFEST_TMP="$(mktemp)"
   trap 'rm -f "$MANIFEST_TMP"' EXIT
@@ -546,6 +564,14 @@ try:
 except Exception:
     pass
 " 2>/dev/null)"
+      SIGNING_PUBKEY="$(python3 -c "
+import json
+try:
+    m = json.load(open('$MANIFEST_TMP'))
+    print(m.get('signing_pubkey') or '')
+except Exception:
+    pass
+" 2>/dev/null)"
       SIGNATURE_REQUIRED="$(python3 -c "
 import json
 try:
@@ -559,8 +585,12 @@ except Exception:
 
   if [ "$SIGNATURE_REQUIRED" = "true" ] && { [ "$SIGNED" != "true" ] || [ -z "$SIGNATURE" ]; }; then
     err "recusando instalar: o manifest exige assinatura Ed25519, mas o artefato '$TARGET_ID' não tem uma assinatura publicada"
+  elif [ "$SIGNATURE_REQUIRED" = "true" ] && [ "$SIGNING_PUBKEY" != "$ED25519_PUBLIC_KEY" ]; then
+    err "recusando instalar: a chave pública Ed25519 do manifest não corresponde à chave pinada"
   elif [ -z "$EXPECTED_SHA256" ]; then
-    if [ "${SIMPLICIO_ALLOW_UNVERIFIED:-}" = "1" ]; then
+    if [ "$SIGNED" = "true" ]; then
+      err "recusando instalar: assinatura Ed25519 publicada sem digest SHA256 verificável"
+    elif [ "${SIMPLICIO_ALLOW_UNVERIFIED:-}" = "1" ]; then
       warn "sem checksum publicado para o alvo '$TARGET_ID' — prosseguindo SEM VERIFICAÇÃO (SIMPLICIO_ALLOW_UNVERIFIED=1)"
     else
       err "recusando instalar: nenhum SHA256 publicado no manifest para o alvo '$TARGET_ID'. Defina SIMPLICIO_ALLOW_UNVERIFIED=1 para prosseguir por sua conta e risco."
@@ -587,6 +617,15 @@ except Exception:
     ok "SHA256 verificado: $ACTUAL_SHA256"
   fi
 
+  if [ "$SIGNED" = "true" ]; then
+    SIGNATURE_HELPER_TMP="$(mktemp)"
+    if [ "$SIGNING_PUBKEY" != "$ED25519_PUBLIC_KEY" ] || ! verify_ed25519_signature "$STAGING_PATH" "$SIGNATURE" "$ED25519_PUBLIC_KEY" "$EXPECTED_SHA256" "$SIGNATURE_HELPER_TMP"; then
+      rm -f "$STAGING_PATH" "$SIGNATURE_HELPER_TMP"
+      err "assinatura Ed25519 inválida ou não verificável; instalação recusada"
+    fi
+    rm -f "$SIGNATURE_HELPER_TMP"
+    ok "assinatura Ed25519 verificada sobre o digest SHA256"
+  fi
   chmod +x "$STAGING_PATH"
   # A clean HOME has no authenticated session yet. Validate only the offline
   # Runtime release contract before the swap; MCP initialize/tools/list is an

--- a/scripts/verify_ed25519.py
+++ b/scripts/verify_ed25519.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Minimal RFC 8032 Ed25519 verifier for installer bootstrap trust."""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import sys
+
+Q = 2**255 - 19
+L = 2**252 + 27742317777372353535851937790883648493
+D = (-121665 * pow(121666, Q - 2, Q)) % Q
+I = pow(2, (Q - 1) // 4, Q)
+B_Y = 4 * pow(5, Q - 2, Q) % Q
+
+def inv(x: int) -> int:
+    return pow(x, Q - 2, Q)
+
+def x_recover(y: int) -> int:
+    xx = (y * y - 1) * inv(D * y * y + 1) % Q
+    x = pow(xx, (Q + 3) // 8, Q)
+    if (x * x - xx) % Q:
+        x = x * I % Q
+    if (x * x - xx) % Q:
+        raise ValueError("invalid Ed25519 point")
+    return x
+
+def decode_point(raw: bytes) -> tuple[int, int]:
+    if len(raw) != 32:
+        raise ValueError("Ed25519 point must be 32 bytes")
+    value = int.from_bytes(raw, "little")
+    sign = value >> 255
+    y = value & ((1 << 255) - 1)
+    if y >= Q:
+        raise ValueError("invalid Ed25519 y coordinate")
+    x = x_recover(y)
+    if (x & 1) != sign:
+        x = Q - x
+    return x, y
+
+def encode_point(point: tuple[int, int]) -> bytes:
+    x, y = point
+    return ((y | ((x & 1) << 255))).to_bytes(32, "little")
+
+def add(P: tuple[int, int], R: tuple[int, int]) -> tuple[int, int]:
+    x1, y1 = P
+    x2, y2 = R
+    denominator_x = inv(1 + D * x1 * x2 * y1 * y2)
+    denominator_y = inv(1 - D * x1 * x2 * y1 * y2)
+    return ((x1 * y2 + x2 * y1) * denominator_x % Q,
+            (y1 * y2 + x1 * x2) * denominator_y % Q)
+
+def scalar_mult(point: tuple[int, int], scalar: int) -> tuple[int, int]:
+    result = (0, 1)
+    current = point
+    while scalar:
+        if scalar & 1:
+            result = add(result, current)
+        current = add(current, current)
+        scalar >>= 1
+    return result
+
+B = (x_recover(B_Y), B_Y)
+if B[0] & 1:
+    B = (Q - B[0], B[1])
+
+def verify(public_key: bytes, signature: bytes, message: bytes) -> bool:
+    if len(public_key) != 32 or len(signature) != 64:
+        return False
+    try:
+        A = decode_point(public_key)
+        R = decode_point(signature[:32])
+    except ValueError:
+        return False
+    S = int.from_bytes(signature[32:], "little")
+    if S >= L:
+        return False
+    h = int.from_bytes(hashlib.sha512(signature[:32] + public_key + message).digest(), "little") % L
+    return encode_point(scalar_mult(B, S)) == encode_point(add(R, scalar_mult(A, h)))
+
+def parse_signature(value: str) -> bytes:
+    if not value.startswith("ed25519:"):
+        raise ValueError("signature must use ed25519:<base64> format")
+    return base64.b64decode(value[8:], validate=True)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--public-key", required=True, help="base64 raw Ed25519 public key")
+    parser.add_argument("--signature", required=True, help="ed25519:<base64> manifest signature")
+    parser.add_argument("--sha256", required=True, help="hex SHA-256 digest; the raw 32-byte digest is signed")
+    args = parser.parse_args(argv)
+    try:
+        digest = bytes.fromhex(args.sha256)
+        if len(digest) != 32:
+            raise ValueError("SHA-256 digest must be 32 bytes")
+        public_key = base64.b64decode(args.public_key, validate=True)
+        signature = parse_signature(args.signature)
+    except (ValueError, base64.binascii.Error) as exc:
+        print(f"invalid Ed25519 verification input: {exc}", file=sys.stderr)
+        return 2
+    if not verify(public_key, signature, digest):
+        print("Ed25519 signature verification failed", file=sys.stderr)
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ed25519_verification.py
+++ b/tests/test_ed25519_verification.py
@@ -1,0 +1,36 @@
+import base64
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+HELPER = ROOT / 'scripts' / 'verify_ed25519.py'
+# RFC 8032 public key, with a deterministic 32-byte zero digest payload.
+RFC_PUBLIC_KEY = base64.b64encode(bytes.fromhex('d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a')).decode()
+RFC_SIGNATURE = 'NVx0BTo4CrWLKY3iOtzKSfObfKUKLOxbhh9sf934fIpTt4x7s5WSaMDbHt6wRAeGg5713vqtYjKQB2GYVgs8Ag=='
+
+
+def run(signature=RFC_SIGNATURE, digest='00' * 32):
+    return subprocess.run([
+        sys.executable, str(HELPER), '--public-key', RFC_PUBLIC_KEY,
+        '--signature', 'ed25519:' + signature, '--sha256', digest,
+    ], capture_output=True, text=True)
+
+
+def test_rfc8032_signature_is_accepted():
+    result = run()
+    assert result.returncode == 0, result.stderr
+
+
+def test_tampered_signature_is_rejected():
+    tampered = ('A' if RFC_SIGNATURE[0] != 'A' else 'B') + RFC_SIGNATURE[1:]
+    assert run(tampered).returncode != 0
+
+
+def test_installers_pin_and_invoke_crypto_verification():
+    shell = (ROOT / 'install.sh').read_text(encoding='utf-8')
+    powershell = (ROOT / 'install.ps1').read_text(encoding='utf-8')
+    assert 'ED25519_PUBLIC_KEY' in shell and 'verify_ed25519_signature' in shell
+    assert '$Ed25519PublicKey' in powershell and 'Test-Ed25519Signature' in powershell
+    assert 'SIMPLICIO_ALLOW_UNVERIFIED' in shell and 'SIMPLICIO_ALLOW_UNVERIFIED' in powershell


### PR DESCRIPTION
## Summary
- add a dependency-free RFC 8032 Ed25519 verifier
- pin the release public key and helper SHA-256 in shell and PowerShell installers
- verify the raw SHA-256 digest after checksum validation and fail closed
- restore executable installer/helper modes
- add accepted/tampered signature contract tests

Closes #88

## Verification
- Simplicio Mapper: context pack complete / gate ready
- Simplicio Dev CLI mechanical-edit: applied with passing validation
- Ed25519 RFC-derived vector: PASS
- tampered signature: rejected
- `sh -n install.sh`
- `git diff --check`