### PR TITLE
fix(release): build PyPI wheel from clean source

### DIFF
--- a/SIMPLICIO_ECOSYSTEM.md
+++ b/SIMPLICIO_ECOSYSTEM.md
@@ -8,7 +8,7 @@ Consumidores finais via release do Runtime e, opcionalmente, via `npx @wesleysim
 
 ## Versão atual
 
-3.8.30 (release pública; quatro alvos Runtime para Windows, macOS e Linux)
+3.8.31 (release pública; quatro alvos Runtime para Windows, macOS e Linux)
 
 ## Regra de distribuição
 
@@ -43,10 +43,10 @@ release, não uma advertência ignorável.
 
 ## Estado do manifest público
 
-O manifest atualmente publicado neste repositório é o `3.8.30`. Esta release
+O manifest atualmente publicado neste repositório é o `3.8.31`. Esta release
 publica os quatro alvos Runtime canônicos (macOS Apple Silicon, macOS Intel, Linux x64
-e Windows x64), cada um com SHA256 e sidecar Ed25519, além dos assets Desktop
-macOS ARM64 DMG e ZIP registrados em `docs/RELEASE_RUNBOOK.md`. O binário informa
+e Windows x64), cada um com SHA256, sidecar Ed25519, SBOM e proveniência. Assets
+Desktop são opcionais e, quando publicados, seguem `docs/RELEASE_RUNBOOK.md`. O binário informa
 `source_code_distributed=true`, `identity.enabled/login_enabled=true` e
 `security.signature_required/public_key_configured=true`. O instalador continua
 fail-closed: exige bundle Python embutido, login Google ativo e manifest
@@ -57,4 +57,4 @@ Nenhuma — repo é ponto de entrada para usuários finais.
 
 ---
 
-_Last updated: 2026-08-24_
+_Last updated: 2026-08-26_

--- a/npm/simplicio-installer/package.json
+++ b/npm/simplicio-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio-installer",
-  "version": "3.8.30",
+  "version": "3.8.31",
   "description": "Simplicio installer wrapper for npm.",
   "bin": {
     "simplicio-installer": "./install.js"

--- a/npm/simplicio-unscoped/package.json
+++ b/npm/simplicio-unscoped/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "3.8.30",
+  "version": "3.8.31",
   "description": "Simplicio \u2014 up to 96% token savings on any LLM. One-command install.",
   "bin": {
     "simplicio": "./install.js"

--- a/npm/simplicio/package.json
+++ b/npm/simplicio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wesleysimplicio/simplicio",
-  "version": "3.8.30",
+  "version": "3.8.31",
   "description": "Simplicio CLI \u2014 up to 96% token savings on any LLM. One command install.",
   "bin": {
     "simplicio": "./install.js"

--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -15,6 +15,7 @@ import time
 import tomllib
 import urllib.request
 import venv
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -270,6 +271,43 @@ def update_public_metadata(tag: str, version: str, source_commit: str) -> list[P
         )
         path.write_text(body, encoding="utf-8")
         changed.append(path)
+
+    for relative in (
+        "npm/simplicio/package.json",
+        "npm/simplicio-installer/package.json",
+        "npm/simplicio-unscoped/package.json",
+    ):
+        path = ROOT / relative
+        body = path.read_text(encoding="utf-8")
+        body, replacements = re.subn(
+            r'(?m)^  "version": "[0-9]+\.[0-9]+\.[0-9]+",$',
+            '  "version": "' + version + '",',
+            body,
+            count=1,
+        )
+        if replacements != 1:
+            raise PublishError("could not update wrapper version: " + relative)
+        path.write_text(body, encoding="utf-8")
+        changed.append(path)
+
+    ecosystem = ROOT / "SIMPLICIO_ECOSYSTEM.md"
+    body = ecosystem.read_text(encoding="utf-8")
+    body, current_replacements = re.subn(
+        r"(?m)^[0-9]+\.[0-9]+\.[0-9]+ \(release pública;",
+        version + " (release pública;",
+        body,
+        count=1,
+    )
+    body, manifest_replacements = re.subn(
+        r"(?m)^O manifest atualmente publicado neste repositório é o `[0-9]+\.[0-9]+\.[0-9]+`\.",
+        "O manifest atualmente publicado neste repositório é o `" + version + "`.",
+        body,
+        count=1,
+    )
+    if current_replacements != 1 or manifest_replacements != 1:
+        raise PublishError("could not update SIMPLICIO_ECOSYSTEM.md version")
+    ecosystem.write_text(body, encoding="utf-8")
+    changed.append(ecosystem)
     return changed
 
 
@@ -299,13 +337,45 @@ def prepare_package(version: str) -> list[Path]:
 
 def build_wheel(output: Path, version: str) -> Path:
     output.mkdir(parents=True, exist_ok=True)
-    run([sys.executable, "-m", "build", "--wheel", "--outdir", str(output), str(PACKAGE_ROOT)])
+    with tempfile.TemporaryDirectory(prefix="simplicio-wheel-source-") as raw:
+        clean_package = Path(raw) / "simplicio"
+        shutil.copytree(
+            PACKAGE_ROOT,
+            clean_package,
+            ignore=shutil.ignore_patterns(
+                "build",
+                "dist",
+                "*.egg-info",
+                "__pycache__",
+                "*.pyc",
+            ),
+        )
+        run([
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--outdir",
+            str(output),
+            str(clean_package),
+        ])
     wheels = list(output.glob("*.whl"))
     if len(wheels) != 1:
         raise PublishError("expected exactly one wheel, found %d" % len(wheels))
     wheel = wheels[0]
     if version not in wheel.name:
         raise PublishError("wheel filename does not contain release version")
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            cached = [
+                name
+                for name in archive.namelist()
+                if "__pycache__" in name or name.endswith(".pyc")
+            ]
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise PublishError("wheel is not a valid ZIP archive") from exc
+    if cached:
+        raise PublishError("wheel contains cached bytecode: " + ", ".join(cached))
     run([sys.executable, "-m", "twine", "check", str(wheel)])
     return wheel
 

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import re
 import importlib.util
 import shutil
 import subprocess
+import zipfile
 from pathlib import Path
 
 
@@ -102,6 +104,99 @@ def test_public_publisher_can_resume_after_an_external_partial_failure():
     assert "def resume_public_preflight(" in source
     assert "def resume_publish(" in source
     assert "already_published_to_pypi" in source
+
+
+def test_public_publisher_builds_wheel_from_clean_source(tmp_path, monkeypatch):
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_clean_wheel", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    package = tmp_path / "package"
+    source = package / "simplicio"
+    source.mkdir(parents=True)
+    (source / "__init__.py").write_text("", encoding="utf-8")
+    cache = source / "__pycache__"
+    cache.mkdir()
+    (cache / "stale.pyc").write_bytes(b"stale")
+    build = package / "build"
+    build.mkdir()
+    (build / "stale.txt").write_text("stale", encoding="utf-8")
+    monkeypatch.setattr(module, "PACKAGE_ROOT", package)
+
+    def fake_run(command, **_kwargs):
+        if command[1:3] == ["-m", "build"]:
+            clean_source = Path(command[-1])
+            assert not (clean_source / "build").exists()
+            assert not any(
+                "__pycache__" in path.parts or path.suffix == ".pyc"
+                for path in clean_source.rglob("*")
+            )
+            output = Path(command[command.index("--outdir") + 1])
+            output.mkdir(parents=True, exist_ok=True)
+            wheel = output / "simplicio_installer-3.8.31-py3-none-any.whl"
+            with zipfile.ZipFile(wheel, "w") as archive:
+                archive.writestr("simplicio/__init__.py", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(module, "run", fake_run)
+    wheel = module.build_wheel(tmp_path / "output", "3.8.31")
+    with zipfile.ZipFile(wheel) as archive:
+        assert archive.namelist() == ["simplicio/__init__.py"]
+
+
+def test_public_publisher_updates_all_release_version_consumers(tmp_path, monkeypatch):
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_versions", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+
+    (tmp_path / "VERSION.md").write_text(
+        "## Runtime snapshot: v3.8.30\n"
+        "## Current Version: v3.8.30\n"
+        "  `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`\n",
+        encoding="utf-8",
+    )
+    for relative in ("README.md", "MCP-CONNECT.md"):
+        (tmp_path / relative).write_text(
+            "SIMPLICIO_CODEX_HOOK_REF=v3.8.30\n",
+            encoding="utf-8",
+        )
+    wrappers = (
+        "npm/simplicio/package.json",
+        "npm/simplicio-installer/package.json",
+        "npm/simplicio-unscoped/package.json",
+    )
+    for relative in wrappers:
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {"name": relative, "version": "3.8.30", "description": "fixture"},
+                indent=2,
+            ) + "\n",
+            encoding="utf-8",
+        )
+    (tmp_path / "SIMPLICIO_ECOSYSTEM.md").write_text(
+        "3.8.30 (release pública; quatro alvos)\n"
+        "O manifest atualmente publicado neste repositório é o `3.8.30`.\n",
+        encoding="utf-8",
+    )
+
+    changed = module.update_public_metadata(
+        "v3.8.31",
+        "3.8.31",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    assert (tmp_path / "version.txt").read_text(encoding="utf-8") == "3.8.31\n"
+    assert all(json.loads((tmp_path / path).read_text())["version"] == "3.8.31" for path in wrappers)
+    ecosystem = (tmp_path / "SIMPLICIO_ECOSYSTEM.md").read_text(encoding="utf-8")
+    assert "3.8.30" not in ecosystem
+    assert ecosystem.count("3.8.31") == 2
+    assert tmp_path / "SIMPLICIO_ECOSYSTEM.md" in changed
 
 
 def test_public_runbook_requires_manual_publication_without_actions():


### PR DESCRIPTION
## Resumo
- constroi o wheel em copia temporaria sem build/dist/egg-info/pycache/pyc
- bloqueia wheel que contenha bytecode cacheado
- sincroniza automaticamente os tres wrappers npm e o documento de ecossistema
- corrige os metadados publicos da v3.8.31

## Evidencia
- 204 passed, 30 subtests passed
- auditor de distribuicao: 0 erros, 0 avisos, 8 OK
- wheel PyPI publicado: 7 entradas, nenhum pyc/__pycache__