### PR TITLE
docs(release): require local manual publication

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -105,9 +105,10 @@ instalado sem reutilizar estado do mantenedor:
 python3 scripts/release_install_smoke.py --version vX.Y.Z --json
 ```
 
-O workflow `publish-pypi.yml` executa esse mesmo comando em Linux, Windows,
-macOS Intel e macOS Apple Silicon depois do job de publicação. Uma nova release
-não deve ser considerada pronta se qualquer um dos dois métodos falhar.
+O publicador local/manual executa esse mesmo comando antes e depois dos uploads.
+Os recibos nativos de Linux, Windows, macOS Intel e macOS Apple Silicon são
+registrados por host, sem delegar build ou publicação a workflows remotos. Uma
+nova release não deve ser considerada pronta se qualquer um dos dois métodos falhar.
 
 ## Latest-only installation
 

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -104,6 +104,13 @@ def test_public_publisher_can_resume_after_an_external_partial_failure():
     assert "already_published_to_pypi" in source
 
 
+def test_public_runbook_requires_manual_publication_without_actions():
+    source = (ROOT / "docs/RELEASE_RUNBOOK.md").read_text(encoding="utf-8")
+    assert "publish-pypi.yml" not in source
+    assert "GitHub Actions" not in source
+    assert "publicador local/manual" in source
+
+
 def test_publication_cleanliness_ignores_only_protected_local_state():
     script = ROOT / "scripts/publish_release_local.py"
     spec = importlib.util.spec_from_file_location("publish_release_local", script)


### PR DESCRIPTION
## Resumo
- remove a referencia obsoleta ao workflow publish-pypi.yml
- documenta o publicador local/manual e os recibos nativos por host
- adiciona regressao que impede a dependencia voltar

## Testes
- python3 -m pytest -q tests/test_release_local_contract.py (11 passed)
- git diff --check