### PR TITLE
docs(issue-93): align public installation and MCP contract

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,23 +47,25 @@ then checks the Runtime readiness contract before completing installation.
 
 ## Doctor / Uninstall
 
-Both installers are idempotent and expose a health check and a clean,
-data-preserving uninstall — safe to re-run at any time:
+Both installers are idempotent and expose a read-only health check plus an
+explicit data-preserving uninstall:
 
-```bash
+~~~bash
 # macOS / Linux
 sh install.sh --doctor
-sh install.sh --uninstall
-```
+sh install.sh --uninstall --keep-data
+sh install.sh --uninstall --purge       # confirmation required
+~~~
 
-```powershell
+~~~powershell
 # Windows
 pwsh install.ps1 -Doctor
-pwsh install.ps1 -Uninstall
-```
+pwsh install.ps1 -Uninstall -KeepData
+pwsh install.ps1 -Uninstall -Purge      # confirmation required
+~~~
 
-Uninstall only removes the installed binary; it never deletes user data or
-config under `~/.simplicio`.
+Uninstall removes the installed binary and keeps user data by default. Set
+SIMPLICIO_CONFIRM_PURGE=1 for a non-interactive purge.
 
 ## Verify Installation
 
@@ -211,18 +213,18 @@ simplicio login google
 simplicio auth status --json
 ```
 
-Depois do login, o instalador configura o Codex para executar diretamente o
-binário local por STDIO e instala os hooks Simplicio em `~/.codex/hooks.json`.
-Reinicie o Codex, abra Settings → Hooks para revisar os hooks e confirme:
+Codex integration is opt-in; the base installer does not modify another
+product's configuration. To enable versioned MCP registration and managed hooks:
 
-```bash
-codex mcp list
-```
+~~~bash
+SIMPLICIO_INSTALL_CODEX=1 sh install.sh
+~~~
 
-O registro deve apontar para `simplicio serve --mcp --stdio`. O Runtime ainda
-exige login Google e entitlement ativo; nunca copie tokens manualmente para
-arquivos. Para desativar temporariamente o roteamento do hook, use
-`SIMPLICIO_MCP_ROUTE=0`.
+The registration points to simplicio serve --mcp --stdio. The Runtime still
+requires Google login and active entitlement for every local MCP session; never
+copy tokens into config files. Review enabled hooks in Settings → Hooks and use
+codex mcp list. To repair, rerun with SIMPLICIO_INSTALL_CODEX=1. Use
+SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
 
 ## Building from Source
 
@@ -253,11 +255,18 @@ cargo build --release --no-default-features --features tui
 
 ## Uninstall
 
-```bash
-# Remove the binary
-rm $(which simplicio)
+Use the installer so the binary and transaction journal are handled together:
 
-# Remove data (optional)
-rm -rf ~/.simplicio
-rm -rf .simplicio  # per-project data
-```
+~~~bash
+sh install.sh --uninstall --keep-data       # default, preserves ~/.simplicio
+sh install.sh --uninstall --purge            # removes ~/.simplicio after confirmation
+~~~
+
+~~~powershell
+pwsh install.ps1 -Uninstall -KeepData
+pwsh install.ps1 -Uninstall -Purge
+~~~
+
+Interactive purge requires typing PURGE. For non-interactive use, set
+SIMPLICIO_CONFIRM_PURGE=1. Project-local .simplicio data is not removed by
+--keep-data; inspect the target before choosing --purge.

--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -15,29 +15,28 @@ Continue only when the status reports `active: true`. Never copy a password, dev
 
 ## Codex: local STDIO MCP and hooks
 
-The official installer configures Codex to launch the installed binary directly:
+Codex integration is opt-in. The base installer leaves Codex unchanged. Enable
+the versioned, reversible integration explicitly:
 
-```toml
+~~~bash
+SIMPLICIO_INSTALL_CODEX=1 sh install.sh
+~~~
+
+When enabled, Codex launches the installed binary directly:
+
+~~~toml
 [mcp_servers.simplicio]
 command = "/path/to/simplicio"
 args = ["serve", "--mcp", "--stdio"]
-```
+~~~
 
-The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
-`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`, preserving
-unrelated user hooks. Restart Codex and review the result in **Settings →
-Hooks**. The Runtime still validates Google login and entitlement on every
-local MCP session; never paste tokens into either config file.
+STDIO is local and avoids a local HTTP daemon, but the Runtime still validates
+Google login and entitlement on every MCP session. Existing user hooks remain
+preserved; review enabled Simplicio hooks in Settings → Hooks and run codex mcp
+list. Never paste tokens into either config file.
 
-To verify the registration:
-
-```bash
-codex mcp list
-```
-
-Set `SIMPLICIO_MCP_ROUTE=0` for a temporary hook escape hatch. Rerunning the
-installer repairs the integration idempotently and leaves `.simplicio.bak`
-copies of the original Codex files.
+To repair the managed integration, rerun with SIMPLICIO_INSTALL_CODEX=1. Set
+SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
 
 ## Other clients: local STDIO
 
@@ -94,12 +93,14 @@ A successful response contains the tool definitions. A `login required` error me
 
 ## Automatic setup
 
-The official installers perform the binary checksum and embedded-bundle checks,
-require active login, and configure Codex's local STDIO MCP plus Simplicio
-hooks:
+The official installers verify the binary checksum, Ed25519 signature, and
+embedded-bundle contract, then require active login. Codex MCP registration and
+routing hooks are opt-in; enable them explicitly with SIMPLICIO_INSTALL_CODEX=1.
+Other MCP clients can use the local STDIO entry above without copying tokens.
 
-```bash
+A quick installer bootstrap is:
+~~~bash
 curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
-```
+~~~
 
 For the full installation, update, benchmark, and troubleshooting guide, see [`README.md`](README.md).

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ optional, not required.**
 
 ## 🚀 Installation
 
-The official installers download the latest Runtime release from this
-repository, verify the published SHA256 manifest, validate the Runtime release
-contract, require an active Simplicio account, and attempt to register the local
-MCP endpoint. They do not clone or download the `simplicio-*` sibling repositories.
+The official installers download one canonical asset from the latest
+Runtime release, verify its SHA256 checksum and Ed25519 signature, validate the
+Runtime release contract, and require an active Simplicio account. They do not
+clone sibling repositories, install the embedded Python projects with pip, or
+modify Codex configuration unless SIMPLICIO_INSTALL_CODEX=1 is explicitly set.
 
 ### macOS / Linux
 
@@ -110,13 +111,21 @@ Maintainers: the exact manual order for building, signing, tagging, publishing,
 and verifying a public release is documented in
 [docs/RELEASE_RUNBOOK.md](docs/RELEASE_RUNBOOK.md).
 
-The doctor command is read-only. Uninstalling is idempotent and preserves user
-data under `~/.simplicio`:
+The doctor command is read-only. Uninstalling is idempotent; the default
+keep-data mode removes the installed binary and preserves ~/.simplicio:
 
-```bash
-sh install.sh --uninstall              # macOS/Linux
-pwsh install.ps1 -Uninstall             # Windows
-```
+~~~bash
+sh install.sh --uninstall --keep-data       # macOS/Linux
+sh install.sh --uninstall --purge            # also removes ~/.simplicio after confirmation
+~~~
+
+~~~powershell
+pwsh install.ps1 -Uninstall -KeepData         # Windows
+pwsh install.ps1 -Uninstall -Purge            # also removes user data after confirmation
+~~~
+
+For non-interactive purge, set SIMPLICIO_CONFIRM_PURGE=1 explicitly. The
+installer never edits PATH profiles.
 
 ### What the binary contains
 
@@ -213,30 +222,36 @@ the table above is a quick orientation, not a substitute for live schemas.
 
 ### Codex: local STDIO MCP and hooks
 
-The installer configures Codex to launch the installed binary directly:
+Codex integration is opt-in. A normal installation does not modify Codex
+configuration or hooks. To enable the versioned, reversible integration:
 
-```toml
+~~~bash
+SIMPLICIO_INSTALL_CODEX=1 sh install.sh
+~~~
+
+When enabled, the installer configures Codex to launch the installed binary
+directly:
+
+~~~toml
 [mcp_servers.simplicio]
 command = "/path/to/simplicio"
 args = ["serve", "--mcp", "--stdio"]
-```
+~~~
 
 This keeps MCP execution local and avoids the latency of the local HTTP daemon.
 The Runtime still enforces Google login and entitlement for every MCP session.
-The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
-`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`; existing
-Codex hooks are preserved and the Simplicio entries are updated idempotently.
+The managed Codex hooks are versioned with the release, existing hooks are
+preserved, and repeated setup is idempotent. Review the result in Settings →
+Hooks and verify the MCP command with:
 
-After installation, restart Codex and open **Settings → Hooks** to review or
-approve the installed hooks. Verify the MCP command with:
-
-```bash
+~~~bash
 codex mcp list
-```
+~~~
 
-To repair only this integration, rerun the installer. The original
-`config.toml` and `hooks.json` are kept in `.simplicio.bak` files on the first
-managed write. Set `SIMPLICIO_MCP_ROUTE=0` for a temporary hook escape hatch.
+To repair the integration, rerun the installer with SIMPLICIO_INSTALL_CODEX=1.
+The managed integration has a separate status/install/uninstall/repair helper in
+scripts/codex_integration.py; user data remains separate from the integration.
+Set SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
 
 ### Other MCP clients: local STDIO
 
@@ -476,11 +491,11 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime
 ## 🔄 Updates, diagnostics, and troubleshooting
 
 Re-running the official installer is the simplest update path. It downloads
-the latest release, verifies the checksum, validates the Runtime release
-contract, and keeps `~/.simplicio` user data. Re-running the installer keeps
-the installation on GitHub's `latest` release. The installer refuses
+the latest release, verifies the SHA256 checksum and Ed25519 signature, validates
+the Runtime release contract, and keeps ~/.simplicio user data. Re-running the
+installer keeps the installation on GitHub's latest release. The installer refuses
 to replace a working binary with a release that lacks the embedded bundle,
-Google login activation, or the signed-update key.
+Google login activation, a configured update key, or a verifiable signature.
 
 When the Runtime's background update checks are enabled, it checks in its
 scheduled windows, notifies once per release, stages the verified asset, and

--- a/VERSION.md
+++ b/VERSION.md
@@ -15,16 +15,16 @@ This is the **public distribution repo** for [Simplicio](https://github.com/wesl
 - **Source:** `simplicio-runtime` main at commit
   `5c178b39` (merged Runtime MCP routing, hook, release-gate, and version fixes).
 - **Targets:** macOS ARM64, macOS x64, Linux x64, and Windows x64. The
-  repository-root binaries and `SHA256SUMS` were regenerated from this same
-  Runtime source and verified locally.
-- **Release status:** signed GitHub Release `v3.8.16` is published.
-  Installers and the update command resolve GitHub's `latest` release and
-  require its signed manifest; the post-publish release gates have passed.
-- **Default branch:** `master`
-- **Release-channel gates:** signed artifacts, the configured
-  `update_public_key`, and the embedded ecosystem bundle were verified for
-  this user-facing release. Each installation still requires active Google
-  login and entitlement validation.
+  canonical target table and release manifest define the asset, checksum,
+  signature, SBOM, and provenance for each platform.
+- **Release status:** GitHub Release v3.8.16 metadata is published. Installers
+  and the update command resolve GitHub's latest release, verify its signed
+  manifest, and fail closed if an artifact signature or checksum is invalid.
+- **Default branch:** master
+- **Release-channel gates:** the installer enforces embedded ecosystem sources,
+  the configured update key, SHA256, Ed25519 signatures, and active Google login.
+  Publication alone is not a bypass for a failed verification; the release
+  metadata must be regenerated when a signed artifact does not validate.
 
 ### Product law (v3.6.0)
 
@@ -35,17 +35,19 @@ This is the **public distribution repo** for [Simplicio](https://github.com/wesl
 
 ## Repository Structure
 
-```
+~~~
 /
 ├── README.md                 # Main English README
 ├── READMEs/                  # README translations
 ├── install.sh / install.ps1  # Installers
-├── VERSION.md                # This file — READ ME FIRST
-├── simplicio                 # macOS ARM64 snapshot
-├── simplicio-linux-x64       # Linux x64 snapshot
-├── simplicio-windows-x64.exe # Windows x64 snapshot
-└── …
-```
+├── distribution/targets.json # Canonical platform-to-asset mapping
+├── simplicio-update-manifest.json # Checksums, signatures, provenance
+└── release binaries           # Published in GitHub Releases per target
+~~~
+
+The current release targets are macOS ARM64, macOS x64 (Intel), Linux x64,
+and Windows x64. The installers consume the canonical mapping and do not
+rewrite or download the embedded Python projects separately.
 
 ## Key Branches
 

--- a/docs/asolaria-integration.md
+++ b/docs/asolaria-integration.md
@@ -1,7 +1,14 @@
 # 🌌 Integração Asolaria — Binary/Host-8 Distribution
 
 > **Documento de Arquitetura e Implementação**
-> _Simplicio Public Distribution Repository — `wesleysimplicio/simplicio`_
+> _Simplicio Public Distribution Repository — simplicio_
+>
+> **Nota de alinhamento público (v3.8.16):** este documento contém arquitetura,
+> histórico e roadmap Host-8/Asolaria. Para instalar o produto atual, prevalecem
+> INSTALL.md, MCP-CONNECT.md, distribution/targets.json e
+> simplicio-update-manifest.json. A release pública é um binário único por
+> target; o instalador verifica SHA256 + Ed25519, exige login Google para MCP,
+> e só configura Codex quando SIMPLICIO_INSTALL_CODEX=1.
 
 ---
 

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def read(name):
+    return (ROOT / name).read_text(encoding='utf-8')
+
+
+def test_install_docs_match_opt_in_transactional_contract():
+    readme = read('README.md')
+    install = read('INSTALL.md')
+    assert 'SIMPLICIO_INSTALL_CODEX=1' in readme
+    assert 'SIMPLICIO_INSTALL_CODEX=1' in install
+    assert '--uninstall --keep-data' in readme
+    assert '--uninstall --purge' in install
+    assert 'SIMPLICIO_CONFIRM_PURGE=1' in readme
+    assert 'rm -rf ~/.simplicio' not in install
+
+
+def test_mcp_docs_match_local_authentication_contract():
+    mcp = read('MCP-CONNECT.md')
+    assert 'local STDIO' in mcp
+    assert 'Google login' in mcp
+    assert 'SIMPLICIO_INSTALL_CODEX=1' in mcp
+    assert 'Ed25519' in mcp
+
+
+def test_public_docs_point_to_canonical_distribution_contract():
+    version = read('VERSION.md')
+    asolaria = read('docs/asolaria-integration.md')
+    assert 'macOS x64' in version
+    assert 'distribution/targets.json' in asolaria
+    assert 'histórico' in asolaria
+    assert 'simplicio-update-manifest.json' in asolaria


### PR DESCRIPTION
## Summary
- align README, INSTALL, MCP-CONNECT, VERSION, and Asolaria docs with the single-binary release contract
- document SHA256 + Ed25519 fail-closed verification, local STDIO with Google login/entitlement, and local-vs-remote inference boundaries
- document Codex as opt-in and uninstall as `--keep-data` by default with confirmed `--purge`
- add public-contract and Markdown fence regression tests

## Verification
- public contract tests
- `python3 scripts/verify_distribution_consistency.py --json` (all OK)
- Markdown fence check
- Python compilation and `git diff --check`

Closes #93