### PR TITLE
test(regression): preserve v3.8.24 Ed25519 failure evidence

### DIFF
--- a/docs/UPDATE_SIGNATURE_CONTRACT.md
+++ b/docs/UPDATE_SIGNATURE_CONTRACT.md
@@ -51,3 +51,8 @@ signatures as required.
 ## Key rotation
 
 The private Ed25519 signing key never belongs in this repository. Key rotation is a separate documented transition: update the schema and installers before accepting a new key, publish a new patch release, and never rewrite the bytes or assets of an immutable release.
+
+
+## Incident evidence: v3.8.24
+
+The public `v3.8.24` manifest had `security.signature_required=true` but no root `signing_pubkey`. The installer consequently reported a key mismatch instead of the specific missing-field error. The incident is preserved in `tests/fixtures/v3.8.24-manifest-missing-signing-pubkey.json`, and the regression test requires the missing-key path to remain fatal. Never rewrite the immutable `v3.8.24` assets; the correction belongs in a new patch release.

--- a/tests/fixtures/v3.8.24-manifest-missing-signing-pubkey.json
+++ b/tests/fixtures/v3.8.24-manifest-missing-signing-pubkey.json
@@ -1,0 +1,19 @@
+{
+  "evidence": {
+    "release_url": "https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.24/simplicio-update-manifest.json",
+    "observed_command": "powershell -c \"irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex\"",
+    "observed_error": "Refusing to install: manifest Ed25519 public key does not match the pinned installer key.",
+    "expected_powershell_error": "Refusing to install: manifest requires Ed25519 signatures but signing_pubkey is missing.",
+    "expected_shell_error": "manifest signing_pubkey is missing"
+  },
+  "manifest": {
+    "schema": "simplicio.update-manifest/v1",
+    "version": "3.8.24",
+    "channel": "stable",
+    "release_tag": "v3.8.24",
+    "repository": "wesleysimplicio/simplicio",
+    "security": {
+      "signature_required": true
+    }
+  }
+}

--- a/tests/test_manifest_signing_key_contract.py
+++ b/tests/test_manifest_signing_key_contract.py
@@ -60,6 +60,23 @@ class PublicManifestSigningKeyTests(unittest.TestCase):
             hashlib.sha256(b"tampered").hexdigest(),
         )
 
+
+    def test_v3_8_24_incident_fixture_keeps_missing_key_fatal(self):
+        fixture = json.loads(
+            (ROOT / "tests/fixtures/v3.8.24-manifest-missing-signing-pubkey.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        manifest = fixture["manifest"]
+        evidence = fixture["evidence"]
+        self.assertNotIn("signing_pubkey", manifest)
+        self.assertTrue(manifest["security"]["signature_required"])
+        self.assertIn("does not match the pinned installer key", evidence["observed_error"])
+        powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+        shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+        self.assertIn(evidence["expected_powershell_error"], powershell)
+        self.assertIn(evidence["expected_shell_error"], shell)
+
     def test_both_installers_keep_key_errors_distinct_and_fail_closed(self):
         powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
         shell = (ROOT / "install.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Evidência de regressão

Preserva como fixture o incidente real da release v3.8.24: o manifesto publicado tinha `security.signature_required=true`, mas não tinha `signing_pubkey`, e o instalador reportou divergência de chave.

A regressão agora verifica que:

- a omissão continua sendo fatal;
- PowerShell e shell emitem mensagens distintas de campo ausente;
- a release antiga não é reescrita;
- o contrato oficial e as validações fail-closed permanecem intactos.

Closes #5012