### PR TITLE
fix(hooks): publish MCP route hook

### DIFF
--- a/plugin/hooks/mcp-route.sh
+++ b/plugin/hooks/mcp-route.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# The Runtime owns the canonical mandatory policy. Fail closed if it is absent.
+set -uo pipefail
+route="${HOME:-}/.simplicio/hooks/mcp-route.sh"
+if [ -z "$route" ] || [ ! -f "$route" ]; then
+  printf '%s\n' 'Simplicio Runtime hook is not installed; install the Simplicio Runtime before using this plugin.' >&2
+  exit 2
+fi
+exec bash "$route"


### PR DESCRIPTION
Publishes the remaining local product hook. Generated .simplicio state remains excluded.