### PR TITLE
Add mandatory post-release quality gates

### DIFF
--- a/distribution/targets.json
+++ b/distribution/targets.json
@@ -1,12 +1,13 @@
 {
   "schema": "simplicio.target-triplets/v1",
-  "$comment": "Single source of truth for platform naming across the ecosystem. Any script, workflow or manifest that needs an asset name for a platform MUST derive it from this table (id -> asset) instead of hard-coding its own convention. scripts/verify_distribution_consistency.py enforces that release.yml, install.sh, install.ps1 and simplicio-update-manifest.json all agree with this table.",
+  "$comment": "Single source of truth for platform naming across the ecosystem. Any script, workflow or manifest that needs an asset name for a platform MUST derive it from this table (id -> asset) instead of hard-coding its own convention. provenance_target_aliases lists the only build-target names accepted in published provenance. scripts/verify_distribution_consistency.py enforces that release.yml, install.sh, install.ps1 and simplicio-update-manifest.json all agree with this table.",
   "targets": [
     {
       "id": "windows-x64",
       "os": "windows",
       "arch": "x64",
       "rust_triple": "x86_64-pc-windows-msvc",
+      "provenance_target_aliases": ["windows-x64"],
       "asset": "simplicio-windows-x64.exe",
       "installer": "install.ps1",
       "manifest_target": "windows-x64"
@@ -16,6 +17,7 @@
       "os": "macos",
       "arch": "arm64",
       "rust_triple": "aarch64-apple-darwin",
+      "provenance_target_aliases": ["macos-aarch64"],
       "asset": "simplicio-macos-arm64",
       "installer": "install.sh",
       "manifest_target": "macos-arm64"
@@ -25,6 +27,7 @@
       "os": "macos",
       "arch": "x64",
       "rust_triple": "x86_64-apple-darwin",
+      "provenance_target_aliases": ["macos-x86_64"],
       "asset": "simplicio-macos-x64",
       "installer": "install.sh",
       "manifest_target": "macos-x64",
@@ -35,6 +38,7 @@
       "os": "linux",
       "arch": "x64",
       "rust_triple": "x86_64-unknown-linux-gnu",
+      "provenance_target_aliases": ["linux-x86_64"],
       "asset": "simplicio-linux-x64",
       "installer": "install.sh",
       "manifest_target": "linux-x64"

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -49,12 +49,26 @@ release can be staged; never bypass it with `SIMPLICIO_ALLOW_UNVERIFIED=1`.
 4. Open and merge a PR into `master`.
 5. Create the immutable `vX.Y.Z` tag at that merge commit.
 6. Upload the exact files from the merged tree with `gh release create`.
-7. Re-download every asset, verify SHA-256 and Ed25519, and test both
-   installers plus `simplicio ecosystem verify --json`.
+7. Run the mandatory post-release smoke on the published GitHub Release:
+   `VERSION=vX.Y.Z; python3 scripts/post_release_smoke.py --version "$VERSION" --execute --json`.
+   Run it once on each native host in the support matrix; this re-downloads
+   the release and checks every artifact, sidecar, SBOM, provenance record,
+   version, clean-home login gate, and MCP login gate.
 
 The release is not ready for users if any check is skipped or unverified. Do
 not force-move a published tag; use a new patch release if published bytes
 need correction.
+
+The post-release receipt is part of the release evidence. It must contain a
+successful result for all four targets from static verification and a
+successful native result for macOS arm64, macOS x64, Linux x64, and Windows
+x64. A green pre-publish build does not replace this test: the test validates
+the bytes and metadata actually served to users.
+
+The installer target ID and the build target in provenance are separate
+namespaces. Their approved aliases are maintained in
+`distribution/targets.json`; the smoke test accepts only those explicit
+aliases, never an arbitrary target string.
 
 ## Latest-only installation
 

--- a/pypi/simplicio/simplicio/__init__.py
+++ b/pypi/simplicio/simplicio/__init__.py
@@ -1,6 +1,6 @@
 """Simplicio — AI coding agent that saves up to 96% on tokens."""
 
-__version__ = "3.8.11"
+__version__ = "3.8.17"
 
 
 def main():

--- a/pypi/simplicio/simplicio/__main__.py
+++ b/pypi/simplicio/simplicio/__main__.py
@@ -31,6 +31,7 @@ MANIFEST_ASSET = "simplicio-update-manifest.json"
 TRUSTED_MANIFEST_SHA256 = {
     "3.5.2": "85a486b1210d3610365ce78279f3b964c5713ab311407efa8812cd6eeda4fc1f",
     "3.8.11": "22e535fb3875bad6af98af1b156975b25f2a4a5b0cbd32462ca2d9d0f2c3a9f0",
+    "3.8.17": "9c0b753a874ee1e6543bcb0df1c59732233ea7ef706d8dc549fc5da4ba5728b9",
 }
 
 # Kept in lockstep with distribution/targets.json.  The PyPI wheel must retain

--- a/scripts/post_release_smoke.py
+++ b/scripts/post_release_smoke.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Fail-closed smoke test for an already-published Simplicio release.
+
+This command validates the bytes served by GitHub Release, not the local
+staging directory. It verifies the immutable manifest, every target artifact,
+SHA-256, Ed25519 sidecars, SBOMs, provenance records, and (with ``--execute``)
+the native artifact for the current host.
+"""
+from __future__ import annotations
+
+import argparse
+import binascii
+import hashlib
+import json
+import os
+import platform
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:
+    from scripts.verify_ed25519 import verify_signature_for_digest
+except ModuleNotFoundError:  # direct execution: python scripts/post_release_smoke.py
+    from verify_ed25519 import verify_signature_for_digest
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPOSITORY = "wesleysimplicio/simplicio"
+MANIFEST_ASSET = "simplicio-update-manifest.json"
+CHECKSUMS_ASSET = "SHA256SUMS"
+VERSION_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def load_target_table(path: Path = ROOT / "distribution/targets.json") -> list[dict]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    targets = document.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ValueError("distribution target table is empty")
+    return [target for target in targets if isinstance(target, dict)]
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def parse_checksums(value: bytes) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line in value.decode("utf-8").splitlines():
+        fields = line.split(maxsplit=1)
+        if len(fields) != 2:
+            continue
+        digest, filename = fields
+        checksums[filename.lstrip("*")] = digest.lower()
+    return checksums
+
+
+def expected_asset_names(manifest: Mapping[str, object], targets: Sequence[dict]) -> set[str]:
+    names = {MANIFEST_ASSET, CHECKSUMS_ASSET}
+    artifacts = manifest.get("artifacts", [])
+    for target in targets:
+        record = next(
+            (item for item in artifacts if isinstance(item, dict) and item.get("target") == target.get("id")),
+            {},
+        )
+        artifact = str(record.get("artifact") or target.get("asset") or "")
+        if not artifact:
+            continue
+        names.add(artifact)
+        names.add(str(record.get("signature_file") or f"{artifact}.sig"))
+        sbom = record.get("sbom")
+        provenance = record.get("provenance")
+        if isinstance(sbom, dict) and sbom.get("file"):
+            names.add(str(sbom["file"]))
+        if isinstance(provenance, dict) and provenance.get("file"):
+            names.add(str(provenance["file"]))
+        # Older Windows releases may carry this compatibility sidecar.
+        names.add(f"{artifact}.sha256")
+    return names
+
+
+def verify_release_payload(
+    release: Mapping[str, object],
+    manifest: Mapping[str, object],
+    assets: Mapping[str, bytes],
+    *,
+    repository: str,
+    tag: str,
+    targets: Sequence[dict],
+) -> dict:
+    """Verify downloaded release payloads and return a machine-readable report."""
+    errors: list[str] = []
+    release_tag = str(release.get("tag_name") or "")
+    if release_tag != tag:
+        errors.append(f"release tag mismatch: {release_tag!r} != {tag!r}")
+    if release.get("draft") is True or release.get("prerelease") is True:
+        errors.append("release is draft or prerelease")
+
+    version = str(manifest.get("version") or "")
+    if manifest.get("release_tag") != tag:
+        errors.append("manifest release_tag does not match the requested immutable tag")
+    if manifest.get("repository") != repository:
+        errors.append("manifest repository does not match the requested repository")
+    if not version or f"v{version}" != tag:
+        errors.append("manifest version does not match the requested release tag")
+
+    security = manifest.get("security")
+    if not isinstance(security, dict):
+        errors.append("manifest security contract is missing")
+        security = {}
+    if security.get("signature_required") is not True or security.get("refuse_unsigned") is not True:
+        errors.append("manifest does not require fail-closed signatures")
+    if security.get("signature_algorithm") != "ed25519":
+        errors.append("manifest signature algorithm is not ed25519")
+    signing_pubkey = str(manifest.get("signing_pubkey") or "").strip()
+    if not signing_pubkey:
+        errors.append("manifest signing_pubkey is missing")
+
+    release_assets = release.get("assets")
+    release_names = {
+        str(item.get("name"))
+        for item in release_assets
+        if isinstance(item, dict) and item.get("name")
+    } if isinstance(release_assets, list) else set()
+    if MANIFEST_ASSET not in release_names or CHECKSUMS_ASSET not in release_names:
+        errors.append("release is missing the manifest or SHA256SUMS asset")
+    expected_names = expected_asset_names(manifest, targets)
+    unexpected = sorted(release_names - expected_names)
+    if unexpected:
+        errors.append("release contains unexpected assets: " + ", ".join(unexpected))
+    missing_payloads = sorted(release_names - set(assets))
+    if missing_payloads:
+        errors.append("release assets were not downloaded: " + ", ".join(missing_payloads))
+
+    checksums = parse_checksums(assets[CHECKSUMS_ASSET]) if CHECKSUMS_ASSET in assets else {}
+    artifact_records = [item for item in manifest.get("artifacts", []) if isinstance(item, dict)]
+    records_by_target = {str(item.get("target")): item for item in artifact_records}
+    target_ids = {str(target.get("id")) for target in targets}
+    if set(records_by_target) != target_ids:
+        errors.append("manifest artifact targets do not match distribution/targets.json")
+
+    verified_artifacts: list[str] = []
+    base_url = f"https://github.com/{repository}/releases/download/{tag}/"
+    for target in targets:
+        target_id = str(target.get("id"))
+        record = records_by_target.get(target_id)
+        if record is None:
+            continue
+        artifact = str(record.get("artifact") or "")
+        expected_artifact = str(target.get("asset") or "")
+        if artifact != expected_artifact:
+            errors.append(f"{target_id}: artifact name mismatch: {artifact!r} != {expected_artifact!r}")
+            continue
+        digest = str(record.get("sha256") or "").lower()
+        signature = str(record.get("signature") or "").strip()
+        signature_file = str(record.get("signature_file") or f"{artifact}.sig")
+        if record.get("url") != base_url + artifact:
+            errors.append(f"{artifact}: URL is not immutable for tag {tag}")
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            errors.append(f"{artifact}: invalid SHA-256 in manifest")
+            continue
+        binary = assets.get(artifact)
+        sidecar = assets.get(signature_file)
+        if binary is None or sidecar is None:
+            continue
+        actual_digest = sha256_bytes(binary)
+        if actual_digest != digest:
+            errors.append(f"{artifact}: downloaded SHA-256 mismatch")
+        if checksums.get(artifact) != digest:
+            errors.append(f"{artifact}: SHA256SUMS mismatch")
+        if sidecar.decode("utf-8").strip() != signature:
+            errors.append(f"{artifact}: signature sidecar differs from manifest")
+        try:
+            valid_signature = verify_signature_for_digest(signing_pubkey, signature, digest)
+        except (ValueError, TypeError, binascii.Error) as exc:
+            valid_signature = False
+            errors.append(f"{artifact}: invalid Ed25519 input: {exc}")
+        if not valid_signature:
+            errors.append(f"{artifact}: Ed25519 signature verification failed")
+        if record.get("size") is not None and int(record["size"]) != len(binary):
+            errors.append(f"{artifact}: manifest size mismatch")
+
+        sbom = record.get("sbom")
+        if security.get("sbom_required") is True:
+            sbom_file = str(sbom.get("file")) if isinstance(sbom, dict) else ""
+            if not sbom_file or sbom_file not in assets:
+                errors.append(f"{artifact}: required SBOM is missing")
+            else:
+                try:
+                    sbom_data = json.loads(assets[sbom_file])
+                    file_entries = sbom_data.get("files", [])
+                    matching = [entry for entry in file_entries if entry.get("fileName") == artifact]
+                    sbom_hashes = {
+                        str(checksum.get("checksumValue", "")).lower()
+                        for entry in matching
+                        for checksum in entry.get("checksums", [])
+                        if checksum.get("algorithm") == "SHA256"
+                    }
+                    if sbom_data.get("spdxVersion") != "SPDX-2.3" or digest not in sbom_hashes:
+                        errors.append(f"{artifact}: SBOM does not describe the verified bytes")
+                except (TypeError, ValueError) as exc:
+                    errors.append(f"{artifact}: invalid SBOM JSON: {exc}")
+
+        provenance = record.get("provenance")
+        if security.get("provenance_required") is True:
+            provenance_file = str(provenance.get("file")) if isinstance(provenance, dict) else ""
+            if not provenance_file or provenance_file not in assets:
+                errors.append(f"{artifact}: required provenance is missing")
+            else:
+                try:
+                    provenance_data = json.loads(assets[provenance_file])
+                    subject = provenance_data.get("subject", {})
+                    build = provenance_data.get("build", {})
+                    if (
+                        subject.get("name") != artifact
+                        or str(subject.get("sha256", "")).lower() != digest
+                        or int(subject.get("size", -1)) != len(binary)
+                        or str(build.get("version")) != version
+                        or str(build.get("target")) not in {
+                            target_id,
+                            str(target.get("rust_triple") or ""),
+                            *(str(alias) for alias in target.get("provenance_target_aliases", [])),
+                        }
+                    ):
+                        errors.append(f"{artifact}: provenance does not describe the verified bytes")
+                except (TypeError, ValueError) as exc:
+                    errors.append(f"{artifact}: invalid provenance JSON: {exc}")
+        if not any(error.startswith(f"{artifact}:") for error in errors):
+            verified_artifacts.append(artifact)
+
+    return {
+        "repository": repository,
+        "tag": tag,
+        "version": version,
+        "verified_artifacts": verified_artifacts,
+        "artifact_count": len(artifact_records),
+        "errors": errors,
+    }
+
+
+def github_request(url: str, token: str = "") -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "simplicio-post-release-smoke"},
+    )
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def download_release(repository: str, tag: str, token: str) -> tuple[dict, dict[str, bytes]]:
+    api_url = f"https://api.github.com/repos/{repository}/releases/tags/{tag}"
+    release = json.loads(github_request(api_url, token))
+    payloads: dict[str, bytes] = {}
+    for item in release.get("assets", []):
+        if not isinstance(item, dict) or not item.get("name") or not item.get("browser_download_url"):
+            continue
+        payloads[str(item["name"])] = github_request(str(item["browser_download_url"]), token)
+    return release, payloads
+
+
+def host_target() -> str:
+    system = platform.system().lower()
+    if system == "windows":
+        return "windows-x64"
+    if system == "linux":
+        return "linux-x64"
+    if system == "darwin":
+        return "macos-arm64" if platform.machine().lower() in {"arm64", "aarch64"} else "macos-x64"
+    raise RuntimeError(f"unsupported host platform: {platform.system()} {platform.machine()}")
+
+
+def reported_runtime_version(version_json: Mapping[str, object]) -> str:
+    """Read the Runtime version from its canonical version JSON envelope."""
+    runtime = version_json.get("runtime")
+    executable = version_json.get("executable")
+    candidates = [
+        runtime.get("version") if isinstance(runtime, dict) else None,
+        executable.get("version") if isinstance(executable, dict) else None,
+        version_json.get("version"),  # compatibility with older Runtime envelopes
+    ]
+    return next((str(value) for value in candidates if value), "")
+
+
+def run_native_smoke(target: str, manifest: Mapping[str, object], binary: bytes) -> dict:
+    record = next(item for item in manifest.get("artifacts", []) if item.get("target") == target)
+    artifact = str(record["artifact"])
+    with tempfile.TemporaryDirectory(prefix="simplicio-post-release-") as directory:
+        binary_path = Path(directory) / artifact
+        binary_path.write_bytes(binary)
+        if os.name != "nt":
+            binary_path.chmod(binary_path.stat().st_mode | stat.S_IXUSR)
+        command = [str(binary_path)]
+        version_proc = subprocess.run(command + ["version", "--json"], capture_output=True, text=True, timeout=90)
+        if version_proc.returncode != 0:
+            raise RuntimeError(f"version --json failed: {version_proc.stderr[-500:]}")
+        version_json = json.loads(version_proc.stdout)
+        binary_version = reported_runtime_version(version_json)
+        if binary_version != str(manifest.get("version")):
+            raise RuntimeError("binary version does not match manifest")
+
+        with tempfile.TemporaryDirectory(prefix="simplicio-clean-home-") as home:
+            clean_env = dict(os.environ)
+            clean_env.update({
+                "HOME": home,
+                "USERPROFILE": home,
+                "XDG_CONFIG_HOME": str(Path(home) / ".config"),
+                "SIMPLICIO_E2E_EXPECT_LOGIN_REQUIRED": "1",
+            })
+            auth = subprocess.run(command + ["auth", "status", "--json"], env=clean_env, capture_output=True, text=True, timeout=90)
+            auth_text = (auth.stdout + auth.stderr).lower()
+            if "login" not in auth_text and "unauthenticated" not in auth_text and "not authenticated" not in auth_text:
+                raise RuntimeError("clean-home auth status did not enforce login")
+            handshake = "".join(json.dumps(item) + "\n" for item in (
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "simplicio_map",
+                        "arguments": {"repo": home, "task": "post-release login gate"},
+                    },
+                },
+            ))
+            mcp = subprocess.run(command + ["serve", "--mcp", "--stdio", "--json"], input=handshake, env=clean_env, capture_output=True, text=True, timeout=90)
+            responses = {}
+            for line in mcp.stdout.splitlines():
+                try:
+                    response = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if response.get("id") is not None:
+                    responses[response["id"]] = response
+            listed_tools = {
+                str(tool.get("name"))
+                for tool in responses.get(2, {}).get("result", {}).get("tools", [])
+                if isinstance(tool, dict) and tool.get("name")
+            }
+            required_tools = {"simplicio_map", "simplicio_memory", "simplicio_gate", "simplicio_edit", "simplicio_validate"}
+            missing_tools = sorted(required_tools - listed_tools)
+            if missing_tools:
+                raise RuntimeError("MCP tools/list is missing required tools: " + ", ".join(missing_tools))
+            call_error = responses.get(3, {}).get("error", {})
+            call_data = call_error.get("data", {}) if isinstance(call_error, dict) else {}
+            if call_error.get("code") != -32001 or call_data.get("login_required") is not True:
+                raise RuntimeError("MCP tools/call did not return structured login_required gate")
+        return {
+            "target": target,
+            "binary_version": binary_version,
+            "login_gate": True,
+            "mcp_login_gate": True,
+            "mcp_tools": len(listed_tools),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="immutable release tag, for example v3.8.17")
+    parser.add_argument("--repo", default=DEFAULT_REPOSITORY)
+    parser.add_argument("--execute", action="store_true", help="execute the release artifact for this native host")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    if not VERSION_RE.fullmatch(args.version):
+        parser.error("--version must be a semantic version tag such as v3.8.17")
+    tag = args.version if args.version.startswith("v") else f"v{args.version}"
+    try:
+        release, payloads = download_release(args.repo, tag, os.environ.get("GITHUB_TOKEN", ""))
+        manifest = json.loads(payloads[MANIFEST_ASSET])
+        report = verify_release_payload(
+            release,
+            manifest,
+            payloads,
+            repository=args.repo,
+            tag=tag,
+            targets=load_target_table(),
+        )
+        if not report["errors"] and args.execute:
+            target = host_target()
+            artifact = next(item for item in manifest["artifacts"] if item.get("target") == target)["artifact"]
+            report["native_smoke"] = run_native_smoke(target, manifest, payloads[artifact])
+    except (KeyError, OSError, RuntimeError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
+        report = {"tag": tag, "errors": [str(exc)]}
+    if args.json:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if not report.get("errors") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ed25519_verification.py
+++ b/tests/test_ed25519_verification.py
@@ -1,4 +1,3 @@
-import base64
 import subprocess
 import sys
 from pathlib import Path
@@ -6,25 +5,25 @@ from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
 HELPER = ROOT / 'scripts' / 'verify_ed25519.py'
-# RFC 8032 public key, with a deterministic 32-byte zero digest payload.
-RFC_PUBLIC_KEY = base64.b64encode(bytes.fromhex('d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a')).decode()
-RFC_SIGNATURE = 'NVx0BTo4CrWLKY3iOtzKSfObfKUKLOxbhh9sf934fIpTt4x7s5WSaMDbHt6wRAeGg5713vqtYjKQB2GYVgs8Ag=='
+RUNTIME_PUBLIC_KEY = 'A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg='
+RUNTIME_SIGNATURE = 'UKIyIZkSH3nmk+E1LybN3bjQlPpiumLoLIu+bdQUC/j4/6nQkNX3MBhU7kZv+OZ6S9iLYVGwwzPZD5n//MGGAQ=='
+RUNTIME_DIGEST = '3ba84e1d362618f0e9f45064634a1594485bca3298b8182b5a7eaa3fded4688f'
 
 
-def run(signature=RFC_SIGNATURE, digest='00' * 32):
+def run(signature=RUNTIME_SIGNATURE, digest=RUNTIME_DIGEST):
     return subprocess.run([
-        sys.executable, str(HELPER), '--public-key', RFC_PUBLIC_KEY,
+        sys.executable, str(HELPER), '--public-key', RUNTIME_PUBLIC_KEY,
         '--signature', 'ed25519:' + signature, '--sha256', digest,
     ], capture_output=True, text=True)
 
 
-def test_rfc8032_signature_is_accepted():
+def test_runtime_domain_separated_signature_is_accepted():
     result = run()
     assert result.returncode == 0, result.stderr
 
 
 def test_tampered_signature_is_rejected():
-    tampered = ('A' if RFC_SIGNATURE[0] != 'A' else 'B') + RFC_SIGNATURE[1:]
+    tampered = ('A' if RUNTIME_SIGNATURE[0] != 'A' else 'B') + RUNTIME_SIGNATURE[1:]
     assert run(tampered).returncode != 0
 
 

--- a/tests/test_post_release_smoke.py
+++ b/tests/test_post_release_smoke.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+
+from scripts import post_release_smoke as smoke
+
+
+PUBLIC_KEY = "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="
+SIGNATURE = "ed25519:UKIyIZkSH3nmk+E1LybN3bjQlPpiumLoLIu+bdQUC/j4/6nQkNX3MBhU7kZv+OZ6S9iLYVGwwzPZD5n//MGGAQ=="
+PAYLOAD = b"signed release bytes"
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def fixture() -> tuple[dict, dict, dict[str, bytes], list[dict]]:
+    target = {
+        "id": "macos-arm64",
+        "asset": "simplicio-macos-arm64",
+        "rust_triple": "aarch64-apple-darwin",
+        "provenance_target_aliases": ["macos-aarch64"],
+    }
+    artifact = target["asset"]
+    signature_file = f"{artifact}.sig"
+    sbom_file = f"{artifact}.spdx.json"
+    provenance_file = f"{artifact}.provenance.json"
+    manifest = {
+        "schema": "simplicio.update-manifest/v1",
+        "version": "3.8.17",
+        "release_tag": "v3.8.17",
+        "repository": "wesleysimplicio/simplicio",
+        "security": {
+            "signature_algorithm": "ed25519",
+            "signature_required": True,
+            "refuse_unsigned": True,
+            "sbom_required": True,
+            "provenance_required": True,
+        },
+        "signing_pubkey": PUBLIC_KEY,
+        "artifacts": [{
+            "target": target["id"],
+            "artifact": artifact,
+            "url": f"https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.17/{artifact}",
+            "size": len(PAYLOAD),
+            "sha256": DIGEST,
+            "signature": SIGNATURE,
+            "signature_file": signature_file,
+            "sbom": {"file": sbom_file, "format": "SPDX-2.3"},
+            "provenance": {"file": provenance_file, "format": "simplicio.provenance/v1"},
+        }],
+    }
+    sbom = {
+        "spdxVersion": "SPDX-2.3",
+        "files": [{"fileName": artifact, "checksums": [{"algorithm": "SHA256", "checksumValue": DIGEST}]}],
+    }
+    provenance = {
+        "schema": "simplicio.provenance/v1",
+        "subject": {"name": artifact, "sha256": DIGEST, "size": len(PAYLOAD)},
+        "build": {"version": "3.8.17", "target": "macos-aarch64"},
+    }
+    payloads = {
+        smoke.MANIFEST_ASSET: json.dumps(manifest).encode(),
+        smoke.CHECKSUMS_ASSET: f"{DIGEST} *{artifact}\n".encode(),
+        artifact: PAYLOAD,
+        signature_file: f"{SIGNATURE}\n".encode(),
+        sbom_file: json.dumps(sbom).encode(),
+        provenance_file: json.dumps(provenance).encode(),
+    }
+    release = {"tag_name": "v3.8.17", "draft": False, "prerelease": False, "assets": [{"name": name} for name in payloads]}
+    return release, manifest, payloads, [target]
+
+
+class PostReleaseSmokeTests(unittest.TestCase):
+    def test_runtime_version_uses_canonical_json_envelope(self):
+        self.assertEqual(
+            smoke.reported_runtime_version({"runtime": {"version": "3.8.17"}, "version": "wrong"}),
+            "3.8.17",
+        )
+
+    def test_published_payload_verifies_all_integrity_records(self):
+        release, manifest, payloads, targets = fixture()
+        report = smoke.verify_release_payload(
+            release, manifest, payloads, repository="wesleysimplicio/simplicio", tag="v3.8.17", targets=targets
+        )
+        self.assertEqual(report["errors"], [])
+        self.assertEqual(report["verified_artifacts"], ["simplicio-macos-arm64"])
+
+    def test_tampered_sidecar_is_rejected(self):
+        release, manifest, payloads, targets = fixture()
+        payloads["simplicio-macos-arm64.sig"] = b"ed25519:tampered\n"
+        report = smoke.verify_release_payload(
+            release, manifest, payloads, repository="wesleysimplicio/simplicio", tag="v3.8.17", targets=targets
+        )
+        self.assertTrue(any("signature" in error for error in report["errors"]))
+
+    def test_latest_url_is_rejected_as_non_immutable(self):
+        release, manifest, payloads, targets = fixture()
+        manifest["artifacts"][0]["url"] = "https://github.com/wesleysimplicio/simplicio/releases/latest/download/simplicio-macos-arm64"
+        report = smoke.verify_release_payload(
+            release, manifest, payloads, repository="wesleysimplicio/simplicio", tag="v3.8.17", targets=targets
+        )
+        self.assertTrue(any("immutable" in error for error in report["errors"]))
+
+    def test_missing_provenance_is_rejected(self):
+        release, manifest, payloads, targets = fixture()
+        payloads.pop("simplicio-macos-arm64.provenance.json")
+        release["assets"] = [{"name": name} for name in payloads]
+        report = smoke.verify_release_payload(
+            release, manifest, payloads, repository="wesleysimplicio/simplicio", tag="v3.8.17", targets=targets
+        )
+        self.assertTrue(any("provenance" in error for error in report["errors"]))
+
+    def test_unapproved_provenance_target_alias_is_rejected(self):
+        release, manifest, payloads, targets = fixture()
+        targets[0]["provenance_target_aliases"] = []
+        report = smoke.verify_release_payload(
+            release, manifest, payloads, repository="wesleysimplicio/simplicio", tag="v3.8.17", targets=targets
+        )
+        self.assertTrue(any("provenance" in error for error in report["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_pypi_installer.py
+++ b/tests/unit/test_pypi_installer.py
@@ -14,7 +14,8 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 import simplicio  # noqa: E402
 from simplicio import __main__ as installer  # noqa: E402
 
-TEST_TRUST = {"3.8.11": "fixture-digest"}
+CURRENT_VERSION = "3.8.17"
+TEST_TRUST = {CURRENT_VERSION: "fixture-digest"}
 
 
 @pytest.fixture(autouse=True)
@@ -24,7 +25,7 @@ def fixture_manifest_trust(monkeypatch, request):
 
 
 def trusted_digest(payload):
-    TEST_TRUST["3.8.11"] = hashlib.sha256(payload).hexdigest()
+    TEST_TRUST[CURRENT_VERSION] = hashlib.sha256(payload).hexdigest()
     return TEST_TRUST
 
 
@@ -35,7 +36,7 @@ class FakeReleaseClient:
         trusted_digest(manifest)
         self.release_data = (
             {
-                "tag_name": "v3.8.11",
+                "tag_name": "v3.8.17",
                 "assets": [
                     {"name": installer.MANIFEST_ASSET},
                     {"name": "simplicio-linux-x64"},
@@ -70,7 +71,7 @@ class Response:
         return self.payload
 
 
-def manifest_for(payload, version="3.8.11", target="linux-x64", asset="simplicio-linux-x64"):
+def manifest_for(payload, version=CURRENT_VERSION, target="linux-x64", asset="simplicio-linux-x64"):
     return json_bytes(
         {
             "version": version,
@@ -88,7 +89,7 @@ def json_bytes(value):
 def valid_runner(command, **kwargs):
     assert command[1:] == ["version", "--json"]
     assert kwargs["check"] and kwargs["capture_output"] and kwargs["text"]
-    return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.11"}}', "")
+    return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.17"}}', "")
 
 
 def test_install_verifies_then_atomically_replaces_binary(tmp_path, monkeypatch):
@@ -171,7 +172,7 @@ def test_target_uses_canonical_distribution_asset_names():
 def test_install_rejects_missing_release_before_any_download(tmp_path, monkeypatch):
     client = FakeReleaseClient(manifest_for(b"runtime"), release=False)
     monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
-    with pytest.raises(installer.InstallError, match="Release v3.8.11 was not found"):
+    with pytest.raises(installer.InstallError, match=f"GitHub Release v{CURRENT_VERSION}"):
         installer.do_install(client=client, install_dir=tmp_path, runner=valid_runner)
     assert client.downloaded == []
 
@@ -278,7 +279,7 @@ def test_release_client_rejects_non_github_asset_url():
 
 def test_default_manifest_pin_matches_versioned_checkout():
     payload = (REPO_ROOT / "simplicio-update-manifest.json").read_bytes()
-    assert installer.TRUSTED_MANIFEST_SHA256["3.8.11"] == hashlib.sha256(payload).hexdigest()
+    assert installer.TRUSTED_MANIFEST_SHA256[CURRENT_VERSION] == hashlib.sha256(payload).hexdigest()
 
 
 def test_install_rejects_substituted_or_unpinned_manifest_before_runtime_download(
@@ -292,7 +293,7 @@ def test_install_rejects_substituted_or_unpinned_manifest_before_runtime_downloa
             client=client,
             install_dir=tmp_path,
             runner=valid_runner,
-            trusted_manifest_sha256={"3.8.11": "0" * 64},
+            trusted_manifest_sha256={CURRENT_VERSION: "0" * 64},
         )
     assert client.downloaded == [installer.MANIFEST_ASSET]
 
@@ -311,11 +312,11 @@ def test_target_rejects_unsupported_platform():
 
 def test_artifact_rejects_wrong_name_and_invalid_digest():
     with pytest.raises(installer.InstallError, match="asset mismatch"):
-        installer._artifact(json.loads(manifest_for(b"x")), "linux-x64", "other", "3.8.11")
+        installer._artifact(json.loads(manifest_for(b"x")), "linux-x64", "other", CURRENT_VERSION)
     manifest = json.loads(manifest_for(b"x"))
     manifest["artifacts"][0]["sha256"] = "not-a-digest"
     with pytest.raises(installer.InstallError, match="valid SHA-256"):
-        installer._artifact(manifest, "linux-x64", "simplicio-linux-x64", "3.8.11")
+        installer._artifact(manifest, "linux-x64", "simplicio-linux-x64", CURRENT_VERSION)
 
 
 @pytest.mark.parametrize(
@@ -348,7 +349,7 @@ def test_windows_staging_uses_exe_suffix(tmp_path, monkeypatch):
 
     def runner(command, **kwargs):
         staged_paths.append(command[0])
-        return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.11"}}', "")
+        return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.17"}}', "")
 
     installer.do_install(client=client, install_dir=tmp_path, runner=runner)
     assert staged_paths[0].endswith(".exe")


### PR DESCRIPTION
## Summary
- Add `scripts/post_release_smoke.py` to validate the published GitHub Release, not only local staging.
- Verify all four artifacts, immutable URLs, SHA-256, Ed25519 sidecars, SBOMs, provenance, and release asset set.
- Execute the native artifact with a clean HOME to verify runtime version, login enforcement, MCP tool exposure, and structured `login_required` on `tools/call`.
- Make provenance target aliases explicit and synchronize the PyPI launcher to Runtime v3.8.17.
- Document the mandatory post-release receipt in `docs/RELEASE_RUNBOOK.md`.

## Verification
- `python3 -m pytest -q`: 156 passed, 30 subtests passed.
- Distribution audit: 0 errors, 0 warnings, 8 OK.
- Public v3.8.17 static smoke: all 4 artifacts verified.
- Native macOS arm64 smoke: version 3.8.17, 46 MCP tools, login gate and MCP call gate passed.
- `sh -n install.sh`, Python compilation, and `git diff --check` passed.

No new binary release is created by this PR; it establishes the mandatory verification gate for every future published release.
