### PR TITLE
test: normalize standalone Loop contract whitespace

### DIFF
--- a/tests/test_loop_standalone_contract.py
+++ b/tests/test_loop_standalone_contract.py
@@ -6,7 +6,8 @@ SKILL = Path(__file__).parents[1] / "plugin/skills/simplicio-loop/SKILL.md"
 
 def test_loop_contract_allows_standalone_mode_without_runtime():
     text = SKILL.read_text(encoding="utf-8")
-    assert "Runtime first when available" in text
-    assert "continue through the standalone Loop operators" in text
-    assert "runtime-integration=degraded" in text
-    assert "never claim Runtime activation, Runtime authority" in text
+    normalized = " ".join(text.split())
+    assert "Runtime first when available" in normalized
+    assert "continue through the standalone Loop operators" in normalized
+    assert "runtime-integration=degraded" in normalized
+    assert "never claim Runtime activation, Runtime authority" in normalized


### PR DESCRIPTION
## Summary
- normalize whitespace before checking the standalone Loop Runtime-authority contract
- keep the regression test aligned with the wrapped documentation line

## Verification
- manual targeted contract runner: 17 tests passed
- `sh -n install.sh`
- Python compilation
- `git diff --check`