### PR TITLE
docs(install): document both paths in all locales

### DIFF
--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### التثبيت المباشر (بدون PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 تم. أمر واحد. لا حاجة لمدير حزم أو تهيئة نموذج.
 
 ---

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Instalador directo (sin PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Listo. Un solo comando. Sin gestor de paquetes, sin configuración de modelos.
 
 ---

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Installation directe (sans PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Terminé. Une seule commande. Pas de gestionnaire de paquets, pas de configuration de modèle.
 
 ---

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### התקנה ישירה (ללא PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 בוצע. פקודה אחת. ללא מנהל חבילות, ללא הגדרת מודל.
 
 ---

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### प्रत्यक्ष इंस्टॉलर (PyPI के बिना)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 हो गया। एक कमांड। कोई पैकेज मैनेजर नहीं, कोई मॉडल कॉन्फ़िगरेशन नहीं।
 
 ---

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Instalasi langsung (tanpa PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Selesai. Satu perintah. Tanpa manajer paket, tanpa konfigurasi model.
 
 ---

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Installazione diretta (senza PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Fatto. Un comando. Nessun package manager, nessuna configurazione del modello.
 
 ---

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -89,6 +89,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### 直接インストール（PyPIなし）
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 完了。たった1つのコマンドです。パッケージマネージャーもモデル設定も不要です。
 
 ---

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -92,6 +92,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### 직접 설치(PyPI 없이)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 끝. 하나의 명령어입니다. 패키지 매니저도, 모델 설정도 필요 없습니다.
 
 ---

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Pemasangan terus (tanpa PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Selesai. Satu arahan. Tiada pengurus pakej, tiada konfigurasi model.
 
 ---

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Instalacja bezpośrednia (bez PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Gotowe. Jedno polecenie. Żaden menedżer pakietów, żadna konfiguracja modelu.
 
 ---

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -74,6 +74,20 @@ No Windows (PowerShell), use `py -m pip install --upgrade simplicio-installer`
 no lugar de `python3 -m pip ...`. O token do PyPI fica somente no ambiente de
 publicação; nunca é copiado para o repositório.
 
+### Instalação direta (sem PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 O launcher instala o Runtime verificado em `~/.local/bin/simplicio` no
 macOS/Linux ou `%USERPROFILE%\.local\bin\simplicio.exe` no Windows. Garanta que
 o diretório de scripts do Python e esse diretório estejam no `PATH`; o launcher

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### Прямая установка (без PyPI)
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 Готово. Одна команда. Никакого менеджера пакетов, никакой настройки модели.
 
 ---

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -93,6 +93,20 @@ py -m pip install --upgrade simplicio-installer
 simplicio install
 ```
 
+### 直接安装（不使用 PyPI）
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
+```
+
 完成。一条命令。无需包管理器，无需模型配置。
 
 ---

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -39,6 +39,17 @@ def test_mcp_docs_use_copy_safe_absolute_paths_for_every_platform():
         assert not re.search(r'command\s*=\s*"[A-Za-z]:\\(?!\\)', source)
 
 
+def test_all_readmes_document_pypi_and_direct_installer_paths():
+    readmes = [ROOT / "README.md", *sorted((ROOT / "READMEs").glob("README.*.md"))]
+    assert len(readmes) == 15
+    for path in readmes:
+        source = path.read_text(encoding="utf-8")
+        assert "simplicio-installer" in source, path
+        assert "pip install" in source, path
+        assert "install.sh" in source, path
+        assert "install.ps1" in source, path
+
+
 def test_powershell_parser_accepts_the_public_installer():
     pwsh = shutil.which("pwsh")
     assert pwsh is not None, "pwsh is a required local release-test dependency"


### PR DESCRIPTION
## Resumo
- documenta instalação via PyPI e instalador direto em todos os 15 READMEs
- inclui comandos macOS/Linux e Windows PowerShell
- adiciona regressão que exige os dois caminhos em todos os idiomas

## Validação
- auditoria: 15 arquivos, 0 ausentes
- contrato local: 10 aprovados
- diff check aprovado