### PR TITLE
fix: preserve provider credentials during uninstall

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -412,8 +412,16 @@ if ($Uninstall) {
   if (Test-Path $PreviousPath) { Remove-Item -Force $PreviousPath }
   if ($purgeData) {
     if ([string]::IsNullOrWhiteSpace($bundleDir) -or $bundleDir -eq $env:USERPROFILE -or $bundleDir -eq "\") { Write-Error "refusing to purge a broad directory: $bundleDir"; exit 1 }
-    if (Test-Path $bundleDir) { Remove-Item -Recurse -Force $bundleDir }
-    Write-Host "  ✓ user data removed from $bundleDir"
+    if (Test-Path $bundleDir) {
+      # Provider credentials may live in ~/.simplicio/.env. Purge only
+      # Simplicio-managed state and keep that user-owned secret file intact.
+      Get-ChildItem -LiteralPath $bundleDir -Force |
+        Where-Object { $_.Name -ne ".env" } |
+        Remove-Item -Recurse -Force
+      Write-Host "  ✓ Simplicio data removed from $bundleDir (.env preserved)"
+    } else {
+      Write-Host "  ✓ no Simplicio data found at $bundleDir (.env absent)"
+    }
   } else {
     Write-Host "  ✓ user data under $env:USERPROFILE\.simplicio was preserved (-KeepData)"
   }

--- a/install.sh
+++ b/install.sh
@@ -496,8 +496,18 @@ run_uninstall() {
     case "$PURGE_DIR" in
       ""|"/"|"$HOME") err "recusando purge de um diretório amplo: $PURGE_DIR" ;;
     esac
-    rm -rf "$PURGE_DIR"
-    ok "dados do usuário removidos de $PURGE_DIR"
+    if [ -d "$PURGE_DIR" ]; then
+      # Provider credentials may live in ~/.simplicio/.env.  Purge only
+      # Simplicio-managed state and keep that user-owned secret file intact.
+      for _entry in "$PURGE_DIR"/* "$PURGE_DIR"/.[!.]* "$PURGE_DIR"/..?*; do
+        [ -e "$_entry" ] || [ -L "$_entry" ] || continue
+        [ "$(basename "$_entry")" = ".env" ] && continue
+        rm -rf "$_entry"
+      done
+      ok "dados do Simplicio removidos de $PURGE_DIR (.env preservado)"
+    else
+      ok "não havia dados do Simplicio em $PURGE_DIR (.env inexistente)"
+    fi
   else
     ok "dados do usuário em $PURGE_DIR foram preservados (--keep-data)"
   fi

--- a/tests/test_install_transaction_contract.py
+++ b/tests/test_install_transaction_contract.py
@@ -11,7 +11,9 @@ def test_shell_uninstall_policy_and_rollback_are_explicit():
     assert 'INSTALL_TRANSACTION_ACTIVE' in text
     assert 'PREVIOUS_PATH' in text
     assert 'rollback_install' in text
-    assert 'rm -rf "$PURGE_DIR"' in text
+    assert 'for _entry in "$PURGE_DIR"/*' in text
+    assert 'basename "$_entry"' in text
+    assert 'dados do Simplicio removidos' in text
 
 
 def test_powershell_uninstall_policy_and_rollback_are_explicit():
@@ -21,4 +23,39 @@ def test_powershell_uninstall_policy_and_rollback_are_explicit():
     assert '$InstallTransactionActive' in text
     assert '$PreviousPath' in text
     assert 'Invoke-Rollback' in text
-    assert 'Remove-Item -Recurse -Force $bundleDir' in text
+    assert 'Where-Object { $_.Name -ne ".env" }' in text
+    assert 'Simpli' in text and '.env preserved' in text
+
+
+def test_shell_purge_removes_simplicio_state_but_preserves_provider_env(tmp_path):
+    import os
+    import subprocess
+
+    bundle = tmp_path / '.simplicio'
+    bundle.mkdir()
+    dotenv = bundle / '.env'
+    dotenv.write_text('XAI_API_KEY=redacted-test-value\n', encoding='utf-8')
+    (bundle / 'runtime-state.json').write_text('{}\n', encoding='utf-8')
+    binary = tmp_path / '.local' / 'bin' / 'simplicio'
+    binary.parent.mkdir(parents=True)
+    binary.write_text('binary\n', encoding='utf-8')
+
+    env = os.environ.copy()
+    env.update({
+        'HOME': str(tmp_path),
+        'SIMPLICIO_BIN_DIR': str(binary.parent),
+        'SIMPLICIO_BUNDLE_DIR': str(bundle),
+        'SIMPLICIO_CONFIRM_PURGE': '1',
+    })
+    result = subprocess.run(
+        ['sh', str(ROOT / 'install.sh'), '--uninstall', '--purge'],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert dotenv.exists()
+    assert not (bundle / 'runtime-state.json').exists()
+    assert not binary.exists()


### PR DESCRIPTION
Summary: make public purge remove only Simplicio-managed children; preserve .simplicio/.env; add behavioral regression coverage for provider credentials. Validation: pytest installer/public contracts and sh -n install.sh. The repository default branch is master; pre-existing working-tree documentation and hook changes remain unstaged and were not included.