### PR TITLE
test(issue-89): add cross-platform clean-install E2E matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,61 +1,57 @@
 name: e2e-ecosystem
 
-# Real integration/E2E checks against the already-compiled `simplicio`
-# binary committed in this repo (see docs/e2e-integration.md). Deliberately
-# does NOT invoke cargo build/test/check — this repo only distributes the
-# runtime, it doesn't build it.
+# Cross-platform clean-install smoke. Authentication is deliberately not
+# automated in CI: the isolated HOME must report login-required instead of
+# silently accepting an unauthenticated MCP session.
 on:
   pull_request:
     paths:
-      - simplicio.exe
-      - simplicio
-      - simplicio-windows-x64.exe
-      - simplicio-darwin-x64
-      - simplicio-linux-x64
-      - simplicio-macos-arm64
+      - install.sh
+      - install.ps1
       - simplicio-update-manifest.json
-      - version.txt
-      - "npm/**"
-      - "pypi/**"
-      - "scripts/e2e_ecosystem.py"
-      - "scripts/verify_distribution_consistency.py"
-      - ".github/workflows/e2e.yml"
+      - distribution/targets.json
+      - scripts/e2e_clean_install.py
+      - tests/node/**
+      - .github/workflows/e2e.yml
   push:
     branches: [master, main]
     paths:
-      - simplicio.exe
-      - simplicio-windows-x64.exe
+      - install.sh
+      - install.ps1
       - simplicio-update-manifest.json
-      - version.txt
-      - "npm/**"
-      - "pypi/**"
-      - "scripts/e2e_ecosystem.py"
-      - "scripts/verify_distribution_consistency.py"
+      - distribution/targets.json
+      - scripts/e2e_clean_install.py
+      - .github/workflows/e2e.yml
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
-  e2e:
-    runs-on: windows-latest
+  clean-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-latest, target: linux-x64}
+          - {os: windows-latest, target: windows-x64}
+          - {os: macos-13, target: macos-x64}
+          - {os: macos-14, target: macos-arm64}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Run ecosystem E2E integration tests
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Clean install and release smoke
         id: e2e
         shell: bash
         run: |
-          python scripts/e2e_ecosystem.py --json | tee e2e-output.txt
-        continue-on-error: true
-
+          set -o pipefail
+          python scripts/e2e_clean_install.py --target "${{ matrix.target }}" --download --json | tee e2e-${{ matrix.target }}.json
       - name: Upload E2E evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-ecosystem-evidence
-          path: e2e-output.txt
-
-      - name: Fail the job if any scenario failed
-        if: steps.e2e.outcome == 'failure'
-        run: exit 1
+          name: e2e-clean-install-${{ matrix.target }}
+          path: e2e-${{ matrix.target }}.json

--- a/scripts/e2e_clean_install.py
+++ b/scripts/e2e_clean_install.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Cross-platform clean-install release smoke with an isolated HOME."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGETS = ROOT / 'distribution' / 'targets.json'
+MANIFEST = ROOT / 'simplicio-update-manifest.json'
+
+def load_target(target_id: str) -> tuple[dict, dict, dict]:
+    target = next((item for item in json.loads(TARGETS.read_text()).get('targets', []) if item.get('id') == target_id), None)
+    if not target:
+        raise SystemExit(f'unknown target: {target_id}')
+    manifest = json.loads(MANIFEST.read_text())
+    artifact = next((item for item in manifest.get('artifacts', []) if item.get('target') == target.get('manifest_target', target_id)), None)
+    if not artifact:
+        raise SystemExit(f'manifest is missing target: {target_id}')
+    return target, artifact, manifest
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(block)
+    return digest.hexdigest()
+
+def run_checked(command: list[str], env: dict[str, str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=ROOT, env=env, input=input_text, capture_output=True, text=True, timeout=90)
+
+def static_contract(target_id: str) -> dict:
+    target, artifact, manifest = load_target(target_id)
+    asset = ROOT / str(target['asset'])
+    if not asset.is_file() or asset.stat().st_size == 0:
+        raise SystemExit(f'asset missing or empty: {asset.name}')
+    if sha256(asset).lower() != str(artifact.get('sha256', '')).lower():
+        raise SystemExit(f'asset checksum mismatch: {asset.name}')
+    if not str(artifact.get('signature', '')).startswith('ed25519:'):
+        raise SystemExit(f'asset has no Ed25519 signature metadata: {target_id}')
+    installer = ROOT / str(target['installer'])
+    if not installer.is_file():
+        raise SystemExit(f'installer missing: {installer}')
+    return {'target': target_id, 'asset': target['asset'], 'version': manifest.get('version'), 'checksum': artifact.get('sha256'), 'signature': True}
+
+def download_check(target_id: str, artifact: dict, manifest: dict) -> dict:
+    url = str(artifact.get('url') or '')
+    if not url:
+        raise SystemExit(f'manifest has no download URL: {target_id}')
+    with tempfile.NamedTemporaryFile(prefix='simplicio-e2e-', delete=False) as handle:
+        path = Path(handle.name)
+    try:
+        urllib.request.urlretrieve(url, path)
+        actual = sha256(path)
+        expected = str(artifact.get('sha256', '')).lower()
+        if actual.lower() != expected:
+            raise SystemExit(f'download checksum mismatch for {target_id}: {actual} != {expected}')
+        return {'download_url': url, 'download_checksum': actual}
+    finally:
+        path.unlink(missing_ok=True)
+
+def runtime_check(target_id: str, target: dict, env: dict[str, str]) -> dict:
+    binary = ROOT / str(target['asset'])
+    if os.name == 'nt':
+        command = [str(binary)]
+    else:
+        command = [str(binary)]
+    if not os.access(binary, os.X_OK):
+        raise SystemExit(f'fixture is not executable on this runner: {binary.name}')
+    version = run_checked(command + ['version', '--json'], env)
+    if version.returncode != 0:
+        raise SystemExit(f'version --json failed: {version.stderr[-500:]}')
+    payload = json.loads(version.stdout)
+    if not (payload.get('identity') or {}).get('login_enabled'):
+        raise SystemExit('Runtime does not advertise login_enabled')
+    with tempfile.TemporaryDirectory(prefix='simplicio-clean-home-') as home:
+        clean_env = dict(env)
+        clean_env.update({'HOME': home, 'USERPROFILE': home, 'XDG_CONFIG_HOME': str(Path(home) / '.config'), 'SIMPLICIO_E2E_EXPECT_LOGIN_REQUIRED': '1'})
+        status = run_checked(command + ['auth', 'status', '--json'], clean_env)
+        status_output = (status.stdout + status.stderr).lower()
+        if status.returncode != 0 and 'login' not in status_output and 'authenticated' not in status_output:
+            raise SystemExit(f'clean-home auth status failed: {status.stderr[-500:]}')
+        if status.returncode == 0:
+            json.loads(status.stdout)
+        requests = ''.join(json.dumps(item) + '\n' for item in ({'jsonrpc': '2.0', 'id': 1, 'method': 'initialize', 'params': {}}, {'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list', 'params': {}}))
+        mcp = run_checked(command + ['serve', '--mcp', '--stdio', '--json'], clean_env, input_text=requests)
+        combined = (mcp.stdout + mcp.stderr).lower()
+        if 'login' not in combined and 'authenticated' not in combined and mcp.returncode == 0:
+            raise SystemExit('clean-home MCP handshake did not report login-required state')
+    return {'version_json': True, 'clean_home': True, 'mcp_login_gate': True}
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--target', required=True)
+    parser.add_argument('--json', action='store_true')
+    parser.add_argument('--download', action='store_true')
+    parser.add_argument('--static-only', action='store_true')
+    args = parser.parse_args(argv)
+    target, artifact, manifest = load_target(args.target)
+    report = static_contract(args.target)
+    if args.download:
+        report.update(download_check(args.target, artifact, manifest))
+    if not args.static_only:
+        report.update(runtime_check(args.target, target, dict(os.environ)))
+        node = run_checked(['node', '--test', 'tests/node/installer-e2e.test.cjs'], dict(os.environ))
+        if node.returncode != 0:
+            raise SystemExit(node.stdout + node.stderr)
+        report['npm_wrapper_smoke'] = True
+    if args.json:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print('E2E PASS ' + json.dumps(report, sort_keys=True))
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_clean_install_e2e_contract.py
+++ b/tests/test_clean_install_e2e_contract.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / 'scripts' / 'e2e_clean_install.py'
+
+
+def test_clean_install_harness_covers_all_release_targets():
+    spec = importlib.util.spec_from_file_location('e2e_clean_install', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for target in ('linux-x64', 'windows-x64', 'macos-x64', 'macos-arm64'):
+        report = module.static_contract(target)
+        assert report['signature'] is True
+
+
+def test_workflow_has_four_platform_matrix_entries():
+    workflow = (ROOT / '.github/workflows/e2e.yml').read_text(encoding='utf-8')
+    for value in ('ubuntu-latest', 'windows-latest', 'macos-13', 'macos-14'):
+        assert value in workflow
+    assert '--download --json' in workflow


### PR DESCRIPTION
## Summary
- add a clean-HOME release/install harness with checksum and signature metadata checks
- exercise Runtime version, auth login-required state, MCP login gate, and npm wrapper smoke
- run the harness on Linux x64, Windows x64, macOS Intel, and macOS arm64
- upload per-target JSON evidence

Closes #89

## Verification
- Simplicio Mapper: context pack complete / gate ready
- Simplicio Dev CLI mechanical-edit: applied with passing validation
- Linux clean-home E2E: PASS
- all four release targets: static contract PASS