### PR TITLE
Fix installer Ed25519 signature contract

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -22,13 +22,30 @@ refuse unsigned artifacts, and match the checksums and sidecars byte-for-byte.
 Do not publish a new release from a checkout where `version.txt` and the
 manifest disagree.
 
+## Signature payload contract
+
+The compiled Runtime command `update sign <sha256>` signs this exact UTF-8
+payload, including the domain prefix and the lowercase hexadecimal digest:
+
+```text
+simplicio-release-v1:<lowercase-sha256>
+```
+
+The `.sig` sidecar and the manifest `signature` field must contain the same
+`ed25519:<base64>` value. The bootstrap verifier used by both `install.ps1`
+and `install.sh` validates this domain-separated payload and is pinned by its
+SHA-256 in the installers. A raw 32-byte SHA-256 digest is not a valid release
+signature payload. The publication gate also verifies every signature before a
+release can be staged; never bypass it with `SIMPLICIO_ALLOW_UNVERIFIED=1`.
+
 ## Manual publication order
 
 1. Build and sign the artifacts from the intended `simplicio-runtime` main
    commit.
 2. Copy only the required public files into a release branch.
-3. Run `python3 scripts/verify_distribution_consistency.py` and the release
-   provenance tests.
+3. Run `python3 scripts/verify_distribution_consistency.py`,
+   `python3 -m unittest discover -s tests -p 'test_verify_ed25519.py'`, and
+   the release provenance tests.
 4. Open and merge a PR into `master`.
 5. Create the immutable `vX.Y.Z` tag at that merge commit.
 6. Upload the exact files from the merged tree with `gh release create`.

--- a/docs/UPDATE_SIGNATURE_CONTRACT.md
+++ b/docs/UPDATE_SIGNATURE_CONTRACT.md
@@ -1,0 +1,48 @@
+# Update signature contract
+
+This document records the trust contract shared by the compiled Runtime and
+the public bootstrap installers. It exists to prevent a future release from
+being published with a signature that the installer cannot validate.
+
+## Canonical payload
+
+For an artifact digest `D`, where `D` is the lowercase 64-character SHA-256
+hex string, Runtime `simplicio update sign D` signs the UTF-8 bytes of:
+
+```text
+simplicio-release-v1:D
+```
+
+The signature is published as `ed25519:<base64-signature>` in both the artifact
+sidecar (`<artifact>.sig`) and the corresponding manifest entry. The manifest
+public key must match the key compiled into the Runtime and pinned by the
+installers.
+
+## Verification order
+
+Every installer must:
+
+1. download the immutable release manifest and artifact;
+2. compare the artifact SHA-256 with the manifest;
+3. verify the Ed25519 signature over the canonical payload above;
+4. verify the Runtime distribution contract;
+5. only then replace the installed binary.
+
+An invalid or missing signature is a hard failure. `SIMPLICIO_ALLOW_UNVERIFIED=1`
+is only an explicit checksum-only emergency override and must not be used for
+official releases.
+
+## Regression protection
+
+The public repository keeps the verifier in `scripts/verify_ed25519.py`. The
+following tests must remain green before publishing:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_verify_ed25519.py'
+python3 -m unittest discover -s tests -p 'test_release_provenance.py'
+```
+
+The fixture covers the real Runtime domain-separated payload and deliberately
+rejects a raw digest signature. The release provenance gate also verifies the
+cryptographic signature for every staged artifact whenever the manifest marks
+signatures as required.

--- a/install.ps1
+++ b/install.ps1
@@ -38,7 +38,7 @@ $Target = "windows-x64"
 $Asset = "simplicio-windows-x64.exe"
 $Ed25519PublicKey = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 $Ed25519HelperUrl = "https://raw.githubusercontent.com/$Repo/master/scripts/verify_ed25519.py"
-$Ed25519HelperSha256 = "6d25fed7ea3d45db4a184d0c499511d235931b2693e5d8369851d27b349d932b"
+$Ed25519HelperSha256 = "f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
 if ($env:SIMPLICIO_BIN_DIR) {
   $InstallDir = $env:SIMPLICIO_BIN_DIR
 } else {

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ REPO="wesleysimplicio/simplicio"
 GITHUB="https://github.com/$REPO"
 ED25519_PUBLIC_KEY="2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 ED25519_HELPER_URL="https://raw.githubusercontent.com/$REPO/master/scripts/verify_ed25519.py"
-ED25519_HELPER_SHA256="6d25fed7ea3d45db4a184d0c499511d235931b2693e5d8369851d27b349d932b"
+ED25519_HELPER_SHA256="f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
 BIN_NAME="simplicio"
 
 GREEN='\033[0;32m'

--- a/scripts/verify_ed25519.py
+++ b/scripts/verify_ed25519.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Minimal RFC 8032 Ed25519 verifier for installer bootstrap trust."""
+"""Minimal RFC 8032 Ed25519 verifier for installer bootstrap trust.
+
+The Runtime signs a domain-separated UTF-8 payload, not the raw 32-byte
+SHA-256 digest.  Keeping this contract here prevents the Windows and
+macOS/Linux bootstrap installers from drifting from the compiled Runtime:
+
+    simplicio-release-v1:<lowercase sha256>
+
+The sidecar and manifest carry the resulting ``ed25519:<base64>`` signature.
+"""
 from __future__ import annotations
 
 import argparse
@@ -12,6 +21,7 @@ L = 2**252 + 27742317777372353535851937790883648493
 D = (-121665 * pow(121666, Q - 2, Q)) % Q
 I = pow(2, (Q - 1) // 4, Q)
 B_Y = 4 * pow(5, Q - 2, Q) % Q
+SIGNATURE_DOMAIN = "simplicio-release-v1:"
 
 def inv(x: int) -> int:
     return pow(x, Q - 2, Q)
@@ -83,22 +93,44 @@ def parse_signature(value: str) -> bytes:
         raise ValueError("signature must use ed25519:<base64> format")
     return base64.b64decode(value[8:], validate=True)
 
+
+def canonical_sha256(value: str) -> str:
+    """Return the canonical lowercase SHA-256 text accepted by the Runtime."""
+    digest = value.strip().lower()
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise ValueError("SHA-256 digest must be exactly 64 hexadecimal characters")
+    return digest
+
+
+def signature_payload(sha256_hex: str) -> bytes:
+    """Build the exact domain-separated payload signed by Runtime ``update sign``."""
+    digest = canonical_sha256(sha256_hex)
+    return f"{SIGNATURE_DOMAIN}{digest}".encode("ascii")
+
+
+def verify_signature_for_digest(public_key_value: str, signature_value: str, sha256_hex: str) -> bool:
+    """Verify a Runtime release signature for a hexadecimal artifact digest."""
+    public_key = base64.b64decode(public_key_value.strip(), validate=True)
+    signature = parse_signature(signature_value.strip())
+    return verify(public_key, signature, signature_payload(sha256_hex))
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--public-key", required=True, help="base64 raw Ed25519 public key")
     parser.add_argument("--signature", required=True, help="ed25519:<base64> manifest signature")
-    parser.add_argument("--sha256", required=True, help="hex SHA-256 digest; the raw 32-byte digest is signed")
+    parser.add_argument(
+        "--sha256",
+        required=True,
+        help="lowercase hex SHA-256 digest; Runtime signs simplicio-release-v1:<digest>",
+    )
     args = parser.parse_args(argv)
     try:
-        digest = bytes.fromhex(args.sha256)
-        if len(digest) != 32:
-            raise ValueError("SHA-256 digest must be 32 bytes")
-        public_key = base64.b64decode(args.public_key, validate=True)
-        signature = parse_signature(args.signature)
+        digest = canonical_sha256(args.sha256)
+        verified = verify_signature_for_digest(args.public_key, args.signature, digest)
     except (ValueError, base64.binascii.Error) as exc:
         print(f"invalid Ed25519 verification input: {exc}", file=sys.stderr)
         return 2
-    if not verify(public_key, signature, digest):
+    if not verified:
         print("Ed25519 signature verification failed", file=sys.stderr)
         return 1
     return 0

--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import binascii
 import hashlib
 import json
 import os
@@ -16,6 +17,11 @@ from typing import Sequence
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+
+try:
+    from scripts.verify_ed25519 import verify_signature_for_digest
+except ModuleNotFoundError:  # direct execution: python scripts/verify_release_provenance.py
+    from verify_ed25519 import verify_signature_for_digest
 
 PROVENANCE_FIELDS = ("artifact", "url", "sha256", "signature")
 
@@ -247,6 +253,27 @@ def verify_staged_files(working: dict, staging_dir: Path) -> list[str]:
         actual = hashlib.sha256(path.read_bytes()).hexdigest()
         if actual != expected_sha256:
             errors.append(f"staged artifact digest mismatch for {name}")
+    if errors:
+        return errors
+
+    security = working.get("security")
+    if not isinstance(security, dict) or security.get("signature_required") is not True:
+        return errors
+    if security.get("signature_algorithm") != "ed25519":
+        return ["manifest requires an unsupported signature algorithm"]
+    public_key = str(working.get("signing_pubkey") or "").strip()
+    if not public_key:
+        return ["manifest requires Ed25519 but signing_pubkey is missing"]
+    for name, _, expected_sha256, signature in artifacts:
+        try:
+            valid = verify_signature_for_digest(public_key, signature, expected_sha256)
+        except (ValueError, TypeError, binascii.Error) as exc:
+            valid = False
+            reason = str(exc)
+        else:
+            reason = "signature verification failed"
+        if not valid:
+            errors.append(f"invalid Ed25519 signature for {name}: {reason}")
     return errors
 
 

--- a/tests/test_release_provenance.py
+++ b/tests/test_release_provenance.py
@@ -14,6 +14,8 @@ from scripts import verify_release_provenance as provenance
 
 REPOSITORY = "wesleysimplicio/simplicio"
 STAGING = "https://artifacts.example/simplicio/v3.5.2"
+SIGNED_TEST_PUBLIC_KEY = "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="
+SIGNED_TEST_SIGNATURE = "ed25519:UKIyIZkSH3nmk+E1LybN3bjQlPpiumLoLIu+bdQUC/j4/6nQkNX3MBhU7kZv+OZ6S9iLYVGwwzPZD5n//MGGAQ=="
 
 
 class FakeResponse:
@@ -55,6 +57,26 @@ def remote_release(value: dict, *, digest: str | None = None) -> dict:
             {
                 "name": artifact["artifact"],
                 "digest": digest or f"sha256:{artifact['sha256']}",
+            }
+        ],
+    }
+
+
+def signed_manifest(payload: bytes = b"signed release bytes") -> dict:
+    digest = hashlib.sha256(payload).hexdigest()
+    return {
+        "version": "3.8.17",
+        "security": {
+            "signature_algorithm": "ed25519",
+            "signature_required": True,
+        },
+        "signing_pubkey": SIGNED_TEST_PUBLIC_KEY,
+        "artifacts": [
+            {
+                "artifact": "simplicio-macos-arm64",
+                "url": f"https://github.com/{REPOSITORY}/releases/download/v3.8.17/simplicio-macos-arm64",
+                "sha256": digest,
+                "signature": SIGNED_TEST_SIGNATURE,
             }
         ],
     }
@@ -223,6 +245,18 @@ class ReleaseProvenanceTests(unittest.TestCase):
             )
             artifact.write_bytes(payload)
             self.assertEqual(provenance.verify_staged_files(working, root), [])
+
+    def test_staged_artifact_verifies_runtime_domain_separated_signature(self):
+        payload = b"signed release bytes"
+        working = signed_manifest(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "simplicio-macos-arm64"
+            artifact.write_bytes(payload)
+            self.assertEqual(provenance.verify_staged_files(working, Path(directory)), [])
+
+            working["artifacts"][0]["signature"] = working["artifacts"][0]["signature"].replace("UKIy", "UKIz")
+            errors = provenance.verify_staged_files(working, Path(directory))
+            self.assertTrue(any("invalid Ed25519 signature" in error for error in errors))
 
     def test_download_and_metadata_use_verified_staging(self):
         payload = b"immutable staged bytes"

--- a/tests/test_verify_ed25519.py
+++ b/tests/test_verify_ed25519.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import base64
+import unittest
+
+from scripts import verify_ed25519
+
+
+PUBLIC_KEY = "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="
+SIGNATURE = "ed25519:UKIyIZkSH3nmk+E1LybN3bjQlPpiumLoLIu+bdQUC/j4/6nQkNX3MBhU7kZv+OZ6S9iLYVGwwzPZD5n//MGGAQ=="
+DIGEST = "3ba84e1d362618f0e9f45064634a1594485bca3298b8182b5a7eaa3fded4688f"
+
+
+class Ed25519ReleaseContractTests(unittest.TestCase):
+    def test_runtime_domain_separated_payload_verifies(self):
+        self.assertTrue(verify_ed25519.verify_signature_for_digest(PUBLIC_KEY, SIGNATURE, DIGEST))
+        self.assertEqual(
+            verify_ed25519.signature_payload(DIGEST),
+            f"simplicio-release-v1:{DIGEST}".encode("ascii"),
+        )
+
+    def test_raw_digest_is_not_the_release_payload(self):
+        self.assertFalse(
+            verify_ed25519.verify(
+                base64.b64decode(PUBLIC_KEY),
+                verify_ed25519.parse_signature(SIGNATURE),
+                bytes.fromhex(DIGEST),
+            )
+        )
+
+    def test_invalid_digest_is_rejected(self):
+        with self.assertRaises(ValueError):
+            verify_ed25519.signature_payload("not-a-sha256")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Align the bootstrap Ed25519 verifier with the Runtime signing payload: `simplicio-release-v1:<lowercase-sha256>`.
- Pin the corrected verifier hash in both `install.ps1` and `install.sh`.
- Make release provenance validation cryptographically verify required artifact signatures.
- Add regression coverage and document the contract and publication gates.

## Verification
- Real v3.8.17 Windows artifact signature verified successfully.
- `test_verify_ed25519.py`: 3 passed.
- `test_release_provenance.py`: 17 passed.
- Python compilation, `sh -n install.sh`, bootstrap pin equality, and `git diff --check` passed.

This fixes the reported Windows install failure without weakening fail-closed verification or requiring `SIMPLICIO_ALLOW_UNVERIFIED=1`.
