### PR TITLE
fix(installer): publish local MCP hooks and install contracts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,17 +54,21 @@ explicit data-preserving uninstall:
 # macOS / Linux
 sh install.sh --doctor
 sh install.sh --uninstall --keep-data
-sh install.sh --uninstall --purge       # confirmation required
+sh install.sh --uninstall --purge       # confirmation required; preserves ~/.simplicio/.env
 ~~~
 
 ~~~powershell
 # Windows
 pwsh install.ps1 -Doctor
 pwsh install.ps1 -Uninstall -KeepData
-pwsh install.ps1 -Uninstall -Purge      # confirmation required
+pwsh install.ps1 -Uninstall -Purge      # confirmation required; preserves .env
 ~~~
 
-Uninstall removes the installed binary and keeps user data by default. Set
+Uninstall removes the installed binary and keeps user data by default. This
+includes the 30-day Google login state at `~/.simplicio/login.json`, which is
+outside the executable and survives upgrades. Even an explicit purge removes
+only Simplicio-managed state and preserves `~/.simplicio/.env`, where provider
+credentials may live; purge intentionally removes the login state too. Set
 SIMPLICIO_CONFIRM_PURGE=1 for a non-interactive purge.
 
 ## Verify Installation
@@ -220,11 +224,16 @@ product's configuration. To enable versioned MCP registration and managed hooks:
 SIMPLICIO_INSTALL_CODEX=1 sh install.sh
 ~~~
 
-The registration points to simplicio serve --mcp --stdio. The Runtime still
+The registration points to `simplicio serve --mcp --stdio`. The Runtime still
 requires Google login and active entitlement for every local MCP session; never
-copy tokens into config files. Review enabled hooks in Settings → Hooks and use
-codex mcp list. To repair, rerun with SIMPLICIO_INSTALL_CODEX=1. Use
-SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
+copy tokens into config files. The managed Codex hooks cover all tool events,
+are versioned with the release, preserve existing user hooks, and are updated
+idempotently. The route is mandatory and has no environment-variable escape:
+native reads, edits, shell commands, and directory exploration are denied; use
+the Simplicio MCP tools. Review enabled hooks in Settings → Hooks and verify
+the MCP command with `codex mcp list`. To repair, rerun with
+`SIMPLICIO_INSTALL_CODEX=1`; the integration helper keeps user data separate
+and `.simplicio.bak` copies are created for managed Codex files.
 
 ## Building from Source
 
@@ -259,14 +268,15 @@ Use the installer so the binary and transaction journal are handled together:
 
 ~~~bash
 sh install.sh --uninstall --keep-data       # default, preserves ~/.simplicio
-sh install.sh --uninstall --purge            # removes ~/.simplicio after confirmation
+sh install.sh --uninstall --purge            # removes Simplicio state; preserves ~/.simplicio/.env
 ~~~
 
 ~~~powershell
 pwsh install.ps1 -Uninstall -KeepData
-pwsh install.ps1 -Uninstall -Purge
+pwsh install.ps1 -Uninstall -Purge            # preserves ~/.simplicio/.env
 ~~~
 
 Interactive purge requires typing PURGE. For non-interactive use, set
 SIMPLICIO_CONFIRM_PURGE=1. Project-local .simplicio data is not removed by
---keep-data; inspect the target before choosing --purge.
+--keep-data; inspect the target before choosing --purge. Provider credentials
+stored in `.simplicio/.env` are preserved by both installers.

--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -35,8 +35,18 @@ Google login and entitlement on every MCP session. Existing user hooks remain
 preserved; review enabled Simplicio hooks in Settings → Hooks and run codex mcp
 list. Never paste tokens into either config file.
 
-To repair the managed integration, rerun with SIMPLICIO_INSTALL_CODEX=1. Set
-SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
+To verify the registration:
+
+```bash
+codex mcp list
+```
+
+The hook route is mandatory and has no environment-variable escape hatch.
+Native reads, edits, shell commands, and directory exploration are denied; use
+the Simplicio MCP tools. Rerunning the installer repairs the integration
+idempotently. To repair the managed integration, rerun with
+`SIMPLICIO_INSTALL_CODEX=1`. The integration helper keeps user data separate
+and leaves `.simplicio.bak` copies of the original Codex files.
 
 ## Other clients: local STDIO
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ keep-data mode removes the installed binary and preserves ~/.simplicio:
 
 ~~~bash
 sh install.sh --uninstall --keep-data       # macOS/Linux
-sh install.sh --uninstall --purge            # also removes ~/.simplicio after confirmation
+sh install.sh --uninstall --purge            # removes Simplicio state; preserves ~/.simplicio/.env
 ~~~
 
 ~~~powershell
 pwsh install.ps1 -Uninstall -KeepData         # Windows
-pwsh install.ps1 -Uninstall -Purge            # also removes user data after confirmation
+pwsh install.ps1 -Uninstall -Purge            # removes Simplicio state; preserves .env
 ~~~
 
 For non-interactive purge, set SIMPLICIO_CONFIRM_PURGE=1 explicitly. The
-installer never edits PATH profiles.
+installer never edits PATH profiles or removes provider credentials from `.simplicio/.env`.
 
 ### What the binary contains
 
@@ -148,6 +148,13 @@ required before product commands, MCP, and the ecosystem integration can be used
 Public beta access may be free, but beta does not bypass the active-entitlement
 check. When beta access ends, the entitlement must come from an active
 subscription.
+
+A completed login remains usable for 30 days through the rotating refresh token.
+The Runtime stores that revocable state at `~/.simplicio/login.json`, outside the
+executable, so reinstalling or upgrading to another release does not require a
+new Google login. The official installers preserve this file; an explicit
+`--purge` is the only installer mode that removes it. To use another location,
+set `SIMPLICIO_AUTH_FILE` consistently before logging in and before upgrading.
 
 ### First login (compatible releases)
 
@@ -240,18 +247,27 @@ args = ["serve", "--mcp", "--stdio"]
 
 This keeps MCP execution local and avoids the latency of the local HTTP daemon.
 The Runtime still enforces Google login and entitlement for every MCP session.
-The managed Codex hooks are versioned with the release, existing hooks are
-preserved, and repeated setup is idempotent. Review the result in Settings →
-Hooks and verify the MCP command with:
+The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
+`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`; existing
+Codex hooks are preserved and the Simplicio entries are updated idempotently.
+The `PreToolUse` route is mandatory: native host reads, edits, shell commands,
+and directory exploration are denied; use Simplicio MCP. Lifecycle events also
+start a bounded `map -> fast` context warm-up in the background.
+The managed hooks are versioned with the release, and repeated setup is
+idempotent. Review the result in Settings → Hooks and verify the MCP command
+with:
 
 ~~~bash
 codex mcp list
 ~~~
 
-To repair the integration, rerun the installer with SIMPLICIO_INSTALL_CODEX=1.
-The managed integration has a separate status/install/uninstall/repair helper in
-scripts/codex_integration.py; user data remains separate from the integration.
-Set SIMPLICIO_MCP_ROUTE=0 for a temporary hook escape hatch.
+To repair the integration, rerun the installer with
+`SIMPLICIO_INSTALL_CODEX=1`. The managed integration has a separate
+status/install/uninstall/repair helper in `scripts/codex_integration.py`; user
+data remains separate from the integration. Original `config.toml` and
+`hooks.json` files are kept in `.simplicio.bak` copies on the first managed
+write. There is no environment-variable escape hatch; rerun the installer to
+repair a missing or stale route.
 
 ### Other MCP clients: local STDIO
 
@@ -492,7 +508,8 @@ LLM (Claude/Codex/Gemini)          Simplicio Runtime
 
 Re-running the official installer is the simplest update path. It downloads
 the latest release, verifies the SHA256 checksum and Ed25519 signature, validates
-the Runtime release contract, and keeps ~/.simplicio user data. Re-running the
+the Runtime release contract, preserves `~/.simplicio/login.json`, and keeps
+the remaining ~/.simplicio user data. Re-running the
 installer keeps the installation on GitHub's latest release. The installer refuses
 to replace a working binary with a release that lacks the embedded bundle,
 Google login activation, a configured update key, or a verifiable signature.

--- a/codex/mcp-route.ps1
+++ b/codex/mcp-route.ps1
@@ -1,82 +1,67 @@
-# Simplicio MCP route hook for Codex on Windows.
-$ErrorActionPreference = "SilentlyContinue"
-
-function Allow-Hook {
-  Write-Output '{"decision":"allow"}'
-  exit 0
-}
-
-function Deny-Hook([string]$Reason) {
-  $payload = @{ decision = "deny"; reason = $Reason } | ConvertTo-Json -Compress
-  Write-Output $payload
-  [Console]::Error.WriteLine($Reason)
-  exit 2
-}
-
-if ($env:SIMPLICIO_MCP_ROUTE -eq "0" -or $env:SIMPLICIO_MCP_ROUTE -eq "off") {
-  Allow-Hook
-}
-
+# Simplicio MCP route — mandatory PreToolUse policy for Windows hosts.
+# simplicio-hook-version: 3240-v1
+$ErrorActionPreference = 'Stop'
 $raw = [Console]::In.ReadToEnd()
-if ([string]::IsNullOrWhiteSpace($raw)) { Allow-Hook }
-try { $hook = $raw | ConvertFrom-Json } catch { Allow-Hook }
-
-$event = [string]($hook.hookEventName)
-if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.hook_event_name }
-if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.event }
-$eventKey = $event.Replace("-", "_").ToLowerInvariant()
-
-$context = "Use Simplicio MCP for this hop. Orient: simplicio_orient (or map --task). Create: simplicio_edit. Read one file: simplicio_file_read. Do not run simplicio --help / edit --help / runtime map / search_tool for simplicio. Do not read SKILL.md / simplicio-orient / simplicio-runtime/src. Escape: SIMPLICIO_MCP_ROUTE=0 or # simplicio:allow."
-$contextEvents = @{
-  "sessionstart" = "SessionStart"; "session_start" = "SessionStart"
-  "userpromptsubmit" = "UserPromptSubmit"; "user_prompt_submit" = "UserPromptSubmit"
-  "subagentstart" = "SubagentStart"; "subagent_start" = "SubagentStart"
-}
-if ($contextEvents.ContainsKey($eventKey)) {
-  @{ hookSpecificOutput = @{ hookEventName = $contextEvents[$eventKey]; additionalContext = $context } } | ConvertTo-Json -Compress
-  exit 0
-}
-
+if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+try { $hook = $raw | ConvertFrom-Json } catch { [Console]::Error.WriteLine('Simplicio MCP hook received invalid input JSON.'); exit 2 }
+if ($null -eq $hook) { [Console]::Error.WriteLine('Simplicio MCP hook received an empty input payload.'); exit 2 }
 $tool = [string]$hook.toolName
 if ([string]::IsNullOrWhiteSpace($tool)) { $tool = [string]$hook.tool_name }
-if ($tool.ToLowerInvariant().Contains("simplicio")) { Allow-Hook }
-$toolInput = $hook.toolInput
-if ($null -eq $toolInput) { $toolInput = $hook.tool_input }
-$command = [string]$toolInput.command
-$path = [string]$toolInput.target_file
-if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.file_path }
-if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.path }
-if ([string]::IsNullOrWhiteSpace($path)) { $path = [string]$toolInput.file }
-$blob = "$command $path"
-if ($blob.Contains("simplicio:allow") -or $blob.Contains("SIMPLICIO_MCP_ROUTE=0")) { Allow-Hook }
-
-$pathNorm = $path.Replace("\", "/")
-if ($pathNorm.EndsWith("/simplicio/SKILL.md") -or $path -match "AGENTS\.md|CLAUDE\.md|USER\.md|mcp-route\.ps1|[\\/]\.grok[\\/]docs[\\/]|[\\/]\.claude[\\/]hooks[\\/]|[\\/]\.simplicio[\\/]hooks[\\/]") { Allow-Hook }
-
-$lower = $tool.ToLowerInvariant()
-$base = ($lower -split "__|/")[-1] -replace "[^a-z0-9_]", ""
-if ($base -in @("list_dir", "listdir", "readdirectory")) { Allow-Hook }
-if ($base -in @("read", "grep", "glob", "readdirectory", "filesearch", "read_file", "readfile") -or $lower.EndsWith("_read") -or $lower.Contains("read_file")) {
-  Deny-Hook ("Use simplicio_file_read / simplicio_read / simplicio_search / simplicio_orient. " + $context)
+$input = $hook.toolInput
+if ($null -eq $input) { $input = $hook.tool_input }
+$event = [string]$hook.hookEventName
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.hook_event_name }
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.event }
+$event = $event.Replace('-','_').ToLowerInvariant()
+$isPreToolUse = $event -in @('pretooluse','pre_tool_use')
+$command = if ($input) { [string]$input.command } else { '' }
+$path = if ($input) {
+  $candidate = [string]$input.target_file
+  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.file_path }
+  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.path }
+  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.file }
+  $candidate
+} else { '' }
+$context = 'Simplicio MCP is mandatory. Use simplicio_map first, then simplicio_context for the bounded Fast context packet and simplicio_memory for recall; use simplicio_file_read or simplicio_read, simplicio_search, simplicio_edit, simplicio_run/simplicio_exec, and simplicio_validate. There is no host-tool escape hatch.'
+$events = @{'sessionstart'='SessionStart';'session_start'='SessionStart';'userpromptsubmit'='UserPromptSubmit';'user_prompt_submit'='UserPromptSubmit';'subagentstart'='SubagentStart';'subagent_start'='SubagentStart'}
+if ($events.ContainsKey($event)) {
+  @{hookSpecificOutput=@{hookEventName=$events[$event];additionalContext=$context}} | ConvertTo-Json -Compress
+  exit 0
 }
-
-if ($base -in @("write") -or $lower.EndsWith("_write")) {
-  $destination = $path
-  if (-not [System.IO.Path]::IsPathRooted($destination) -and $hook.cwd) { $destination = Join-Path ([string]$hook.cwd) $destination }
-  if ($destination -and -not (Test-Path -LiteralPath $destination)) { Allow-Hook }
+function Deny([string]$detail) {
+  $reason = '[Simplicio MCP required] ' + $detail + ' ' + $context
+  EmitDecision 'deny' $reason
+  [Console]::Error.WriteLine($reason)
+  exit 2
 }
-if ($base -in @("search_replace", "searchreplace", "strreplace") -or $lower.Contains("search_replace")) { Allow-Hook }
-if ($base -in @("edit", "write", "multiedit", "strreplace", "search_replace", "searchreplace", "applypatch", "apply_patch") -or $lower.EndsWith("_write")) {
-  Deny-Hook ("Use simplicio_edit for mutations. " + $context)
+function EmitDecision([string]$decision, [string]$reason = '') {
+  if ($isPreToolUse) {
+    $specific = @{hookEventName='PreToolUse';permissionDecision=$decision}
+    if ($reason) { $specific.permissionDecisionReason = $reason }
+    @{hookSpecificOutput=$specific} | ConvertTo-Json -Compress
+  } else {
+    $result = @{decision=$decision}
+    if ($reason) { $result.reason = $reason }
+    $result | ConvertTo-Json -Compress
+  }
 }
-
-if ($base -in @("bash", "run_terminal_command", "shell", "run")) {
-  if ($command -match "(^|[;&|`n])\s*\S*simplicio(\s+--help|\s+-h|\s+serve\s+--help|\s+\S+\s+--help)\b") { Deny-Hook ("Do not dump simplicio --help. " + $context) }
-  if ($command -match "(^|[;&|`n])\s*(?:\S*[\\/])?simplicio(?![\w./-])\s*([;&`n]|$)") { Deny-Hook ("Do not run bare simplicio. " + $context) }
-  if ($command -match "simplicio-runtime[\\/](src|schemas|crates)|edit-plan\.schema|operations\.rs") { Deny-Hook ("Do not search Simplicio source to learn edit. " + $context) }
-  $lead = (($command.Trim() -split "\s+") | Where-Object { $_ -notmatch "^[A-Za-z_][A-Za-z0-9_]*=" } | Select-Object -First 1)
-  if ($lead -in @("cat", "head", "tail", "less", "more", "bat", "nl", "rg", "grep", "ag", "find")) { Deny-Hook ("Use simplicio_file_read / simplicio_search instead of " + $lead + ". " + $context) }
-  if ($lead -in @("sed", "awk", "perl")) { Deny-Hook ("Use simplicio_edit instead of " + $lead + ". " + $context) }
+if ($tool.ToLowerInvariant().Contains('simplicio')) { EmitDecision 'allow'; exit 0 }
+$normalized = $path.Replace('\','/')
+if ((Split-Path -Leaf $normalized) -in @('AGENTS.md','CLAUDE.md','GEMINI.md','USER.md') -or $normalized.Contains('/.simplicio/hooks/')) { EmitDecision 'allow'; exit 0 }
+$tokens = $command.Trim() -split '\s+' | Where-Object { $_ -ne '' }
+$index = 0
+while ($index -lt $tokens.Count -and $tokens[$index] -match '^[A-Za-z_][A-Za-z0-9_]*=') { $index++ }
+$lead = if ($index -lt $tokens.Count) { Split-Path -Leaf $tokens[$index] } else { '' }
+$base = $tool.ToLowerInvariant().Split('__')[-1].Split('/')[-1] -replace '[^a-z0-9_]',''
+if ($base -in @('bash','shell','run','runterminalcommand','run_terminal_command','terminal')) {
+  if ($lead -in @('simplicio','simplicio.exe')) {
+    if ($command -match '(^|\s)(--help|-h)(\s|$)' -or $command.Trim() -in @('simplicio','simplicio.exe')) { Deny 'Use a specific Simplicio MCP tool; do not dump CLI help or run the bare CLI.' }
+    EmitDecision 'allow'; exit 0
+  }
+  if ($lead -in @('sed','awk','perl')) {
+    if ($command -match '(^|\s)(--in-place|-i|-[A-Za-z]*i[A-Za-z]*)(\s|$)') { Deny ('Use simplicio_edit instead of ' + $lead + '.') }
+    Deny ('Use simplicio_file_read / simplicio_read / simplicio_search instead of ' + $lead + '.')
+  }
+  Deny 'Native shell commands are disabled; use simplicio_exec, simplicio_run, or the matching Simplicio MCP tool.'
 }
-
-Allow-Hook
+Deny ("Native host tool '" + $(if ($tool) { $tool } else { 'unknown' }) + "' is disabled; use the matching Simplicio MCP tool.")

--- a/codex/mcp-route.sh
+++ b/codex/mcp-route.sh
@@ -1,177 +1,127 @@
 #!/usr/bin/env bash
-# Simplicio MCP route hook for Codex.
-# It nudges host reads/edits toward the local Simplicio MCP tools while keeping
-# an explicit escape hatch for operations that must stay host-native.
+# Simplicio MCP route — mandatory PreToolUse policy for every supported host.
+# simplicio-hook-version: 3240-v1
 set -uo pipefail
 
-if [ "${SIMPLICIO_MCP_ROUTE:-on}" = "0" ] || [ "${SIMPLICIO_MCP_ROUTE:-on}" = "off" ]; then
-  printf '%s\n' '{"decision":"allow"}'
-  exit 0
-fi
-
 INPUT="$(cat 2>/dev/null || true)"
-[ -n "$INPUT" ] || { printf '%s\n' '{"decision":"allow"}'; exit 0; }
-
+[ -n "$INPUT" ] || exit 0
 if ! command -v python3 >/dev/null 2>&1; then
-  printf '%s\n' '{"decision":"allow"}'
-  exit 0
+  printf '%s\n' 'Simplicio MCP hook cannot run because python3 is unavailable.' >&2
+  exit 2
 fi
-
 export SIMPLICIO_MCP_ROUTE_INPUT="$INPUT"
 python3 - <<'PY'
-import json
-import os
-import re
-import sys
+import json, os, pathlib, re, subprocess, sys
 
 raw = os.environ.get("SIMPLICIO_MCP_ROUTE_INPUT", "")
 try:
     hook = json.loads(raw)
 except Exception:
-    print(json.dumps({"decision": "allow"}))
-    raise SystemExit(0)
-
-event = (
-    hook.get("hookEventName")
-    or hook.get("hook_event_name")
-    or hook.get("event")
-    or ""
-).replace("-", "_").lower()
-tool = hook.get("toolName") or hook.get("tool_name") or ""
-tool_input = hook.get("toolInput") or hook.get("tool_input") or {}
-if not isinstance(tool_input, dict):
-    tool_input = {}
-
-create_plan = (
-    '{"file":"<relative-path>","operations":[{"op":"create",'
-    '"content":"<file body>"}]}'
-)
-context = (
-    "Use Simplicio MCP for this hop. "
-    "Orient: simplicio_orient (or map --task). "
-    "Create: simplicio_edit plan=" + create_plan + ". "
-    "Read one file: simplicio_file_read. "
-    "Do not run simplicio --help / edit --help / runtime map / search_tool for simplicio. "
-    "Do not read SKILL.md / simplicio-orient / simplicio-runtime/src. "
-    "Second pass on a file you just wrote: search_replace the tokens; do not re-read. "
-    "Escape: SIMPLICIO_MCP_ROUTE=0 or # simplicio:allow."
-)
-
-context_events = {
-    "sessionstart": "SessionStart",
-    "session_start": "SessionStart",
-    "userpromptsubmit": "UserPromptSubmit",
-    "user_prompt_submit": "UserPromptSubmit",
-    "subagentstart": "SubagentStart",
-    "subagent_start": "SubagentStart",
-}
-if event in context_events:
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": context_events[event],
-            "additionalContext": context,
-        }
-    }))
-    raise SystemExit(0)
-
-lower = str(tool).lower()
-if "simplicio" in lower:
-    print(json.dumps({"decision": "allow"}))
-    raise SystemExit(0)
-
-command = str(tool_input.get("command") or "")
-path = str(
-    tool_input.get("target_file")
-    or tool_input.get("file_path")
-    or tool_input.get("path")
-    or tool_input.get("file")
-    or ""
-)
-blob = f"{command} {path}"
-if "simplicio:allow" in blob or "SIMPLICIO_MCP_ROUTE=0" in blob:
-    print(json.dumps({"decision": "allow"}))
-    raise SystemExit(0)
-
-bootstrap = (
-    "AGENTS.md",
-    "CLAUDE.md",
-    "USER.md",
-    "mcp-route.sh",
-    "/.grok/docs/",
-    "/.claude/hooks/",
-    "/.simplicio/hooks/",
-)
-path_norm = path.replace("\\", "/")
-if path_norm.endswith("/simplicio/SKILL.md") or any(token in path for token in bootstrap):
-    print(json.dumps({"decision": "allow"}))
-    raise SystemExit(0)
-
-
-def deny(reason: str) -> None:
-    print(json.dumps({"decision": "deny", "reason": reason}))
-    sys.stderr.write(reason + "\n")
+    print("Simplicio MCP hook received invalid input JSON.", file=sys.stderr)
     raise SystemExit(2)
 
+event = str(hook.get("hookEventName") or hook.get("hook_event_name") or hook.get("event") or "").replace("-", "_").lower()
+tool = str(hook.get("toolName") or hook.get("tool_name") or "")
+tool_input = hook.get("toolInput") or hook.get("tool_input") or {}
+if not isinstance(tool_input, dict): tool_input = {}
+context = ("Simplicio MCP is mandatory. Use simplicio_map first, then simplicio_context for the bounded Fast context packet "
+           "and simplicio_memory for recall; use simplicio_file_read or simplicio_read, simplicio_search, "
+           "simplicio_edit, simplicio_run/simplicio_exec, and simplicio_validate. There is no host-tool escape hatch.")
 
-reads = {
-    "read", "grep", "glob", "readdirectory", "filesearch", "read_file",
-    "readfile", "list_dir", "listdir",
-}
-edits = {
-    "edit", "write", "multiedit", "strreplace", "search_replace",
-    "searchreplace", "applypatch", "apply_patch",
-}
-base = re.sub(r"[^a-z0-9_]+", "", lower.split("__")[-1].split("/")[-1])
+def which(name):
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = pathlib.Path(directory) / name
+        if candidate.is_file() and os.access(candidate, os.X_OK): return str(candidate)
+    return None
 
-if base in {"list_dir", "listdir", "readdirectory"}:
-    print(json.dumps({"decision": "allow"}))
+def warm(root):
+    root = pathlib.Path(root).expanduser()
+    binary = which("simplicio")
+    if not root.is_dir() or not binary: return
+    state = root / ".simplicio" / "hook-context"
+    try:
+        state.mkdir(parents=True, exist_ok=True)
+        marker = state / "warm.pid"
+        if marker.is_file():
+            try:
+                os.kill(int(marker.read_text().strip()), 0); return
+            except (ValueError, OSError): pass
+        worker = (
+            "import pathlib,subprocess,sys\n"
+            "root=pathlib.Path(sys.argv[1]); state=root/'.simplicio'/'hook-context'; state.mkdir(parents=True,exist_ok=True); marker=state/'warm.pid'; marker.write_text(str(__import__('os').getpid()))\n"
+            "def run(args,out):\n"
+            "  tmp=out.with_suffix(out.suffix+'.tmp')\n"
+            "  try:\n"
+            "    with open(tmp,'w',encoding='utf-8') as f: subprocess.run(args,stdout=f,stderr=subprocess.DEVNULL,timeout=45,check=False)\n"
+            "    tmp.replace(out)\n"
+            "  except Exception:\n"
+            "    try: tmp.unlink()\n"
+            "    except OSError: pass\n"
+            "try:\n"
+            "  binary=sys.argv[2]\n"
+            "  run([binary,'map','--repo',str(root),'--for-llm','markdown'],state/'map.md')\n"
+            "  run([binary,'fast','build','--root',str(root),'--max-bytes','32000','--json'],state/'fast-build.json')\n"
+            "  run([binary,'fast','context','--root',str(root),'--max-bytes','32000','--json'],state/'fast-context.json')\n"
+            "finally:\n"
+            "  try: marker.unlink()\n"
+            "  except OSError: pass\n"
+        )
+        subprocess.Popen([sys.executable,"-c",worker,str(root),binary], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    except (OSError, ValueError): pass
+
+def packet(root):
+    state = pathlib.Path(root).expanduser()/".simplicio"/"hook-context"
+    parts=[]
+    for name,limit in (("map.md",24000),("fast-context.json",8000)):
+        try:
+            value=(state/name).read_text(encoding="utf-8",errors="replace")
+            if value.strip(): parts.append(f"\nSimplicio {name} (background, bounded):\n{value[:limit]}")
+        except OSError: pass
+    return "".join(parts)
+
+events={"sessionstart":"SessionStart","session_start":"SessionStart","userpromptsubmit":"UserPromptSubmit","user_prompt_submit":"UserPromptSubmit","subagentstart":"SubagentStart","subagent_start":"SubagentStart"}
+pre_tool_use = event in {"pretooluse", "pre_tool_use"}
+if event in events:
+    workspace=hook.get("workspace") or {}
+    root=str(hook.get("cwd") or hook.get("cwd_path") or (workspace.get("current_dir") if isinstance(workspace,dict) else "") or os.getcwd())
+    warm(root)
+    print(json.dumps({"hookSpecificOutput":{"hookEventName":events[event],"additionalContext":context+packet(root)}}))
     raise SystemExit(0)
 
-if base in reads or lower.endswith("_read") or "read_file" in lower:
-    deny("Use simplicio_file_read / simplicio_read / simplicio_search / simplicio_orient. " + context)
+def emit_decision(decision, reason=None):
+    if pre_tool_use:
+        specific = {"hookEventName": "PreToolUse", "permissionDecision": decision}
+        if reason: specific["permissionDecisionReason"] = reason
+        print(json.dumps({"hookSpecificOutput": specific}))
+    else:
+        result = {"decision": decision}
+        if reason: result["reason"] = reason
+        print(json.dumps(result))
 
-if base in {"write"} or lower.endswith("_write"):
-    destination = path
-    cwd = hook.get("cwd") or hook.get("cwd_path") or os.getcwd()
-    if destination and not os.path.isabs(destination):
-        destination = os.path.join(str(cwd), destination)
-    if destination and not os.path.exists(destination):
-        print(json.dumps({"decision": "allow"}))
-        raise SystemExit(0)
+def allow(): emit_decision("allow"); raise SystemExit(0)
+def deny(detail):
+    reason="[Simplicio MCP required] "+detail+" "+context
+    emit_decision("deny", reason); sys.stderr.write(reason+"\n"); raise SystemExit(2)
 
-if base in {"search_replace", "searchreplace", "strreplace"} or "search_replace" in lower:
-    print(json.dumps({"decision": "allow"}))
-    raise SystemExit(0)
+if "simplicio" in tool.lower(): allow()
+command=str(tool_input.get("command") or "")
+path=str(tool_input.get("target_file") or tool_input.get("file_path") or tool_input.get("path") or tool_input.get("file") or "")
+normalized=path.replace("\\","/")
+if normalized.rsplit("/",1)[-1] in {"AGENTS.md","CLAUDE.md","GEMINI.md","USER.md"} or "/.simplicio/hooks/" in normalized: allow()
 
-if base in edits or lower.endswith("_write"):
-    deny("Use simplicio_edit for mutations. Create: simplicio_edit plan=" + create_plan + ". " + context)
-
-if base in {"bash", "run_terminal_command", "shell", "run"}:
-    if re.search(
-        r"(^|[;&|\n])\s*\S*simplicio(\s+--help|\s+-h|\s+serve\s+--help|\s+\S+\s+--help)\b",
-        command,
-    ):
-        deny("Do not dump simplicio --help. " + context)
-    if re.search(r"(?:^|[;&|\n])\s*(?:\S*/)?simplicio(?![\w./-])\s*(?:[;&\n]|$)", command):
-        deny("Do not run bare simplicio (it dumps USAGE). " + context)
-    runtime_source = (
-        "simplicio-runtime/src", "simplicio-runtime/schemas", "simplicio-runtime/crates",
-        "edit-plan.schema", "operations.rs",
-    )
-    if any(token in command for token in runtime_source):
-        deny("Do not search Simplicio source to learn edit. " + context)
-    tokens = command.strip().split()
-    index = 0
-    while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
-        index += 1
-    lead = os.path.basename(tokens[index]) if index < len(tokens) else ""
-    if lead in {"cat", "head", "tail", "less", "more", "bat", "nl", "rg", "grep", "ag", "find"}:
-        deny("Use simplicio_file_read / simplicio_search instead of " + lead + ". " + context)
+tokens=command.strip().split(); i=0
+while i<len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=",tokens[i]): i+=1
+lead=os.path.basename(tokens[i]) if i<len(tokens) else ""
+base=re.sub(r"[^a-z0-9_]+","",tool.lower().split("__")[-1].split("/")[-1])
+if base in {"bash","shell","run","runterminalcommand","run_terminal_command","terminal"}:
+    if lead in {"simplicio","simplicio.exe"}:
+        if re.search(r"(?:^|\s)(?:--help|-h)(?:\s|$)",command) or command.strip() in {"simplicio","simplicio.exe"}: deny("Use a specific Simplicio MCP tool; do not dump CLI help or run the bare CLI.")
+        allow()
     if lead in {"sed", "awk", "perl"}:
-        deny("Use simplicio_edit instead of " + lead + ". " + context)
-    if lead in {"simplicio", "git", "gh", "cargo", "npm", "python", "python3", "sqlite3", "rustfmt"}:
-        print(json.dumps({"decision": "allow"}))
-        raise SystemExit(0)
-
-print(json.dumps({"decision": "allow"}))
+        in_place = re.search(r"(?:^|\s)(?:--in-place|-i|-[A-Za-z]*i[A-Za-z]*)(?:\s|$)", command)
+        if in_place:
+            deny("Use simplicio_edit instead of " + lead + ".")
+        deny("Use simplicio_file_read / simplicio_read / simplicio_search instead of " + lead + ".")
+    deny("Native shell commands are disabled; use simplicio_exec, simplicio_run, or the matching Simplicio MCP tool.")
+deny("Native host tool '"+(tool or "unknown")+"' is disabled; use the matching Simplicio MCP tool.")
 PY

--- a/install.ps1
+++ b/install.ps1
@@ -412,8 +412,16 @@ if ($Uninstall) {
   if (Test-Path $PreviousPath) { Remove-Item -Force $PreviousPath }
   if ($purgeData) {
     if ([string]::IsNullOrWhiteSpace($bundleDir) -or $bundleDir -eq $env:USERPROFILE -or $bundleDir -eq "\") { Write-Error "refusing to purge a broad directory: $bundleDir"; exit 1 }
-    if (Test-Path $bundleDir) { Remove-Item -Recurse -Force $bundleDir }
-    Write-Host "  ✓ user data removed from $bundleDir"
+    if (Test-Path $bundleDir) {
+      # Provider credentials may live in ~/.simplicio/.env. Purge only
+      # Simplicio-managed state and keep that user-owned secret file intact.
+      Get-ChildItem -LiteralPath $bundleDir -Force |
+        Where-Object { $_.Name -ne ".env" } |
+        Remove-Item -Recurse -Force
+      Write-Host "  ✓ Simplicio data removed from $bundleDir (.env preserved)"
+    } else {
+      Write-Host "  ✓ no Simplicio data found at $bundleDir (.env absent)"
+    }
   } else {
     Write-Host "  ✓ user data under $env:USERPROFILE\.simplicio was preserved (-KeepData)"
   }

--- a/install.ps1
+++ b/install.ps1
@@ -15,6 +15,7 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - Runtime report directory (default: ~/.simplicio)
+#   SIMPLICIO_AUTH_FILE        - optional stable login state path
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem) — target "windows-x64", asset
@@ -46,6 +47,8 @@ if ($env:SIMPLICIO_BIN_DIR) {
 }
 $DestPath = Join-Path $InstallDir $BinName
 $PreviousPath = "$DestPath.simplicio.previous"
+$AuthFile = if ($env:SIMPLICIO_AUTH_FILE) { $env:SIMPLICIO_AUTH_FILE } else { Join-Path $env:USERPROFILE ".simplicio\login.json" }
+$AuthFileWasPresent = Test-Path -LiteralPath $AuthFile
 $InstallTransactionActive = $false
 
 function Invoke-Rollback {
@@ -345,7 +348,7 @@ function Install-CodexIntegration {
     $hooks | Add-Member -MemberType NoteProperty -Name $Event -Value $items -Force
   }
 
-  Upsert-CodexHook "PreToolUse" "Bash|apply_patch|Edit|Write"
+  Upsert-CodexHook "PreToolUse" ".*"
   Upsert-CodexHook "SessionStart" "startup|resume|clear|compact"
   Upsert-CodexHook "SubagentStart" ""
   Upsert-CodexHook "UserPromptSubmit" ""
@@ -438,7 +441,7 @@ if ($Uninstall) {
       Get-ChildItem -LiteralPath $bundleDir -Force |
         Where-Object { $_.Name -ne ".env" } |
         Remove-Item -Recurse -Force
-      Write-Host "  ✓ Simplicio data removed from $bundleDir (.env preserved)"
+      Write-Host "  ✓ Simplicio data removed from $bundleDir (.env and login state removed by explicit purge)"
     } else {
       Write-Host "  ✓ no Simplicio data found at $bundleDir (.env absent)"
     }
@@ -586,6 +589,11 @@ try {
   exit 1
 }
 Write-Host "  ✓ installed: $DestPath"
+if ($AuthFileWasPresent -and -not (Test-Path -LiteralPath $AuthFile)) {
+  Invoke-Rollback
+  Write-Error "Login state disappeared during the upgrade: $AuthFile. Previous Runtime restored."
+  exit 1
+}
 
 # ─── Verify the downloaded Runtime ──────────────────────────────────────────
 try {
@@ -614,6 +622,11 @@ try {
   exit 1
 }
 Write-Host "  ✓ active Google session and entitlement verified"
+if ($AuthFileWasPresent -and -not (Test-Path -LiteralPath $AuthFile)) {
+  Invoke-Rollback
+  Write-Error "Login state disappeared during the upgrade: $AuthFile. Previous Runtime restored."
+  exit 1
+}
 
 if (-not (Test-McpToolSurface $DestPath)) {
   Invoke-Rollback
@@ -665,6 +678,7 @@ if (-not (Test-InPath $InstallDir)) {
 Write-Host ""
 Write-Host "  ✓ simplicio Runtime $Version (windows-x64) installed successfully"
 Write-Host "  ✓ Runtime release contract is active"
+Write-Host "  ✓ login state preserved outside the binary: $AuthFile"
 Write-Host "  ✓ no pip packages or sibling checkouts were installed"
 Write-Host "  ✓ active Google login is required for product commands"
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -103,13 +103,33 @@ function Test-Ed25519Signature([string]$BinaryPath, [string]$Signature, [string]
   try {
     $python = $null
     $pythonArgs = @()
-    if (Get-Command python3 -ErrorAction SilentlyContinue) { $python = "python3" }
-    elseif (Get-Command py -ErrorAction SilentlyContinue) { $python = "py"; $pythonArgs = @('-3') }
-    if (-not $python) { return $false }
+    # Windows commonly exposes Python as `py` or `python`, while `python3`
+    # may resolve to the Microsoft Store alias. Probe the interpreter before
+    # trusting its command name, then fail closed if no Python 3 is usable.
+    foreach ($candidate in @(
+      @{ Name = "py"; Args = @('-3') },
+      @{ Name = "python3"; Args = @() },
+      @{ Name = "python"; Args = @() }
+    )) {
+      if (-not (Get-Command $candidate.Name -ErrorAction SilentlyContinue)) { continue }
+      & $candidate.Name @($candidate.Args) -c "import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)" 2>$null
+      if ($LASTEXITCODE -eq 0) {
+        $python = $candidate.Name
+        $pythonArgs = @($candidate.Args)
+        break
+      }
+    }
+    if (-not $python) {
+      Write-Host "  ! Ed25519 verification requires Python 3 (tried py -3, python3, python)"
+      return $false
+    }
     Invoke-WebRequest -Uri $Ed25519HelperUrl -OutFile $helperPath -UseBasicParsing -ErrorAction Stop
     $helperHash = (Get-FileHash -Path $helperPath -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($helperHash -ne $Ed25519HelperSha256.ToLowerInvariant()) { return $false }
-    & $python @pythonArgs $helperPath --public-key $PublicKey --signature $Signature --sha256 $Digest
+    $normalizedSignature = ([string]$Signature).Trim()
+    $normalizedPublicKey = ([string]$PublicKey).Trim()
+    $normalizedDigest = ([string]$Digest).Trim().ToLowerInvariant()
+    & $python @pythonArgs $helperPath --public-key $normalizedPublicKey --signature $normalizedSignature --sha256 $normalizedDigest
     return ($LASTEXITCODE -eq 0)
   } catch {
     return $false

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR        - bundle report/data directory
+#   SIMPLICIO_AUTH_FILE         - optional stable login state path
 #   SIMPLICIO_CONFIRM_PURGE     - "1" confirms non-interactive --purge
 #
 # Asset naming follows distribution/targets.json (the canonical target
@@ -58,6 +59,9 @@ BIN_DIR="${SIMPLICIO_BIN_DIR:-$HOME/.local/bin}"
 DEST_PATH="$BIN_DIR/$BIN_NAME"
 PREVIOUS_PATH="$DEST_PATH.simplicio.previous"
 PURGE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
+AUTH_FILE="${SIMPLICIO_AUTH_FILE:-$HOME/.simplicio/login.json}"
+AUTH_FILE_WAS_PRESENT=false
+[ -s "$AUTH_FILE" ] && AUTH_FILE_WAS_PRESENT=true
 INSTALL_TRANSACTION_ACTIVE=false
 UNINSTALL_KEEP_DATA=true
 
@@ -504,7 +508,7 @@ run_uninstall() {
         [ "$(basename "$_entry")" = ".env" ] && continue
         rm -rf "$_entry"
       done
-      ok "dados do Simplicio removidos de $PURGE_DIR (.env preservado)"
+      ok "dados do Simplicio removidos de $PURGE_DIR (.env e login removidos pelo purge explícito)"
     else
       ok "não havia dados do Simplicio em $PURGE_DIR (.env inexistente)"
     fi
@@ -724,6 +728,9 @@ except Exception:
   INSTALL_TRANSACTION_ACTIVE=true
   mv -f "$STAGING_PATH" "$DEST_PATH"
   ok "Simplicio Runtime instalado em $DEST_PATH"
+  if [ "$AUTH_FILE_WAS_PRESENT" = true ] && [ ! -s "$AUTH_FILE" ]; then
+    err "o estado de login desapareceu durante a atualização: $AUTH_FILE; rollback executado"
+  fi
 fi
 
 # ─── 2.1 Verificar o contrato de release antes de anunciar sucesso ──────────
@@ -738,6 +745,10 @@ if ! require_active_login; then
   err "login não concluído ou sessão sem entitlement ativo; instalação bloqueada"
 fi
 ok "login Google ativo e entitlement válido"
+if [ "$AUTH_FILE_WAS_PRESENT" = true ] && [ ! -s "$AUTH_FILE" ]; then
+  err "o estado de login desapareceu durante a atualização: $AUTH_FILE; rollback executado"
+fi
+ok "estado de login preservado fora do binário: $AUTH_FILE"
 
 # MCP tools/list is intentionally post-login: clean installs must bootstrap the
 # binary and establish the session before invoking the authenticated surface.

--- a/install.sh
+++ b/install.sh
@@ -496,8 +496,18 @@ run_uninstall() {
     case "$PURGE_DIR" in
       ""|"/"|"$HOME") err "recusando purge de um diretório amplo: $PURGE_DIR" ;;
     esac
-    rm -rf "$PURGE_DIR"
-    ok "dados do usuário removidos de $PURGE_DIR"
+    if [ -d "$PURGE_DIR" ]; then
+      # Provider credentials may live in ~/.simplicio/.env.  Purge only
+      # Simplicio-managed state and keep that user-owned secret file intact.
+      for _entry in "$PURGE_DIR"/* "$PURGE_DIR"/.[!.]* "$PURGE_DIR"/..?*; do
+        [ -e "$_entry" ] || [ -L "$_entry" ] || continue
+        [ "$(basename "$_entry")" = ".env" ] && continue
+        rm -rf "$_entry"
+      done
+      ok "dados do Simplicio removidos de $PURGE_DIR (.env preservado)"
+    else
+      ok "não havia dados do Simplicio em $PURGE_DIR (.env inexistente)"
+    fi
   else
     ok "dados do usuário em $PURGE_DIR foram preservados (--keep-data)"
   fi

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -63,14 +63,13 @@ Each step buys a concrete gain in **quality**, **token economy**, or **delivery 
 | Event | Hooks |
 |---|---|
 | `Stop` | `loop_stop.py` (re-feed / evidence-gated exit) |
-| `PreToolUse` (Bash) | `action_gate.py` (fail-closed safety gate) · `orient_rewrite.py` (opt-in output clamp, shells out to `orient_clamp.py`) |
+| `PreToolUse` (all tools) | `mcp-route.sh` (mandatory Runtime route) · `action_gate.py` (fail-closed safety gate) · `orient_rewrite.py` (opt-in output clamp) |
 
-**Project-scoped by design.** The two `PreToolUse` (Bash) hooks act **only inside an active
-simplicio-loop project** — a directory tree containing an `.simplicio/orchestrator/` marker, or any session
-where `SIMPLICIO_LOOP=1` is set. In every other repo on the machine they no-op and the command runs
-unchanged, so installing this plugin never intercepts Bash globally. The home directory is never
-treated as a project, so a stray `~/.simplicio/orchestrator` cannot widen the scope. All hooks run locally and
-make zero network calls.
+The Runtime route is mandatory inside the host session: native reads, edits, shell commands, and
+directory exploration are denied, while Simplicio MCP tools are allowed. It also warms a bounded
+`map → fast` context packet in the background on lifecycle events. Install the Runtime first so
+`~/.simplicio/hooks/mcp-route.sh` exists; there is no environment-variable escape hatch. All hooks
+run locally and make zero network calls.
 
 ## Maintainers
 

--- a/plugin/hooks/hooks.claude.json
+++ b/plugin/hooks/hooks.claude.json
@@ -9,8 +9,9 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": ".*",
         "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mcp-route.sh\"" },
           { "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/action_gate.py\"" },
           { "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/orient_rewrite.py\"" }
         ]

--- a/tests/test_codex_hooks.sh
+++ b/tests/test_codex_hooks.sh
@@ -27,7 +27,65 @@ run_case() {
 run_case "context" '{"hook_event_name":"SessionStart","source":"startup"}' 0 'SessionStart'
 run_case "allow simplicio tool" '{"toolName":"simplicio__simplicio_read","toolInput":{"path":"x"}}' 0 'allow'
 run_case "deny host read" '{"toolName":"read_file","toolInput":{"file_path":"src/main.rs"}}' 2 'deny'
-run_case "allow search replace" '{"toolName":"search_replace","toolInput":{"file_path":"src/main.rs"}}' 0 'allow'
+run_case "deny native edit" '{"toolName":"search_replace","toolInput":{"file_path":"src/main.rs"}}' 2 'deny'
+run_case "deny native shell" '{"toolName":"Bash","toolInput":{"command":"git status"}}' 2 'deny'
+
+check_pre_tool_use_reason() {
+  name="$1"
+  payload="$2"
+  prefix="$3"
+  out="$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)"
+  got=$?
+  if [ "$got" = 2 ] && printf '%s' "$out" | PREFIX="$prefix" python3 -c '
+import json, os, sys
+reason = json.load(sys.stdin)["hookSpecificOutput"]["permissionDecisionReason"]
+assert reason.startswith(os.environ["PREFIX"])
+'; then
+    printf 'PASS %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_pre_tool_use_reason "read-only sed points to MCP read" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -n 1,5p src/main.rs"}}' \
+  '[Simplicio MCP required] Use simplicio_file_read'
+check_pre_tool_use_reason "mutating sed points to MCP edit" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -i s/old/new/ src/main.rs"}}' \
+  '[Simplicio MCP required] Use simplicio_edit'
+
+check_pre_tool_use_schema() {
+  name="$1"
+  payload="$2"
+  want_exit="$3"
+  out="$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)"
+  got=$?
+  if [ "$got" = "$want_exit" ] && printf '%s' "$out" | python3 -c '
+import json, sys
+value = json.load(sys.stdin)
+specific = value.get("hookSpecificOutput") or {}
+assert specific.get("hookEventName") == "PreToolUse"
+assert specific.get("permissionDecision") in {"allow", "deny", "ask"}
+'; then
+    printf 'PASS %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_pre_tool_use_schema "PreToolUse allow schema" \
+  '{"hook_event_name":"PreToolUse","tool_name":"simplicio__simplicio_read","tool_input":{"path":"src/main.rs"},"cwd":"/tmp"}' 0
+check_pre_tool_use_schema "PreToolUse deny schema" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"src/main.rs"},"cwd":"/tmp"}' 2
+
+if ! grep -q 'simplicio_map' "$HOOK" || ! grep -q 'simplicio_context' "$HOOK"; then
+  printf 'FAIL hook context is missing map/context routing\n' >&2
+  FAIL=$((FAIL + 1))
+fi
 
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -25,6 +25,15 @@ def test_installers_preserve_existing_codex_state():
     assert "Write-AtomicText" in powershell
 
 
+def test_installers_preserve_stable_login_state_during_upgrades():
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert "SIMPLICIO_AUTH_FILE" in shell
+    assert "SIMPLICIO_AUTH_FILE" in powershell
+    assert "login.json" in shell
+    assert "login.json" in powershell
+
+
 def test_windows_installer_migrates_legacy_unix_hooks():
     powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
     # Existing Windows users may have the old global hook, which invokes
@@ -62,11 +71,24 @@ def test_unix_installer_accepts_release_manifest_target_aliases():
 def test_codex_hooks_have_all_required_lifecycle_events():
     shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")
+    # Claude's current PreToolUse protocol rejects the legacy top-level
+    # {decision: allow|deny} response. Both platform hooks must emit the
+    # event-specific permissionDecision envelope.
+    assert "permissionDecision" in shell_hook
+    assert "permissionDecision" in powershell_hook
+    assert "hookEventName" in shell_hook
+    assert "hookEventName" in powershell_hook
+    assert "Use simplicio_file_read / simplicio_read / simplicio_search instead of" in shell_hook
+    assert "Use simplicio_file_read / simplicio_read / simplicio_search instead of" in powershell_hook
     for event in ("SessionStart", "UserPromptSubmit", "SubagentStart"):
         assert event in shell_hook
         assert event in powershell_hook
     assert "PreToolUse" in (ROOT / "install.sh").read_text(encoding="utf-8")
     assert "PreToolUse" in (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert '"matcher": ".*"' in (ROOT / "install.sh").read_text(encoding="utf-8")
+    assert '".*"' in (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert "simplicio_map" in shell_hook
+    assert "simplicio_context" in shell_hook
 
 
 def test_docs_describe_stdio_instead_of_codex_http_authenticate_flow():

--- a/tests/test_install_transaction_contract.py
+++ b/tests/test_install_transaction_contract.py
@@ -14,6 +14,9 @@ def test_shell_uninstall_policy_and_rollback_are_explicit():
     assert 'for _entry in "$PURGE_DIR"/*' in text
     assert 'basename "$_entry"' in text
     assert 'dados do Simplicio removidos' in text
+    assert 'AUTH_FILE' in text
+    assert 'AUTH_FILE_WAS_PRESENT' in text
+    assert 'estado de login desapareceu' in text
 
 
 def test_powershell_uninstall_policy_and_rollback_are_explicit():
@@ -24,7 +27,10 @@ def test_powershell_uninstall_policy_and_rollback_are_explicit():
     assert '$PreviousPath' in text
     assert 'Invoke-Rollback' in text
     assert 'Where-Object { $_.Name -ne ".env" }' in text
-    assert 'Simpli' in text and '.env preserved' in text
+    assert 'Simpli' in text and '.env and login state removed by explicit purge' in text
+    assert '$AuthFile' in text
+    assert '$AuthFileWasPresent' in text
+    assert 'Login state disappeared during the upgrade' in text
 
 
 def test_shell_purge_removes_simplicio_state_but_preserves_provider_env(tmp_path):

--- a/tests/test_install_transaction_contract.py
+++ b/tests/test_install_transaction_contract.py
@@ -11,7 +11,9 @@ def test_shell_uninstall_policy_and_rollback_are_explicit():
     assert 'INSTALL_TRANSACTION_ACTIVE' in text
     assert 'PREVIOUS_PATH' in text
     assert 'rollback_install' in text
-    assert 'rm -rf "$PURGE_DIR"' in text
+    assert 'for _entry in "$PURGE_DIR"/*' in text
+    assert 'basename "$_entry"' in text
+    assert 'dados do Simplicio removidos' in text
 
 
 def test_powershell_uninstall_policy_and_rollback_are_explicit():
@@ -21,4 +23,39 @@ def test_powershell_uninstall_policy_and_rollback_are_explicit():
     assert '$InstallTransactionActive' in text
     assert '$PreviousPath' in text
     assert 'Invoke-Rollback' in text
-    assert 'Remove-Item -Recurse -Force $bundleDir' in text
+    assert 'Where-Object { $_.Name -ne ".env" }' in text
+    assert 'Simpli' in text and '.env preserved' in text
+
+
+def test_shell_purge_removes_simplicio_state_but_preserves_provider_env(tmp_path):
+    import os
+    import subprocess
+
+    bundle = tmp_path / '.simplicio'
+    bundle.mkdir()
+    dotenv = bundle / '.env'
+    dotenv.write_text('XAI_API_KEY=redacted-test-value\n', encoding='utf-8')
+    (bundle / 'runtime-state.json').write_text('{}\n', encoding='utf-8')
+    binary = tmp_path / '.local' / 'bin' / 'simplicio'
+    binary.parent.mkdir(parents=True)
+    binary.write_text('binary\n', encoding='utf-8')
+
+    env = os.environ.copy()
+    env.update({
+        'HOME': str(tmp_path),
+        'SIMPLICIO_BIN_DIR': str(binary.parent),
+        'SIMPLICIO_BUNDLE_DIR': str(bundle),
+        'SIMPLICIO_CONFIRM_PURGE': '1',
+    })
+    result = subprocess.run(
+        ['sh', str(ROOT / 'install.sh'), '--uninstall', '--purge'],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert dotenv.exists()
+    assert not (bundle / 'runtime-state.json').exists()
+    assert not binary.exists()

--- a/tests/test_install_transaction_contract.py
+++ b/tests/test_install_transaction_contract.py
@@ -59,3 +59,13 @@ def test_shell_purge_removes_simplicio_state_but_preserves_provider_env(tmp_path
     assert dotenv.exists()
     assert not (bundle / 'runtime-state.json').exists()
     assert not binary.exists()
+
+
+def test_powershell_signature_verifier_probes_all_python3_command_names():
+    script = (ROOT / 'install.ps1').read_text(encoding='utf-8')
+    assert '@{ Name = "py"; Args = @(' in script
+    assert '@{ Name = "python3"; Args = @() }' in script
+    assert '@{ Name = "python"; Args = @() }' in script
+    assert 'sys.version_info[0] == 3' in script
+    assert '([string]$Signature).Trim()' in script
+    assert 'ToLowerInvariant()' in script


### PR DESCRIPTION
Publishes the remaining tracked installer, MCP hook, plugin documentation, and contract-test changes from the local checkout. Generated .simplicio state is intentionally excluded.