### PR TITLE
fix(release): require public PR before tagging

### DIFF
--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -322,17 +322,46 @@ def wheel_help_smoke(wheel: Path) -> None:
 
 def commit_public(paths: list[Path], tag: str, source_commit: str) -> str:
     relative = sorted({str(path.relative_to(ROOT)) for path in paths})
+    branch = "release/" + tag
+    run(["git", "switch", "-c", branch])
     run(["git", "add", "--", *relative])
     run(["git", "-c", "core.whitespace=cr-at-eol", "diff", "--cached", "--check"])
     run([
         "git", "commit", "-m", "release(public): publish signed Runtime %s" % tag,
         "-m", "Source commit: " + source_commit,
     ])
-    commit = run(["git", "rev-parse", "HEAD"]).stdout.strip()
-    run(["git", "push", "origin", "master"])
-    run(["git", "tag", tag])
+    release_commit = run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    run(["git", "push", "-u", "origin", branch])
+    run([
+        "gh", "pr", "create",
+        "--repo", PUBLIC_REPOSITORY,
+        "--base", "master",
+        "--head", branch,
+        "--title", "release(public): publish signed Runtime " + tag,
+        "--body", "Source Runtime commit: " + source_commit,
+    ])
+    pull_number = run([
+        "gh", "pr", "view", branch,
+        "--repo", PUBLIC_REPOSITORY,
+        "--json", "number",
+        "--jq", ".number",
+    ]).stdout.strip()
+    run([
+        "gh", "pr", "merge", pull_number,
+        "--repo", PUBLIC_REPOSITORY,
+        "--squash",
+        "--subject", "release(public): publish signed Runtime %s (#%s)" % (tag, pull_number),
+        "--body", "Source Runtime commit: " + source_commit,
+    ], timeout=600)
+
+    run(["git", "fetch", "--quiet", "origin", "master"])
+    run(["git", "switch", "master"])
+    run(["git", "merge", "--ff-only", "origin/master"])
+    public_commit = run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    run(["git", "diff", "--exit-code", release_commit, public_commit, "--", *relative])
+    run(["git", "tag", tag, public_commit])
     run(["git", "push", "origin", "refs/tags/" + tag])
-    return commit
+    return public_commit
 
 
 def create_public_release(tag: str, bundle: Path) -> None:

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -77,6 +77,14 @@ def test_public_publisher_uses_post_release_smoke_cli_contract():
     assert '"core.whitespace=cr-at-eol"' in publisher
 
 
+def test_public_publisher_requires_pr_merge_before_tagging():
+    publisher = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
+    assert '"gh", "pr", "create"' in publisher
+    assert '"gh", "pr", "merge"' in publisher
+    assert '["git", "push", "origin", "master"]' not in publisher
+    assert '["git", "merge", "--ff-only", "origin/master"]' in publisher
+
+
 def test_public_publisher_can_resume_after_an_external_partial_failure():
     source = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
     assert 'mode.add_argument("--resume"' in source


### PR DESCRIPTION
## Resumo
- impede push direto do publisher local para master
- publica a branch, abre PR, faz squash merge e só então cria a tag
- verifica que os arquivos mergeados são idênticos ao commit de release
- retorna o checkout para master para permitir retomada segura

## Validação
- 9 testes do contrato local aprovados
- py_compile aprovado
- diff check aprovado