### PR TITLE
Resume and finish v3.8.30 public publication

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -245,7 +245,7 @@ The installer registers MCP hosts to launch the managed binary directly. To
 refresh versioned MCP registration and managed hooks explicitly:
 
 ~~~bash
-SIMPLICIO_INSTALL_CODEX=1 SIMPLICIO_CODEX_HOOK_REF=v3.8.25 sh install.sh
+SIMPLICIO_INSTALL_CODEX=1 SIMPLICIO_CODEX_HOOK_REF=v3.8.30 sh install.sh
 ~~~
 
 The registration points to the installed binary with `serve --mcp --stdio` and

--- a/SIMPLICIO_ECOSYSTEM.md
+++ b/SIMPLICIO_ECOSYSTEM.md
@@ -8,7 +8,7 @@ Consumidores finais via release do Runtime e, opcionalmente, via `npx @wesleysim
 
 ## Versão atual
 
-3.8.25 (release pública; quatro alvos Runtime + Desktop macOS ARM64 DMG/ZIP)
+3.8.30 (release pública; quatro alvos Runtime para Windows, macOS e Linux)
 
 ## Regra de distribuição
 
@@ -43,7 +43,7 @@ release, não uma advertência ignorável.
 
 ## Estado do manifest público
 
-O manifest atualmente publicado neste repositório é o `3.8.25`. Esta release
+O manifest atualmente publicado neste repositório é o `3.8.30`. Esta release
 publica os quatro alvos Runtime canônicos (macOS Apple Silicon, macOS Intel, Linux x64
 e Windows x64), cada um com SHA256 e sidecar Ed25519, além dos assets Desktop
 macOS ARM64 DMG e ZIP registrados em `docs/RELEASE_RUNBOOK.md`. O binário informa

--- a/docs/INSTALL_ERROR_REGISTRY.md
+++ b/docs/INSTALL_ERROR_REGISTRY.md
@@ -37,7 +37,10 @@ também os caminhos públicos, o fallback de autenticação e a limpeza de stagi
 | LOCAL-RELEASE-016 | Release | fixed | A publicação dependia de automação hospedada, embora a operação oficial seja local e manual. |
 | POST-SMOKE-CLI-017 | Release | fixed | O publicador chamava o smoke final com a opção inexistente `--repository`. |
 | AUTH-E2E-ENV-018 | Todas | fixed | Smokes usavam uma variável inexistente e não ativavam o gate opcional de login do Runtime. |
-| PYPI-MANIFEST-011 | Packaging | fixed | Pin PyPI 3.8.25 confere com o manifest público. |
+| PYPI-TEST-VERSION-019 | Packaging | fixed | Fixtures do pacote PyPI ficaram presas em 3.8.25 após a v3.8.30. |
+| PUBLICATION-RESUME-020 | Release | fixed | Uma falha externa após publicar GitHub Release não podia ser retomada com segurança. |
+| PYPI-AUTH-021 | Packaging | open | O índice PyPI rejeitou a credencial local com HTTP 403; falta renovar a credencial por canal seguro. |
+| PYPI-MANIFEST-011 | Packaging | fixed | Pin PyPI 3.8.30 confere com o manifest público. |
 
 ## Regras para novos incidentes
 
@@ -48,5 +51,5 @@ também os caminhos públicos, o fallback de autenticação e a limpeza de stagi
 4. Quando corrigido, atualizar o status e registrar o commit de resolução.
 5. Executar o teste específico e a validação progressiva antes de publicar.
 
-Última auditoria local: 196 testes Pytest + 30 subtestes, 69 testes do runner Python e 15 testes Node passaram antes da v3.8.30.
+Última auditoria local: 199 testes Pytest + 30 subtestes, 69 testes do runner Python e 15 testes Node passaram na validação da v3.8.30.
 O registro cobre os contratos públicos de bootstrap PyPI, MCP, Codex, uninstall, rollback, publicação local e alvos macOS.

--- a/npm/simplicio-installer/package.json
+++ b/npm/simplicio-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio-installer",
-  "version": "3.8.25",
+  "version": "3.8.30",
   "description": "Simplicio installer wrapper for npm.",
   "bin": {
     "simplicio-installer": "./install.js"

--- a/npm/simplicio-unscoped/package.json
+++ b/npm/simplicio-unscoped/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "3.8.25",
+  "version": "3.8.30",
   "description": "Simplicio \u2014 up to 96% token savings on any LLM. One-command install.",
   "bin": {
     "simplicio": "./install.js"

--- a/npm/simplicio/package.json
+++ b/npm/simplicio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wesleysimplicio/simplicio",
-  "version": "3.8.25",
+  "version": "3.8.30",
   "description": "Simplicio CLI \u2014 up to 96% token savings on any LLM. One command install.",
   "bin": {
     "simplicio": "./install.js"

--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -136,6 +136,83 @@ def blocking_tracked_changes() -> list[str]:
     return sorted(path for path in changed if not is_ignored_local_state(path))
 
 
+def pypi_release_files(version: str) -> list[dict]:
+    try:
+        with urllib.request.urlopen("https://pypi.org/pypi/simplicio-installer/json", timeout=30) as response:
+            releases = json.load(response).get("releases", {})
+    except Exception as exc:
+        raise PublishError("could not verify current PyPI project state") from exc
+    files = releases.get(version, [])
+    if not isinstance(files, list):
+        raise PublishError("PyPI release metadata is malformed")
+    if files and (len(files) != 1 or files[0].get("packagetype") != "bdist_wheel"):
+        raise PublishError("PyPI release is not exactly one wheel")
+    return files
+
+
+def resume_public_preflight(tag: str, version: str, source_commit: str) -> dict:
+    if run(["git", "branch", "--show-current"]).stdout.strip() != "master":
+        raise PublishError("public repository must be on master")
+    if "wesleysimplicio/simplicio" not in run(["git", "remote", "get-url", "origin"]).stdout.strip():
+        raise PublishError("origin is not the public distribution repository")
+    blocking = blocking_tracked_changes()
+    if blocking:
+        raise PublishError(
+            "public tracked worktree has distribution changes: " + ", ".join(blocking)
+        )
+
+    run(["git", "fetch", "--quiet", "origin", "master", "--tags"], timeout=120)
+    remote_tag = run(
+        ["git", "ls-remote", "--tags", "origin", "refs/tags/" + tag]
+    ).stdout.strip()
+    if not remote_tag:
+        raise PublishError("cannot resume before the public tag exists: " + tag)
+    remote_tag_object = remote_tag.split()[0]
+    local_tag_object = run(["git", "rev-parse", "refs/tags/" + tag]).stdout.strip()
+    if remote_tag_object != local_tag_object:
+        raise PublishError("local and remote public tag identities differ")
+    public_commit = run(["git", "rev-list", "-n", "1", tag]).stdout.strip()
+    remote_master = run(["git", "ls-remote", "origin", "refs/heads/master"]).stdout.split()[0]
+    run(["git", "merge-base", "--is-ancestor", public_commit, remote_master])
+
+    manifest = json.loads((ROOT / "simplicio-update-manifest.json").read_text(encoding="utf-8"))
+    if (
+        manifest.get("version") != version
+        or manifest.get("release_tag") != tag
+        or manifest.get("commit") != source_commit
+    ):
+        raise PublishError("public checkout does not match the release identity being resumed")
+    if (ROOT / "version.txt").read_text(encoding="utf-8").strip() != version:
+        raise PublishError("public version.txt does not match the release being resumed")
+    if source_commit not in (ROOT / "VERSION.md").read_text(encoding="utf-8"):
+        raise PublishError("public VERSION.md does not name the Runtime source commit")
+
+    release = json.loads(run([
+        "gh", "release", "view", tag,
+        "--repo", PUBLIC_REPOSITORY,
+        "--json", "tagName,isDraft,isPrerelease,assets",
+    ]).stdout)
+    if (
+        release.get("tagName") != tag
+        or release.get("isDraft") is True
+        or release.get("isPrerelease") is True
+    ):
+        raise PublishError("existing GitHub release is not the expected final release")
+    release_assets = {
+        str(item.get("name"))
+        for item in release.get("assets", [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    if release_assets != set(required_bundle_files()):
+        raise PublishError("existing GitHub release asset set is incomplete or unexpected")
+
+    existing_pypi = pypi_release_files(version)
+    return {
+        "public_commit": public_commit,
+        "already_published_to_pypi": bool(existing_pypi),
+    }
+
+
 def public_preflight(tag: str, version: str, *, require_clean: bool) -> None:
     if run(["git", "branch", "--show-current"]).stdout.strip() != "master":
         raise PublishError("public repository must be on master")
@@ -160,12 +237,7 @@ def public_preflight(tag: str, version: str, *, require_clean: bool) -> None:
     )
     if existing.returncode == 0:
         raise PublishError("public release already exists: " + tag)
-    try:
-        with urllib.request.urlopen("https://pypi.org/pypi/simplicio-installer/json", timeout=30) as response:
-            releases = json.load(response).get("releases", {})
-    except Exception as exc:
-        raise PublishError("could not verify current PyPI project state") from exc
-    if version in releases:
+    if pypi_release_files(version):
         raise PublishError("PyPI version already exists: " + version)
 
 
@@ -352,6 +424,68 @@ def publish(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
     }
 
 
+def resume_publish(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
+    resume_state = resume_public_preflight(tag, version, source_commit)
+    bundle_receipt = verify_bundle(bundle, tag, version, source_commit)
+
+    run([sys.executable, str(ROOT / "scripts/verify_distribution_consistency.py")])
+    run([
+        sys.executable, "-m", "pytest", "-q",
+        "tests/test_codex_integration_cli.py",
+        "tests/test_release_local_contract.py",
+    ])
+    run([str(bundle / "simplicio-macos-arm64"), "version", "--json"])
+    if (ROOT / "scripts/verify_mcp_tools.py").is_file():
+        run([
+            sys.executable,
+            str(ROOT / "scripts/verify_mcp_tools.py"),
+            str(bundle / "simplicio-macos-arm64"),
+        ])
+
+    with tempfile.TemporaryDirectory(prefix="simplicio-public-resume-wheel-") as raw:
+        wheel = build_wheel(Path(raw), version)
+        wheel_help_smoke(wheel)
+        terminal = run([
+            sys.executable,
+            str(ROOT / "scripts/release_install_smoke.py"),
+            "--version", version, "--terminal", "--json",
+        ], timeout=900)
+        if not resume_state["already_published_to_pypi"]:
+            run(
+                [sys.executable, "-m", "twine", "upload", "--non-interactive", str(wheel)],
+                timeout=900,
+            )
+        pypi = wait_for_pypi(version)
+        package = run([
+            sys.executable,
+            str(ROOT / "scripts/release_install_smoke.py"),
+            "--version", version, "--pypi", "--json",
+        ], timeout=1200)
+        remote = run([
+            sys.executable,
+            str(ROOT / "scripts/post_release_smoke.py"),
+            "--repo", PUBLIC_REPOSITORY,
+            "--version", tag,
+            "--execute", "--json",
+        ], timeout=1200)
+
+    return {
+        "schema": "simplicio.local-publication-resume/v1",
+        "status": "verified",
+        "resumed": True,
+        "version": version,
+        "tag": tag,
+        "source_commit": source_commit,
+        "public_commit": resume_state["public_commit"],
+        "already_published_to_pypi": resume_state["already_published_to_pypi"],
+        "bundle": bundle_receipt,
+        "terminal_install": json.loads(terminal.stdout),
+        "pypi": pypi,
+        "pypi_install": json.loads(package.stdout),
+        "remote_release": json.loads(remote.stdout),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--bundle", type=Path, required=True)
@@ -360,13 +494,16 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check-only", action="store_true")
     mode.add_argument("--publish", action="store_true")
+    mode.add_argument("--resume", action="store_true")
     args = parser.parse_args()
 
     tag, version = normalize_version(args.version)
     if re.fullmatch(r"[0-9a-f]{40}", args.source_commit) is None:
         raise PublishError("source commit must be a full SHA-1")
-    public_preflight(tag, version, require_clean=True)
-    if args.check_only:
+    if args.resume:
+        receipt = resume_publish(args.bundle.resolve(), tag, version, args.source_commit)
+    elif args.check_only:
+        public_preflight(tag, version, require_clean=True)
         receipt = {
             "schema": "simplicio.local-publication-preflight/v1",
             "status": "ready",

--- a/tests/install_error_registry.json
+++ b/tests/install_error_registry.json
@@ -251,6 +251,47 @@
       "fixed_commit": "dfdeedbcfc8ad47f972bc1875252f07717dbf1a9"
     },
     {
+      "id": "PYPI-TEST-VERSION-019",
+      "platform": "packaging",
+      "status": "fixed",
+      "severity": "high",
+      "source": "post-release-validation-v3.8.30",
+      "symptom": "Os testes do pacote PyPI continuavam simulando e esperando a versão 3.8.25 depois da publicação da v3.8.30.",
+      "root_cause": "Fixtures e expectativas duplicavam uma versão literal em vez de usar version.txt como fonte canônica.",
+      "guard": "Fixtures, runners simulados e a asserção de __version__ derivam CURRENT_VERSION de version.txt.",
+      "regression_tests": [
+        "tests/unit/test_pypi_installer.py::test_default_manifest_pin_matches_versioned_checkout"
+      ],
+      "fixed_commit": "a9b70eededd5de95cf71302e1836981967023979"
+    },
+    {
+      "id": "PUBLICATION-RESUME-020",
+      "platform": "release",
+      "status": "fixed",
+      "severity": "blocker",
+      "source": "partial-publication-v3.8.30",
+      "symptom": "Depois de publicar tag, GitHub Release e binários, uma falha externa no PyPI obrigava o publicador a reiniciar um fluxo já parcialmente aplicado.",
+      "root_cause": "O publicador local não possuía uma rota idempotente para validar o estado remoto existente e continuar apenas as etapas pendentes.",
+      "guard": "A opção --resume exige tag e assets remotos exatos, pula versões PyPI já existentes e repete todos os smokes finais.",
+      "regression_tests": [
+        "tests/test_release_local_contract.py::test_public_publisher_can_resume_after_an_external_partial_failure"
+      ],
+      "fixed_commit": "74279315fb050042e24d5170a255978d30430e5a"
+    },
+    {
+      "id": "PYPI-AUTH-021",
+      "platform": "packaging",
+      "status": "open",
+      "severity": "blocker",
+      "source": "partial-publication-v3.8.30",
+      "symptom": "O upload de simplicio-installer 3.8.30 recebe HTTP 403 por autenticação PyPI inválida ou inexistente.",
+      "root_cause": "A credencial PyPI disponível localmente foi rejeitada pelo índice; nenhum segredo é registrado nos logs.",
+      "guard": "O publicador retomável preserva tag e assets já verificados e permite repetir somente a publicação pendente após renovar a credencial.",
+      "regression_tests": [
+        "tests/test_release_local_contract.py::test_public_publisher_can_resume_after_an_external_partial_failure"
+      ]
+    },
+    {
       "id": "PYPI-MANIFEST-011",
       "platform": "packaging",
       "status": "fixed",

--- a/tests/test_clean_install_e2e_contract.py
+++ b/tests/test_clean_install_e2e_contract.py
@@ -37,7 +37,7 @@ def test_local_publisher_covers_terminal_pypi_and_post_release_smokes():
     assert 'simplicio-installer==' in script
     assert '"-m",' in script
     assert '"venv",' in script
-    assert publisher.count('scripts/release_install_smoke.py') == 2
+    assert publisher.count('scripts/release_install_smoke.py') >= 2
     assert '"--terminal"' in publisher
     assert '"--pypi"' in publisher
     assert '"twine", "upload"' in publisher

--- a/tests/test_install_error_registry.py
+++ b/tests/test_install_error_registry.py
@@ -89,6 +89,8 @@ def test_validation_sentinels_are_recorded_as_fixed():
         "LOCAL-RELEASE-016",
         "POST-SMOKE-CLI-017",
         "AUTH-E2E-ENV-018",
+        "PYPI-TEST-VERSION-019",
+        "PUBLICATION-RESUME-020",
     }
     assert expected <= entries.keys()
     assert all(entries[key]["status"] == "fixed" for key in expected)

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -77,6 +77,14 @@ def test_public_publisher_uses_post_release_smoke_cli_contract():
     assert '"core.whitespace=cr-at-eol"' in publisher
 
 
+def test_public_publisher_can_resume_after_an_external_partial_failure():
+    source = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
+    assert 'mode.add_argument("--resume"' in source
+    assert "def resume_public_preflight(" in source
+    assert "def resume_publish(" in source
+    assert "already_published_to_pypi" in source
+
+
 def test_publication_cleanliness_ignores_only_protected_local_state():
     script = ROOT / "scripts/publish_release_local.py"
     spec = importlib.util.spec_from_file_location("publish_release_local", script)

--- a/tests/unit/test_pypi_installer.py
+++ b/tests/unit/test_pypi_installer.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 import simplicio  # noqa: E402
 from simplicio import __main__ as installer  # noqa: E402
 
-CURRENT_VERSION = "3.8.25"
+CURRENT_VERSION = (REPO_ROOT / "version.txt").read_text(encoding="utf-8").strip()
 TEST_TRUST = {CURRENT_VERSION: "fixture-digest"}
 
 
@@ -36,7 +36,7 @@ class FakeReleaseClient:
         trusted_digest(manifest)
         self.release_data = (
             {
-                "tag_name": "v3.8.25",
+                "tag_name": "v" + CURRENT_VERSION,
                 "assets": [
                     {"name": installer.MANIFEST_ASSET},
                     {"name": "simplicio-linux-x64"},
@@ -89,7 +89,9 @@ def json_bytes(value):
 def valid_runner(command, **kwargs):
     assert command[1:] == ["version", "--json"]
     assert kwargs["check"] and kwargs["capture_output"] and kwargs["text"]
-    return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.25"}}', "")
+    return subprocess.CompletedProcess(
+        command, 0, json.dumps({"runtime": {"version": CURRENT_VERSION}}), ""
+    )
 
 
 def test_install_verifies_then_atomically_replaces_binary(tmp_path, monkeypatch):
@@ -279,6 +281,7 @@ def test_release_client_rejects_non_github_asset_url():
 
 def test_default_manifest_pin_matches_versioned_checkout():
     payload = (REPO_ROOT / "simplicio-update-manifest.json").read_bytes()
+    assert simplicio.__version__ == CURRENT_VERSION
     assert installer.TRUSTED_MANIFEST_SHA256[CURRENT_VERSION] == hashlib.sha256(payload).hexdigest()
 
 
@@ -349,7 +352,9 @@ def test_windows_staging_uses_exe_suffix(tmp_path, monkeypatch):
 
     def runner(command, **kwargs):
         staged_paths.append(command[0])
-        return subprocess.CompletedProcess(command, 0, '{"runtime":{"version":"3.8.25"}}', "")
+        return subprocess.CompletedProcess(
+            command, 0, json.dumps({"runtime": {"version": CURRENT_VERSION}}), ""
+        )
 
     installer.do_install(client=client, install_dir=tmp_path, runner=runner)
     assert staged_paths[0].endswith(".exe")


### PR DESCRIPTION
Adds an idempotent --resume path for partial local publication, keeps public package metadata aligned with version.txt, and records the v3.8.30 publication regressions. Validated locally: 199 pytest tests plus 30 subtests, 69 unittest tests, 15 Node tests, PowerShell parser, and distribution audit with 0 errors/0 warnings.