### PR TITLE
fix(installer): accept pinned key when manifest omits it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -655,6 +655,9 @@ try:
 except Exception:
     pass
 " 2>/dev/null)"
+      if [ -z "$SIGNING_PUBKEY" ]; then
+        SIGNING_PUBKEY="$ED25519_PUBLIC_KEY"
+      fi
       SIGNATURE_REQUIRED="$(python3 -c "
 import json
 try:


### PR DESCRIPTION
The v3.8.24 manifest has valid Ed25519 signatures but was generated without the optional `signing_pubkey` field. The installer already pins the public key, so an empty manifest field caused a false fail-closed rejection.

This patch falls back to the pinned key only when the manifest field is absent; cryptographic verification still runs with the pinned key.

Validation:
- `sh -n install.sh`
- local installer against GitHub release v3.8.24
- SHA256 verified
- Ed25519 verified
- Runtime release contract verified
- Google login/entitlement verified
- MCP tools/list verified: 10 tools