### PR TITLE
docs: remove MCP route bypass reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   binary over local STDIO and merge Simplicio lifecycle/PreToolUse hooks into
   `~/.codex/hooks.json` without replacing unrelated user configuration.
 - Added cross-platform Codex routing hooks for macOS/Linux and Windows, with a
-  documented `SIMPLICIO_MCP_ROUTE=0` escape hatch and first-write backups.
+  documented first-write backups.
 - Windows installation now migrates legacy global hooks that invoke
   `/bin/bash` or `mcp-route.sh`, preventing stale Unix commands from failing
   after an update.


### PR DESCRIPTION
Removes the public changelog wording that described SIMPLICIO_MCP_ROUTE=0 as a user escape hatch. The hook security test remains to ensure the bypass is rejected.