### PR TITLE
fix(issue-91): add transactional rollback and explicit uninstall data policy

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -25,7 +25,9 @@
 param(
   [string]$Version = "",
   [switch]$Doctor,
-  [switch]$Uninstall
+  [switch]$Uninstall,
+  [switch]$KeepData,
+  [switch]$Purge
 )
 
 $ErrorActionPreference = "Stop"
@@ -43,6 +45,27 @@ if ($env:SIMPLICIO_BIN_DIR) {
   $InstallDir = "$env:USERPROFILE\.local\bin"
 }
 $DestPath = Join-Path $InstallDir $BinName
+$PreviousPath = "$DestPath.simplicio.previous"
+$InstallTransactionActive = $false
+
+function Invoke-Rollback {
+  if (-not $InstallTransactionActive) { return }
+  if (Test-Path $PreviousPath) {
+    Move-Item -Force -Path $PreviousPath -Destination $DestPath
+    Write-Warning "rollback complete: restored previous Runtime at $DestPath"
+  } elseif (Test-Path $DestPath) {
+    Remove-Item -Force $DestPath
+    Write-Warning "rollback complete: removed new Runtime; no previous version existed"
+  }
+  if ($StagingPath -and (Test-Path $StagingPath)) { Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue }
+  $script:InstallTransactionActive = $false
+}
+
+function Confirm-Purge {
+  if ($env:SIMPLICIO_CONFIRM_PURGE -eq "1") { return }
+  $answer = Read-Host "Type PURGE to delete user data under $BundleDir"
+  if ($answer -ne "PURGE") { throw "purge cancelled; confirmation must be PURGE" }
+}
 
 function Test-InPath([string]$dir) {
   return ($env:Path -split ";") -contains $dir
@@ -371,8 +394,14 @@ if ($Doctor) {
   }
 }
 
-# ─── -Uninstall: idempotent removal, safe to run repeatedly ────────────────
+# ─── -Uninstall: transactional removal with explicit data policy ────────────
 if ($Uninstall) {
+  if ($Purge -and $KeepData) { Write-Error "-KeepData and -Purge are mutually exclusive"; exit 1 }
+  $purgeData = $Purge.IsPresent
+  $bundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
+  if ($purgeData) {
+    try { Confirm-Purge } catch { Write-Error $_.Exception.Message; exit 1 }
+  }
   Write-Host "==> simplicio uninstall"
   if (Test-Path $DestPath) {
     Remove-Item -Force $DestPath
@@ -380,13 +409,15 @@ if ($Uninstall) {
   } else {
     Write-Host "  ✓ already removed (nothing at $DestPath)"
   }
-  # Data/config is intentionally preserved (idempotent, non-destructive
-  # uninstall) — user data under ~/.simplicio is never touched here.
-  Write-Host "  ✓ user data under `$env:USERPROFILE\.simplicio was preserved"
-  Write-Host ""
-  Write-Host "  Note: if you added $InstallDir to your PowerShell profile's"
-  Write-Host "  `$env:Path, remove that line manually — this script never"
-  Write-Host "  edits your profile."
+  if (Test-Path $PreviousPath) { Remove-Item -Force $PreviousPath }
+  if ($purgeData) {
+    if ([string]::IsNullOrWhiteSpace($bundleDir) -or $bundleDir -eq $env:USERPROFILE -or $bundleDir -eq "\") { Write-Error "refusing to purge a broad directory: $bundleDir"; exit 1 }
+    if (Test-Path $bundleDir) { Remove-Item -Recurse -Force $bundleDir }
+    Write-Host "  ✓ user data removed from $bundleDir"
+  } else {
+    Write-Host "  ✓ user data under $env:USERPROFILE\.simplicio was preserved (-KeepData)"
+  }
+  Write-Host "  Note: this script never edits your PATH profile."
   exit 0
 }
 
@@ -510,12 +541,18 @@ if (-not (Test-RuntimeReleaseContract $StagingPath)) {
   exit 1
 }
 
-# Atomic swap: rename into place on the same volume so there is never a
-# window where $DestPath is a half-written file, and re-running this script
-# (idempotent update) never leaves stale .tmp files behind on success.
+# Journal the previous executable before the atomic swap. Any later
+# fail-closed path restores it through Invoke-Rollback.
+if (Test-Path $DestPath) {
+  Copy-Item -Force -Path $DestPath -Destination $PreviousPath
+} elseif (Test-Path $PreviousPath) {
+  Remove-Item -Force $PreviousPath
+}
+$InstallTransactionActive = $true
 try {
   Move-Item -Force -Path $StagingPath -Destination $DestPath
 } catch {
+  Invoke-Rollback
   Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
   Write-Error "Could not move verified binary into place: $($_.Exception.Message)"
   exit 1
@@ -532,6 +569,7 @@ try {
 }
 
 if (-not (Test-RuntimeReleaseContract $DestPath)) {
+  Invoke-Rollback
   Write-Error "This Runtime does not meet the distribution contract; refusing to finish installation. Install a compatible Runtime release."
   exit 1
 }
@@ -543,19 +581,27 @@ Write-Host "  ✓ Runtime release contract verified"
 try {
   Require-ActiveLogin
 } catch {
+  Invoke-Rollback
   Write-Error $_.Exception.Message
   exit 1
 }
 Write-Host "  ✓ active Google session and entitlement verified"
 
 if (-not (Test-McpToolSurface $DestPath)) {
+  Invoke-Rollback
   Write-Error "This Runtime does not expose the complete MCP tool surface after login; refusing to finish installation."
   exit 1
 }
 # Codex integration is opt-in. MCP registration and routing hooks remain
 # separate, and the hook reference is versioned/pinned inside the function.
 if ($env:SIMPLICIO_INSTALL_CODEX -eq "1") {
-  Install-CodexIntegration
+  try {
+    Install-CodexIntegration
+  } catch {
+    Invoke-Rollback
+    Write-Error $_.Exception.Message
+    exit 1
+  }
 } else {
   Write-Host "==> Codex integration not installed automatically; set SIMPLICIO_INSTALL_CODEX=1 to enable"
 }
@@ -570,8 +616,13 @@ try {
   Write-Host "  ✓ Runtime release report: $RuntimeReport"
 } catch {
   if (Test-Path $RuntimeReport) { Remove-Item -Force $RuntimeReport -ErrorAction SilentlyContinue }
+  Invoke-Rollback
   Write-Error "Could not persist the Runtime release report: $($_.Exception.Message)"
   exit 1
+}
+if ($InstallTransactionActive) {
+  if (Test-Path $PreviousPath) { Remove-Item -Force $PreviousPath }
+  $InstallTransactionActive = $false
 }
 
 # PATH hint

--- a/install.sh
+++ b/install.sh
@@ -9,15 +9,17 @@
 #   curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
 #
 # Idempotent subcommands:
-#   sh install.sh --doctor      # health check, safe to re-run
-#   sh install.sh --uninstall   # removes the binary, preserves user data
+#   sh install.sh --doctor                    # read-only health check
+#   sh install.sh --uninstall --keep-data     # removes binary, keeps data
+#   sh install.sh --uninstall --purge         # removes binary and data (confirmed)
 #
 # Environment variables:
 #   SIMPLICIO_VERSION           - pin a specific version (default: latest)
 #   SIMPLICIO_BIN_DIR           - custom install directory
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
-#   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
+#   SIMPLICIO_BUNDLE_DIR        - bundle report/data directory
+#   SIMPLICIO_CONFIRM_PURGE     - "1" confirms non-interactive --purge
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem): id "macos-arm64" -> asset
@@ -46,10 +48,18 @@ NC='\033[0m'
 info()  { printf "${CYAN}==>${NC} %s\n" "$*"; }
 ok()    { printf "${GREEN}  ✓${NC} %s\n" "$*"; }
 warn()  { printf "${YELLOW}  ⚠${NC} %s\n" "$*"; }
-err()   { printf "${RED}  ✗${NC} %s\n" "$*"; exit 1; }
+err() {
+  printf "${RED}  ✗${NC} %s\n" "$*"
+  if [ "${INSTALL_TRANSACTION_ACTIVE:-false}" = true ]; then rollback_install; fi
+  exit 1
+}
 
 BIN_DIR="${SIMPLICIO_BIN_DIR:-$HOME/.local/bin}"
 DEST_PATH="$BIN_DIR/$BIN_NAME"
+PREVIOUS_PATH="$DEST_PATH.simplicio.previous"
+PURGE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
+INSTALL_TRANSACTION_ACTIVE=false
+UNINSTALL_KEEP_DATA=true
 
 # ─── Detect platform (canonical os/arch naming, matches distribution/targets.json) ──
 detect_platform() {
@@ -84,6 +94,19 @@ fetch_url() {
   else
     err "Precisa de curl ou wget para baixar"
   fi
+}
+
+rollback_install() {
+  [ "${INSTALL_TRANSACTION_ACTIVE:-false}" = true ] || return 0
+  if [ -f "${PREVIOUS_PATH:-}" ]; then
+    mv -f "$PREVIOUS_PATH" "$DEST_PATH" || true
+    warn "rollback concluído: versão anterior restaurada em $DEST_PATH"
+  else
+    rm -f "$DEST_PATH"
+    warn "rollback concluído: binário novo removido; não havia versão anterior"
+  fi
+  if [ -n "${STAGING_PATH:-}" ]; then rm -f "$STAGING_PATH"; fi
+  INSTALL_TRANSACTION_ACTIVE=false
 }
 
 verify_ed25519_signature() {
@@ -383,8 +406,8 @@ require_active_login() {
     return 0
   fi
   info "Login Google obrigatório para ativar o Simplicio Runtime"
-  "$DEST_PATH" login google || err "login não concluído; instalação bloqueada"
-  verify_active_login || err "sessão ausente, expirada, revogada ou sem entitlement ativo; instalação bloqueada"
+  "$DEST_PATH" login google || return 1
+  verify_active_login
 }
 
 # ─── --doctor: idempotent, read-only health check ──────────────────────────
@@ -443,26 +466,71 @@ run_doctor() {
   exit "$status"
 }
 
-# ─── --uninstall: idempotent removal, safe to run repeatedly ──────────────
+# ─── --uninstall: transactional removal with explicit data policy ──────────
+confirm_purge() {
+  if [ "${SIMPLICIO_CONFIRM_PURGE:-0}" = "1" ]; then
+    return 0
+  fi
+  if [ -t 0 ]; then
+    printf 'Digite PURGE para apagar os dados em %s: ' "$PURGE_DIR" >&2
+    IFS= read -r answer
+    [ "$answer" = "PURGE" ] || err "purge cancelado; confirme digitando PURGE"
+    return 0
+  fi
+  err "--purge exige SIMPLICIO_CONFIRM_PURGE=1 em execução não interativa"
+}
+
 run_uninstall() {
   info "simplicio uninstall"
+  if [ "$UNINSTALL_PURGE" = true ]; then
+    confirm_purge
+  fi
   if [ -e "$DEST_PATH" ]; then
     rm -f "$DEST_PATH"
     ok "removido $DEST_PATH"
   else
     ok "já estava removido (nada em $DEST_PATH)"
   fi
-  # Dados do usuário são preservados intencionalmente (uninstall idempotente
-  # e não-destrutivo) — ~/.simplicio nunca é tocado aqui.
-  ok "dados do usuário em \$HOME/.simplicio foram preservados"
-  warn "se você adicionou $BIN_DIR ao PATH no seu ~/.zshrc ou ~/.bashrc, remova a linha manualmente"
+  rm -f "$PREVIOUS_PATH"
+  if [ "$UNINSTALL_PURGE" = true ]; then
+    case "$PURGE_DIR" in
+      ""|"/"|"$HOME") err "recusando purge de um diretório amplo: $PURGE_DIR" ;;
+    esac
+    rm -rf "$PURGE_DIR"
+    ok "dados do usuário removidos de $PURGE_DIR"
+  else
+    ok "dados do usuário em $PURGE_DIR foram preservados (--keep-data)"
+  fi
+  warn "se você adicionou $BIN_DIR ao PATH no seu perfil, remova a linha manualmente"
   exit 0
 }
 
-case "${1:-}" in
-  --doctor) detect_platform; run_doctor ;;
-  --uninstall) run_uninstall ;;
-esac
+DOCTOR=false
+UNINSTALL=false
+UNINSTALL_PURGE=false
+for arg in "$@"; do
+  case "$arg" in
+    --doctor) DOCTOR=true ;;
+    --uninstall) UNINSTALL=true ;;
+    --keep-data) UNINSTALL_KEEP_DATA=true ;;
+    --purge) UNINSTALL_PURGE=true ;;
+    --help|-h)
+      printf '%s\n' 'uso: sh install.sh [--doctor] [--uninstall [--keep-data|--purge]]'
+      exit 0
+      ;;
+    *) err "argumento desconhecido: $arg" ;;
+  esac
+done
+if [ "$UNINSTALL_PURGE" = true ] && [ "${UNINSTALL:-false}" != true ]; then
+  err "--purge só pode ser usado com --uninstall"
+fi
+if [ "$DOCTOR" = true ]; then
+  detect_platform
+  run_doctor
+fi
+if [ "$UNINSTALL" = true ]; then
+  run_uninstall
+fi
 
 printf "${GREEN}"
 cat << "EOF"
@@ -637,9 +705,14 @@ except Exception:
     rm -f "$STAGING_PATH"
     err "release Runtime não atende ao contrato de distribuição; instalação interrompida"
   fi
-  # Swap atômico: mv no mesmo filesystem nunca deixa $DEST_PATH parcialmente
-  # escrito, e reexecutar este script (update idempotente) não deixa .tmp
-  # órfãos em caso de sucesso.
+  # Journal the previous executable before the atomic swap. Any later
+  # fail-closed error calls rollback_install through err().
+  if [ -e "$DEST_PATH" ]; then
+    cp -p "$DEST_PATH" "$PREVIOUS_PATH" || err "não foi possível guardar a versão anterior para rollback"
+  else
+    rm -f "$PREVIOUS_PATH"
+  fi
+  INSTALL_TRANSACTION_ACTIVE=true
   mv -f "$STAGING_PATH" "$DEST_PATH"
   ok "Simplicio Runtime instalado em $DEST_PATH"
 fi
@@ -652,7 +725,9 @@ fi
 ok "contrato de release do Runtime verificado"
 
 # ─── 2.2 Login obrigatório antes do handshake MCP ───────────────────────────
-require_active_login
+if ! require_active_login; then
+  err "login não concluído ou sessão sem entitlement ativo; instalação bloqueada"
+fi
 ok "login Google ativo e entitlement válido"
 
 # MCP tools/list is intentionally post-login: clean installs must bootstrap the
@@ -686,6 +761,10 @@ if "$DEST_PATH" version --json >"$RUNTIME_REPORT" 2>/dev/null; then
 else
   rm -f "$RUNTIME_REPORT"
   err "não foi possível persistir o contrato de release; instalação interrompida"
+fi
+if [ "${INSTALL_TRANSACTION_ACTIVE:-false}" = true ]; then
+  rm -f "$PREVIOUS_PATH"
+  INSTALL_TRANSACTION_ACTIVE=false
 fi
 
 # ─── 4. Mensagem final ───────────────────────────────────────────────────────

--- a/tests/test_install_transaction_contract.py
+++ b/tests/test_install_transaction_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_shell_uninstall_policy_and_rollback_are_explicit():
+    text = (ROOT / 'install.sh').read_text(encoding='utf-8')
+    assert '--keep-data' in text and '--purge' in text
+    assert 'SIMPLICIO_CONFIRM_PURGE' in text
+    assert 'INSTALL_TRANSACTION_ACTIVE' in text
+    assert 'PREVIOUS_PATH' in text
+    assert 'rollback_install' in text
+    assert 'rm -rf "$PURGE_DIR"' in text
+
+
+def test_powershell_uninstall_policy_and_rollback_are_explicit():
+    text = (ROOT / 'install.ps1').read_text(encoding='utf-8')
+    assert '[switch]$KeepData' in text and '[switch]$Purge' in text
+    assert 'SIMPLICIO_CONFIRM_PURGE' in text
+    assert '$InstallTransactionActive' in text
+    assert '$PreviousPath' in text
+    assert 'Invoke-Rollback' in text
+    assert 'Remove-Item -Recurse -Force $bundleDir' in text


### PR DESCRIPTION
## Summary
- journal the previous Runtime and restore it on post-swap contract, login, MCP, Codex, or report failures
- make uninstall explicit with `--keep-data` (default) and confirmed `--purge`
- add equivalent PowerShell switches and fail-closed purge confirmation

## Verification
- `sh -n install.sh`
- temporary-directory `--uninstall --purge` smoke with `SIMPLICIO_CONFIRM_PURGE=1`
- static Unix/PowerShell transaction contract tests
- Python compilation and `git diff --check`
- `pwsh` unavailable in the execution environment; PowerShell validation is static

Closes #91