### PR TITLE
fix(issue-90): make Codex integration opt-in and reversible

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -227,7 +227,9 @@ function Install-CodexIntegration {
   New-Item -ItemType Directory -Force -Path $codexDir, $hookDir | Out-Null
 
   Write-Host "==> configuring Codex STDIO MCP and hooks"
-  $hookRef = if ($env:SIMPLICIO_CODEX_HOOK_REF) { $env:SIMPLICIO_CODEX_HOOK_REF } else { "master" }
+  $installedVersion = (& $DestPath --version 2>$null | Select-Object -First 1).Split(' ')[1].TrimStart('v')
+  $hookRef = if ($env:SIMPLICIO_CODEX_HOOK_REF) { $env:SIMPLICIO_CODEX_HOOK_REF } else { "v$installedVersion" }
+  if ([string]::IsNullOrWhiteSpace($installedVersion)) { throw "could not derive a versioned Codex hook ref" }
   $hookUrl = "https://raw.githubusercontent.com/$Repo/$hookRef/codex/mcp-route.ps1"
   try {
     Invoke-WebRequest -Uri $hookUrl -OutFile $hookTemp -UseBasicParsing -ErrorAction Stop
@@ -550,11 +552,13 @@ if (-not (Test-McpToolSurface $DestPath)) {
   Write-Error "This Runtime does not expose the complete MCP tool surface after login; refusing to finish installation."
   exit 1
 }
-Write-Host "  ✓ MCP tool surface verified (10 documented tools)"
-
-# Codex runs the installed binary directly over STDIO. Existing settings and
-# hooks are merged, not replaced.
-Install-CodexIntegration
+# Codex integration is opt-in. MCP registration and routing hooks remain
+# separate, and the hook reference is versioned/pinned inside the function.
+if ($env:SIMPLICIO_INSTALL_CODEX -eq "1") {
+  Install-CodexIntegration
+} else {
+  Write-Host "==> Codex integration not installed automatically; set SIMPLICIO_INSTALL_CODEX=1 to enable"
+}
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
 New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,9 @@ configure_codex_stdio() {
   mkdir -p "$codex_dir" "$hook_dir"
 
   info "Configurando MCP stdio e hooks do Codex"
-  hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-master}"
+  installed_version="$("$DEST_PATH" --version 2>/dev/null | awk 'NR == 1 {print $2; exit}' | sed 's/^v//')"
+  hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-v${installed_version:-unknown}}"
+  [ "$hook_ref" != "vunknown" ] || err "não foi possível derivar uma referência versionada para o hook do Codex"
   fetch_url "$GITHUB/raw/$hook_ref/codex/mcp-route.sh" "$hook_tmp" || err "não foi possível baixar o hook do Codex"
   chmod 755 "$hook_tmp"
   mv -f "$hook_tmp" "$hook_path"
@@ -659,11 +661,13 @@ if ! verify_mcp_tools "$DEST_PATH"; then
   err "este Runtime não expõe a superfície MCP completa após o login; instalação interrompida"
 fi
 ok "superfície MCP verificada (10 tools documentadas)"
-
-# Codex runs the installed binary directly over STDIO. This avoids the local
-# HTTP daemon latency and keeps the same Google login/entitlement gate in the
-# Runtime process. Existing Codex settings and hooks are merged, not replaced.
-configure_codex_stdio
+# Codex integration is opt-in. MCP registration and routing hooks remain
+# separate, and the hook reference is versioned/pinned inside the function.
+if [ "${SIMPLICIO_INSTALL_CODEX:-0}" = "1" ]; then
+  configure_codex_stdio
+else
+  info "integração Codex não instalada automaticamente; use SIMPLICIO_INSTALL_CODEX=1 para ativá-la"
+fi
 
 # Adiciona ao PATH se não estiver
 case ":$PATH:" in

--- a/scripts/codex_integration.py
+++ b/scripts/codex_integration.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Transactional, opt-in Codex MCP/hook integration manager."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+MARKER = '# BEGIN SIMPLICIO CODEX INTEGRATION v1'
+END_MARKER = '# END SIMPLICIO CODEX INTEGRATION v1'
+
+def paths(home: Path) -> tuple[Path, Path, Path, Path]:
+    # --home is an explicit isolation boundary for installers, tests, and repair.
+    # Do not let a process-wide CODEX_HOME redirect writes outside that boundary.
+    codex = home / '.codex'
+    return codex / 'config.toml', codex / 'hooks.json', home / '.simplicio' / 'hooks', home / '.simplicio' / 'codex-integration.json'
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw = tempfile.mkstemp(prefix=path.name + '.', dir=str(path.parent))
+    temp = Path(raw)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            handle.write(text)
+        os.replace(temp, path)
+    finally:
+        temp.unlink(missing_ok=True)
+
+def backup_once(path: Path) -> None:
+    backup = Path(str(path) + '.simplicio.bak')
+    if path.exists() and not backup.exists():
+        shutil.copy2(path, backup)
+
+def hook_source(root: Path, platform: str) -> Path:
+    return root / 'codex' / ('mcp-route.ps1' if platform == 'windows' else 'mcp-route.sh')
+
+def load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    value = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(value, dict):
+        raise ValueError(f'{path} must contain an object')
+    return value
+
+def install(args: argparse.Namespace) -> dict:
+    config_path, hooks_path, hook_dir, state_path = paths(args.home)
+    source = hook_source(args.source_root, args.platform)
+    if not source.is_file():
+        raise SystemExit(f'hook source not found: {source}')
+    backup_once(config_path); backup_once(hooks_path)
+    hook_path = hook_dir / source.name
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, hook_path)
+    if hook_path.suffix == '.sh':
+        hook_path.chmod(0o755)
+    config = config_path.read_text(encoding='utf-8') if config_path.exists() else ''
+    while MARKER in config and END_MARKER in config:
+        start = config.index(MARKER); end = config.index(END_MARKER, start) + len(END_MARKER)
+        config = config[:start] + config[end:]
+    binary = args.binary or 'simplicio'
+    block = f'{MARKER}\n[mcp_servers.simplicio]\ncommand = {json.dumps(binary)}\nargs = ["serve", "--mcp", "--stdio"]\n{END_MARKER}\n'
+    config = config.rstrip() + ('\n\n' if config.strip() else '') + block
+    atomic_write(config_path, config)
+    root = load_json(hooks_path)
+    hook_root = root.setdefault('hooks', {})
+    if not isinstance(hook_root, dict):
+        raise SystemExit('hooks.json has an invalid hooks object')
+    entries = hook_root.setdefault('PreToolUse', [])
+    if isinstance(entries, dict): entries = [entries]
+    entries = [item for item in entries if not (isinstance(item, dict) and any('mcp-route' in str(h.get('command', '')) for h in item.get('hooks', []) if isinstance(h, dict)))]
+    command = f'powershell -NoProfile -ExecutionPolicy Bypass -File "{hook_path}"' if args.platform == 'windows' else f'bash "{hook_path}"'
+    entries.append({'matcher': 'Bash|apply_patch|Edit|Write', 'hooks': [{'type': 'command', 'command': command, 'timeout': 8, 'statusMessage': 'Routing through Simplicio MCP'}]})
+    hook_root['PreToolUse'] = entries
+    root['simplicio'] = {'managed': True, 'version': args.version, 'hook_ref': args.hook_ref, 'mcp_separate_from_hooks': True}
+    atomic_write(hooks_path, json.dumps(root, indent=2) + '\n')
+    atomic_write(state_path, json.dumps(root['simplicio'], indent=2) + '\n')
+    return {'status': 'installed', 'version': args.version, 'hook_ref': args.hook_ref, 'config': str(config_path), 'hooks': str(hooks_path)}
+
+def uninstall(args: argparse.Namespace) -> dict:
+    config_path, hooks_path, hook_dir, state_path = paths(args.home)
+    for path in (config_path, hooks_path):
+        backup = Path(str(path) + '.simplicio.bak')
+        if backup.exists():
+            shutil.copy2(backup, path)
+    for hook in (hook_dir / 'mcp-route.sh', hook_dir / 'mcp-route.ps1'):
+        hook.unlink(missing_ok=True)
+    if state_path.exists(): state_path.unlink()
+    return {'status': 'uninstalled', 'preserved_data': True}
+
+def status(args: argparse.Namespace) -> dict:
+    _, _, _, state_path = paths(args.home)
+    state = load_json(state_path) if state_path.exists() else {}
+    return {'status': 'installed' if state.get('managed') else 'absent', 'state': state}
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('command', choices=('status', 'install', 'uninstall', 'repair'))
+    parser.add_argument('--home', type=Path, default=Path.home())
+    parser.add_argument('--source-root', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--binary', default='simplicio')
+    parser.add_argument('--version', default=os.environ.get('SIMPLICIO_VERSION', 'unknown'))
+    parser.add_argument('--hook-ref', default=os.environ.get('SIMPLICIO_CODEX_HOOK_REF', ''))
+    parser.add_argument('--platform', choices=('unix', 'windows'), default='windows' if os.name == 'nt' else 'unix')
+    args = parser.parse_args(argv)
+    if args.command == 'status': result = status(args)
+    elif args.command == 'uninstall': result = uninstall(args)
+    else:
+        if not args.hook_ref: raise SystemExit('hook ref is required; use --hook-ref vX.Y.Z')
+        result = install(args)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_codex_integration_cli.py
+++ b/tests/test_codex_integration_cli.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / 'scripts/codex_integration.py'
+
+
+def call(home, *args):
+    return subprocess.run([sys.executable, str(SCRIPT), *args, '--home', str(home), '--source-root', str(ROOT)], capture_output=True, text=True)
+
+
+def test_cli_install_status_uninstall_is_reversible():
+    with tempfile.TemporaryDirectory() as raw:
+        home = Path(raw)
+        installed = call(home, 'install', '--platform', 'unix', '--version', 'v3.8.16', '--hook-ref', 'v3.8.16')
+        assert installed.returncode == 0, installed.stderr
+        state = json.loads(call(home, 'status').stdout)
+        assert state['status'] == 'installed'
+        assert 'mcp_servers.simplicio' in (home / '.codex/config.toml').read_text()
+        removed = call(home, 'uninstall')
+        assert removed.returncode == 0, removed.stderr
+        assert json.loads(call(home, 'status').stdout)['status'] == 'absent'
+
+
+def test_installers_are_opt_in_and_do_not_use_mutable_master_hook_ref():
+    shell = (ROOT / 'install.sh').read_text(encoding='utf-8')
+    powershell = (ROOT / 'install.ps1').read_text(encoding='utf-8')
+    assert 'SIMPLICIO_INSTALL_CODEX' in shell and 'SIMPLICIO_INSTALL_CODEX' in powershell
+    assert 'hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-master}"' not in shell
+    assert 'else { "master" }' not in powershell


### PR DESCRIPTION
## Summary
- make Codex MCP and hook installation explicitly opt-in via `SIMPLICIO_INSTALL_CODEX=1`
- derive a versioned hook ref by default, with an explicit override for controlled pinning
- add a reversible, atomic Codex integration manager that keeps MCP registration separate from routing hooks

## Verification
- `sh -n install.sh`
- `python3 -m py_compile scripts/codex_integration.py tests/test_codex_integration_cli.py`
- isolated install/status/uninstall contract test
- `git diff --check`

Closes #90