### PR TITLE
fix(issue-92): enable macOS Intel installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ simplicio license status
 |---|---|---|
 | RAM | 8 GB | 16 GB+ |
 | Storage | ~35–50 MB for the release binary | 1.5 GB+ with a local LLM |
-| OS | macOS Apple Silicon, Linux x64, Windows x64 | macOS ARM64 |
+| OS | macOS Apple Silicon and Intel, Linux x64, Windows x64 | macOS ARM64 and x64 |
 | Python | Not required for the embedded Runtime projects | Current CPython 3 for optional external adapters |
 | Browser | Safari, Chrome, or another supported browser for Google login | Current Safari/Chrome |
 | Terminal | any modern terminal | WezTerm / Alacritty / Ghostty |

--- a/install.sh
+++ b/install.sh
@@ -545,9 +545,8 @@ echo ""
 # ─── 1. Detect platform ──────────────────────────────────────────────────────
 detect_platform
 info "Plataforma detectada: $OS-$ARCH"
-if [ "$OS" = "macos" ] && [ "$ARCH" = "x64" ]; then
-  err "esta release publica apenas macOS Apple Silicon; não há asset macOS Intel com checksum"
-fi
+# macOS Intel is a supported distribution target. The canonical target
+# table and signed manifest provide the macos-x64 asset/checksum mapping.
 
 # ─── 2. Instalar simplicio binary (staged download + SHA256 + atomic swap) ──
 info "Instalando Simplicio Runtime..."

--- a/tests/test_macos_x64_contract.py
+++ b/tests/test_macos_x64_contract.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_macos_x64_maps_to_signed_release_asset_and_installer():
+    targets = json.loads((ROOT / 'distribution/targets.json').read_text(encoding='utf-8'))
+    target = next(item for item in targets['targets'] if item['id'] == 'macos-x64')
+    manifest = json.loads((ROOT / 'simplicio-update-manifest.json').read_text(encoding='utf-8'))
+    artifact = next(item for item in manifest['artifacts'] if item['target'] == target['manifest_target'])
+    assert target['asset'] == 'simplicio-macos-x64'
+    assert target['installer'] == 'install.sh'
+    assert artifact['artifact'] == target['asset']
+    assert artifact['sha256']
+    assert artifact['signature'].startswith('ed25519:')
+
+
+def test_shell_installer_does_not_reject_macos_x64():
+    text = (ROOT / 'install.sh').read_text(encoding='utf-8')
+    assert 'macos-x64) MANIFEST_TARGET_ID="macos-x86_64"' in text
+    assert 'esta release publica apenas macOS Apple Silicon' not in text
+    assert 'simplicio-$OS-$ARCH' in text


### PR DESCRIPTION
## Summary
- remove the stale macOS Apple Silicon-only rejection from the Unix installer
- keep the canonical macos-x64 asset/manifest mapping and document Intel support
- add a target-to-asset-to-manifest contract test

## Verification
- `sh -n install.sh`
- macos-x64 contract tests
- `scripts/verify_distribution_consistency.py --json` (all OK)
- `git diff --check`

Closes #92