### PR TITLE
fix(codex): repair PreToolUse allow contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+codex/mcp-route.ps1 text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace the stale mandatory Codex hook with the canonical advisory route:
+  unchanged native, Simplicio, and third-party tool calls now return empty
+  stdout instead of unsupported `permissionDecision: "allow"`.
+- Require local publication to stage both versioned Codex hooks from the
+  Runtime release bundle so future tags cannot retain an older hook protocol.
+- Keep Windows warming failures advisory for read-only repositories and remove
+  obsolete decision-emission paths from the versioned hooks.
+- Gate both fresh and resumed local publication on the executable hook suite.
+
 ### Changed
 
 - Public installers now configure Codex to launch the installed Simplicio

--- a/codex/mcp-route.ps1
+++ b/codex/mcp-route.ps1
@@ -1,69 +1,358 @@
-# Simplicio MCP route — mandatory PreToolUse policy for Windows hosts.
-# simplicio-hook-version: 3240-v1
+# Simplicio MCP route — advisory PreToolUse context for Windows hosts.
+# simplicio-hook-version: 3240-v6
+param([switch]$WarmWorker)
+
 $ErrorActionPreference = 'Stop'
-$defaultBinDir = if ($env:SIMPLICIO_BIN_DIR) { $env:SIMPLICIO_BIN_DIR } else { Join-Path $env:USERPROFILE '.simplicio\bin' }
-$script:SimplicioBin = if ($env:SIMPLICIO_BIN) { $env:SIMPLICIO_BIN } else { Join-Path $defaultBinDir 'simplicio.exe' }
-$raw = [Console]::In.ReadToEnd()
-if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
-try { $hook = $raw | ConvertFrom-Json } catch { [Console]::Error.WriteLine('Simplicio MCP hook received invalid input JSON.'); exit 2 }
-if ($null -eq $hook) { [Console]::Error.WriteLine('Simplicio MCP hook received an empty input payload.'); exit 2 }
-$tool = [string]$hook.toolName
-if ([string]::IsNullOrWhiteSpace($tool)) { $tool = [string]$hook.tool_name }
-$input = $hook.toolInput
-if ($null -eq $input) { $input = $hook.tool_input }
-$event = [string]$hook.hookEventName
-if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.hook_event_name }
-if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]$hook.event }
-$event = $event.Replace('-','_').ToLowerInvariant()
-$isPreToolUse = $event -in @('pretooluse','pre_tool_use')
-$command = if ($input) { [string]$input.command } else { '' }
-$path = if ($input) {
-  $candidate = [string]$input.target_file
-  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.file_path }
-  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.path }
-  if ([string]::IsNullOrWhiteSpace($candidate)) { $candidate = [string]$input.file }
-  $candidate
-} else { '' }
-$context = 'Simplicio MCP is mandatory. Use simplicio_map first, then simplicio_context for the bounded Fast context packet and simplicio_memory for recall; use simplicio_file_read or simplicio_read, simplicio_search, simplicio_edit, simplicio_run/simplicio_exec, and simplicio_validate. There is no host-tool escape hatch.'
-$events = @{'sessionstart'='SessionStart';'session_start'='SessionStart';'userpromptsubmit'='UserPromptSubmit';'user_prompt_submit'='UserPromptSubmit';'subagentstart'='SubagentStart';'subagent_start'='SubagentStart'}
-if ($events.ContainsKey($event)) {
-  @{hookSpecificOutput=@{hookEventName=$events[$event];additionalContext=$context}} | ConvertTo-Json -Compress
+$UserHome = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+$overrideBin = [Environment]::GetEnvironmentVariable('SIMPLICIO_BIN')
+$script:SimplicioBin = if (-not [string]::IsNullOrWhiteSpace($overrideBin)) {
+  $overrideBin
+} elseif ([string]::IsNullOrWhiteSpace($UserHome) -or -not [IO.Path]::IsPathRooted($UserHome)) {
+  ''
+} else {
+  Join-Path (Join-Path $UserHome '.simplicio\bin') 'simplicio.exe'
+}
+
+if ($WarmWorker) {
+  $repo = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_REPO')
+  $outDir = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_OUT_DIR')
+  $marker = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_MARKER')
+  $lock = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_LOCK')
+  $generationValue = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_GENERATION')
+
+  function ConvertTo-ProcessArgument([string]$Value) {
+    if ($null -eq $Value -or $Value.Length -eq 0) { return '""' }
+    if ($Value -notmatch '[\s"]') { return $Value }
+    $quoted = '"'
+    $slashes = 0
+    foreach ($character in $Value.ToCharArray()) {
+      if ($character -eq '\') {
+        $slashes += 1
+        continue
+      }
+      if ($character -eq '"') {
+        $quoted += ('\' * ($slashes * 2 + 1)) + '"'
+        $slashes = 0
+        continue
+      }
+      if ($slashes -gt 0) {
+        $quoted += '\' * $slashes
+        $slashes = 0
+      }
+      $quoted += $character
+    }
+    if ($slashes -gt 0) { $quoted += '\' * ($slashes * 2) }
+    return $quoted + '"'
+  }
+
+  function Invoke-WarmStep([string[]]$Arguments, [string]$OutputPath) {
+    $tmp = $OutputPath + '.tmp'
+    $program = $script:SimplicioBin
+    $processArguments = @($Arguments)
+    if ([IO.Path]::GetExtension($program) -ieq '.ps1') {
+      $processArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-File', $program) + $processArguments
+      $program = (Get-Process -Id $PID -ErrorAction Stop).Path
+    }
+
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $program
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    if ($start.PSObject.Properties.Name -contains 'ArgumentList') {
+      foreach ($argument in $processArguments) {
+        [void]$start.ArgumentList.Add([string]$argument)
+      }
+    } else {
+      $start.Arguments = (($processArguments | ForEach-Object {
+        ConvertTo-ProcessArgument ([string]$_)
+      }) -join ' ')
+    }
+
+    $process = [Diagnostics.Process]::new()
+    try {
+      $process.StartInfo = $start
+      if (-not $process.Start()) { return $false }
+      $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+      $stderrTask = $process.StandardError.ReadToEndAsync()
+      if (-not $process.WaitForExit(45000)) {
+        try { $process.Kill() } catch {}
+        try { $process.WaitForExit() } catch {}
+        try { $stdoutTask.GetAwaiter().GetResult() | Out-Null } catch {}
+        try { $stderrTask.GetAwaiter().GetResult() | Out-Null } catch {}
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        return $false
+      }
+      $process.WaitForExit()
+      $stdout = $stdoutTask.GetAwaiter().GetResult()
+      $stderrTask.GetAwaiter().GetResult() | Out-Null
+      [IO.File]::WriteAllText($tmp, $stdout)
+      Move-Item -LiteralPath $tmp -Destination $OutputPath -Force
+      return $process.ExitCode -eq 0
+    } catch {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+      return $false
+    } finally {
+      $process.Dispose()
+    }
+  }
+
+  $success = $false
+  try {
+    if (
+      [string]::IsNullOrWhiteSpace($repo) -or
+      [string]::IsNullOrWhiteSpace($outDir) -or
+      [string]::IsNullOrWhiteSpace($marker) -or
+      [string]::IsNullOrWhiteSpace($lock) -or
+      [string]::IsNullOrWhiteSpace($generationValue)
+    ) { throw 'missing warm worker environment' }
+
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    Set-Content -LiteralPath $marker -Value $PID -NoNewline
+    $success = $true
+    foreach ($item in @(
+      @('map','--repo',$repo,'--for-llm','markdown','map.md'),
+      @('fast','build','--root',$repo,'--max-bytes','32000','--json','fast-build.json'),
+      @('fast','context','simplicio','--root',$repo,'--max-bytes','32000','--json','fast-context.json')
+    )) {
+      $name = $item[-1]
+      $arguments = [string[]]$item[0..($item.Length - 2)]
+      $stepOk = Invoke-WarmStep $arguments (Join-Path $outDir $name)
+      if (-not $stepOk) { $success = $false }
+    }
+  } catch {
+    $success = $false
+  } finally {
+    try {
+      $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+      $payload = [ordered]@{
+        schema = 'simplicio.hook-context-receipt/v1'
+        status = if ($success) { 'ready' } else { 'failed' }
+        generation = $generationValue
+        completed_at_unix = $now
+      }
+      if (-not $success) { $payload['retry_after_unix'] = $now + 60 }
+      $receipt = Join-Path $outDir 'warm-receipt.json'
+      $tmpReceipt = $receipt + '.tmp'
+      $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath $tmpReceipt -NoNewline
+      Move-Item -LiteralPath $tmpReceipt -Destination $receipt -Force
+    } catch {}
+    if (-not [string]::IsNullOrWhiteSpace($marker)) {
+      Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+    }
+    if (-not [string]::IsNullOrWhiteSpace($lock)) {
+      Remove-Item -LiteralPath $lock -Force -ErrorAction SilentlyContinue
+    }
+  }
   exit 0
 }
-function Deny([string]$detail) {
-  $reason = '[Simplicio MCP required] ' + $detail + ' ' + $context
-  EmitDecision 'deny' $reason
-  [Console]::Error.WriteLine($reason)
-  exit 2
+
+function Allow-Unchanged {
+  # Codex 0.150.0 rejects an explicit PreToolUse allow without updatedInput.
+  exit 0
 }
-function EmitDecision([string]$decision, [string]$reason = '') {
-  if ($isPreToolUse) {
-    $specific = @{hookEventName='PreToolUse';permissionDecision=$decision}
-    if ($reason) { $specific.permissionDecisionReason = $reason }
-    @{hookSpecificOutput=$specific} | ConvertTo-Json -Compress
-  } else {
-    $result = @{decision=$decision}
-    if ($reason) { $result.reason = $reason }
-    $result | ConvertTo-Json -Compress
+
+$raw = (@($input) -join [Environment]::NewLine)
+if ([string]::IsNullOrWhiteSpace($raw)) {
+  $raw = [Console]::In.ReadToEnd()
+}
+if ([string]::IsNullOrWhiteSpace($raw)) {
+  Allow-Unchanged
+}
+
+try { $hook = $raw | ConvertFrom-Json } catch {
+  Allow-Unchanged
+}
+if ($null -eq $hook) { Allow-Unchanged }
+
+$event = [string]($hook.hookEventName)
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]($hook.hook_event_name) }
+if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]($hook.event) }
+$event = $event.Replace('-', '_').ToLowerInvariant()
+$context = 'Simplicio pre-hook ran before the requested tool. Use simplicio_map -> simplicio_context -> simplicio_edit when that improves the task, but preserve the user explicit request and allow native and third-party tools unchanged.'
+$contextEvents = @{
+  'sessionstart' = 'SessionStart'; 'session_start' = 'SessionStart'
+  'userpromptsubmit' = 'UserPromptSubmit'; 'user_prompt_submit' = 'UserPromptSubmit'
+  'subagentstart' = 'SubagentStart'; 'subagent_start' = 'SubagentStart'
+}
+
+function Emit-Context([string]$name, [string]$body) {
+  @{ hookSpecificOutput = @{ hookEventName = $name; additionalContext = $body } } | ConvertTo-Json -Compress
+  exit 0
+}
+
+function Get-Sha256Text([string]$text) {
+  $sha = [Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes($text)
+    return -join ($sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') })
+  } finally {
+    $sha.Dispose()
   }
 }
-if ($tool.ToLowerInvariant().Contains('simplicio')) { EmitDecision 'allow'; exit 0 }
-$normalized = $path.Replace('\','/')
-if ((Split-Path -Leaf $normalized) -in @('AGENTS.md','CLAUDE.md','GEMINI.md','USER.md') -or $normalized.Contains('/.simplicio/hooks/')) { EmitDecision 'allow'; exit 0 }
-$tokens = $command.Trim() -split '\s+' | Where-Object { $_ -ne '' }
-$index = 0
-while ($index -lt $tokens.Count -and $tokens[$index] -match '^[A-Za-z_][A-Za-z0-9_]*=') { $index++ }
-$lead = if ($index -lt $tokens.Count) { Split-Path -Leaf $tokens[$index] } else { '' }
-$base = $tool.ToLowerInvariant().Split('__')[-1].Split('/')[-1] -replace '[^a-z0-9_]',''
-if ($base -in @('bash','shell','run','runterminalcommand','run_terminal_command','terminal')) {
-  if ($lead -in @('simplicio','simplicio.exe')) {
-    if ($command -match '(^|\s)(--help|-h)(\s|$)' -or $command.Trim() -in @('simplicio','simplicio.exe')) { Deny 'Use a specific Simplicio MCP tool; do not dump CLI help or run the bare CLI.' }
-    EmitDecision 'allow'; exit 0
+
+function Get-RepoGeneration([string]$root) {
+  try {
+    $headOutput = @(& git -C $root rev-parse HEAD 2>$null)
+    $headExit = $LASTEXITCODE
+    $statusOutput = @(& git -C $root -c core.quotepath=false status --porcelain=v1 --untracked-files=normal 2>$null)
+    $statusExit = $LASTEXITCODE
+    if ($headExit -eq 0 -and $statusExit -eq 0) {
+      $changed = @()
+      foreach ($rowValue in $statusOutput) {
+        $row = [string]$rowValue
+        if ($row.Length -lt 4) { continue }
+        $pathText = $row.Substring(3).Trim()
+        if ($pathText.Contains(' -> ')) { $pathText = $pathText.Split(@(' -> '), [StringSplitOptions]::None)[-1] }
+        $pathText = $pathText.Trim('"')
+        $normalized = $pathText.Replace('\', '/')
+        if ($normalized -eq '.simplicio' -or $normalized.StartsWith('.simplicio/')) { continue }
+        $identity = 'missing'
+        try {
+          $item = Get-Item -LiteralPath (Join-Path $root $pathText) -ErrorAction Stop
+          $size = if ($item.PSIsContainer) { 0 } else { [long]$item.Length }
+          $identity = '{0}:{1}' -f $item.LastWriteTimeUtc.Ticks, $size
+        } catch {}
+        $changed += ('{0}:{1}:{2}' -f $row.Substring(0, 2), $pathText, $identity)
+      }
+      $material = [ordered]@{
+        head = (($headOutput -join [Environment]::NewLine).Trim())
+        changed = @($changed | Sort-Object)
+      } | ConvertTo-Json -Compress
+      return Get-Sha256Text $material
+    }
+  } catch {}
+  try {
+    $item = Get-Item -LiteralPath $root -ErrorAction Stop
+    return Get-Sha256Text ('fallback:{0}:{1}' -f $item.FullName, $item.LastWriteTimeUtc.Ticks)
+  } catch {
+    return Get-Sha256Text ('fallback:{0}' -f $root)
   }
-  if ($lead -in @('sed','awk','perl')) {
-    if ($command -match '(^|\s)(--in-place|-i|-[A-Za-z]*i[A-Za-z]*)(\s|$)') { Deny ('Use simplicio_edit instead of ' + $lead + '.') }
-    Deny ('Use simplicio_file_read / simplicio_read / simplicio_search instead of ' + $lead + '.')
-  }
-  Deny 'Native shell commands are disabled; use simplicio_exec, simplicio_run, or the matching Simplicio MCP tool.'
 }
-Deny ("Native host tool '" + $(if ($tool) { $tool } else { 'unknown' }) + "' is disabled; use the matching Simplicio MCP tool.")
+
+function Try-AcquireWarmLock([string]$lockPath) {
+  foreach ($attempt in 1..2) {
+    $stream = $null
+    try {
+      $stream = [IO.File]::Open($lockPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+      $payload = [Text.Encoding]::ASCII.GetBytes(('{0}:{1}' -f $PID, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()))
+      $stream.Write($payload, 0, $payload.Length)
+      return $true
+    } catch [IO.IOException] {
+      try {
+        $age = ([DateTime]::UtcNow - (Get-Item -LiteralPath $lockPath -ErrorAction Stop).LastWriteTimeUtc).TotalSeconds
+        if ($age -lt 120) { return $false }
+        Remove-Item -LiteralPath $lockPath -Force -ErrorAction Stop
+      } catch {
+        return $false
+      }
+    } finally {
+      if ($null -ne $stream) { $stream.Dispose() }
+    }
+  }
+  return $false
+}
+
+function Start-WarmContext([string]$root) {
+  try {
+  if ([string]::IsNullOrWhiteSpace($root) -or -not (Test-Path -LiteralPath $root -PathType Container)) { return }
+  if ([string]::IsNullOrWhiteSpace($script:SimplicioBin) -or -not (Test-Path -LiteralPath $script:SimplicioBin -PathType Leaf)) { return }
+  $state = Join-Path $root '.simplicio/hook-context'
+  New-Item -ItemType Directory -Force -Path $state | Out-Null
+  $generation = Get-RepoGeneration $root
+  $receiptPath = Join-Path $state 'warm-receipt.json'
+  if (Test-Path -LiteralPath $receiptPath -PathType Leaf) {
+    try {
+      $receipt = Get-Content -LiteralPath $receiptPath -Raw -ErrorAction Stop | ConvertFrom-Json
+      $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+      if (
+        $receipt.schema -eq 'simplicio.hook-context-receipt/v1' -and
+        $receipt.generation -eq $generation -and
+        (
+          $receipt.status -eq 'ready' -or
+          ($receipt.status -eq 'failed' -and [long]$receipt.retry_after_unix -gt $now)
+        )
+      ) { return }
+    } catch {}
+  }
+
+  $pidPath = Join-Path $state 'warm.pid'
+  if (Test-Path $pidPath) {
+    try { if (Get-Process -Id ([int](Get-Content $pidPath -Raw)) -ErrorAction Stop) { return } } catch { Remove-Item $pidPath -Force -ErrorAction SilentlyContinue }
+  }
+  $lockPath = Join-Path $state 'warm.lock'
+  if (-not (Try-AcquireWarmLock $lockPath)) { return }
+
+  $environment = [ordered]@{
+    SIMPLICIO_BIN = $script:SimplicioBin
+    SIMPLICIO_HOOK_SELF = $PSCommandPath
+    SIMPLICIO_HOOK_WARM_REPO = $root
+    SIMPLICIO_HOOK_WARM_OUT_DIR = $state
+    SIMPLICIO_HOOK_WARM_MARKER = $pidPath
+    SIMPLICIO_HOOK_WARM_LOCK = $lockPath
+    SIMPLICIO_HOOK_WARM_GENERATION = $generation
+  }
+  $previous = @{}
+  try {
+    foreach ($entry in $environment.GetEnumerator()) {
+      $previous[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key, 'Process')
+      [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, 'Process')
+    }
+    $shellPath = (Get-Process -Id $PID -ErrorAction Stop).Path
+    $encodedWorker = [Convert]::ToBase64String(
+      [Text.Encoding]::Unicode.GetBytes('& $env:SIMPLICIO_HOOK_SELF -WarmWorker')
+    )
+    $launch = @{
+      FilePath = $shellPath
+      ArgumentList = @(
+        '-NoLogo', '-NoProfile', '-NonInteractive',
+        '-ExecutionPolicy', 'Bypass',
+        '-EncodedCommand', $encodedWorker
+      )
+      PassThru = $true
+    }
+    if ($env:OS -eq 'Windows_NT') { $launch['WindowStyle'] = 'Hidden' }
+    Start-Process @launch | Out-Null
+  } catch {
+    Remove-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
+  } finally {
+    foreach ($entry in $environment.GetEnumerator()) {
+      [Environment]::SetEnvironmentVariable(
+        $entry.Key,
+        $previous[$entry.Key],
+        'Process'
+      )
+    }
+  }
+  } catch {
+    # Context warming is advisory and must never block the requested host tool.
+    return
+  }
+}
+
+if ($contextEvents.ContainsKey($event)) {
+  $repo = [string]($hook.cwd)
+  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = [string]$hook.cwd_path }
+  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = (Get-Location).Path }
+  Start-WarmContext $repo
+  $parts = @($context)
+  $state = Join-Path $repo '.simplicio/hook-context'
+  foreach ($item in @(@('map.md',24000), @('fast-context.json',8000))) {
+    $file = Join-Path $state $item[0]
+    if (Test-Path $file) {
+      $content = Get-Content -LiteralPath $file -Raw -ErrorAction SilentlyContinue
+      if ($content) { $parts += "`nSimplicio $($item[0]) (background, bounded):`n" + $content.Substring(0, [Math]::Min([int]$item[1], $content.Length)) }
+    }
+  }
+  Emit-Context $contextEvents[$event] ($parts -join '')
+}
+
+# Advisory pre-hook: begin bounded Simplicio context work before the host tool,
+# then preserve the original native, third-party, or user-requested operation.
+$repo = [string]($hook.cwd)
+if ([string]::IsNullOrWhiteSpace($repo)) { $repo = [string]$hook.cwd_path }
+if ([string]::IsNullOrWhiteSpace($repo) -and $hook.workspace) { $repo = [string]$hook.workspace.current_dir }
+if ([string]::IsNullOrWhiteSpace($repo)) { $repo = (Get-Location).Path }
+Start-WarmContext $repo
+Allow-Unchanged

--- a/codex/mcp-route.sh
+++ b/codex/mcp-route.sh
@@ -1,125 +1,292 @@
 #!/usr/bin/env bash
-# Simplicio MCP route — mandatory PreToolUse policy for every supported host.
-# simplicio-hook-version: 3240-v1
+# Simplicio MCP route — advisory PreToolUse context for every supported host.
+# simplicio-hook-version: 3240-v6
+#
+# Simplicio starts first to warm bounded context, then the original native,
+# user-requested, or third-party tool is always allowed unchanged.
 set -uo pipefail
 
 SIMPLICIO_BIN="${SIMPLICIO_BIN:-${SIMPLICIO_BIN_DIR:-${HOME}/.simplicio/bin}/simplicio}"
 export SIMPLICIO_BIN
 
 INPUT="$(cat 2>/dev/null || true)"
+# Codex 0.150.0 rejects an explicit PreToolUse allow without updatedInput.
+# Empty stdout is the portable allow-unchanged contract; deny remains JSON.
 [ -n "$INPUT" ] || exit 0
+
 if ! command -v python3 >/dev/null 2>&1; then
-  printf '%s\n' 'Simplicio MCP hook cannot run because python3 is unavailable.' >&2
-  exit 2
+  exit 0
 fi
+
 export SIMPLICIO_MCP_ROUTE_INPUT="$INPUT"
 python3 - <<'PY'
-import json, os, pathlib, re, subprocess, sys
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import time
 
 raw = os.environ.get("SIMPLICIO_MCP_ROUTE_INPUT", "")
-runtime_bin = os.environ.get("SIMPLICIO_BIN") or str(pathlib.Path.home() / ".simplicio" / "bin" / "simplicio")
+RUNTIME_BIN = os.environ.get("SIMPLICIO_BIN") or str(pathlib.Path.home() / ".simplicio" / "bin" / "simplicio")
+
+
 try:
     hook = json.loads(raw)
 except Exception:
-    print("Simplicio MCP hook received invalid input JSON.", file=sys.stderr)
-    raise SystemExit(2)
+    # Hooks are advisory: malformed third-party payloads must never block.
+    raise SystemExit(0)
 
-event = str(hook.get("hookEventName") or hook.get("hook_event_name") or hook.get("event") or "").replace("-", "_").lower()
-tool = str(hook.get("toolName") or hook.get("tool_name") or "")
-tool_input = hook.get("toolInput") or hook.get("tool_input") or {}
-if not isinstance(tool_input, dict): tool_input = {}
-context = ("Simplicio MCP is mandatory. Use simplicio_map first, then simplicio_context for the bounded Fast context packet "
-           "and simplicio_memory for recall; use simplicio_file_read or simplicio_read, simplicio_search, "
-           "simplicio_edit, simplicio_run/simplicio_exec, and simplicio_validate. There is no host-tool escape hatch.")
+event = (
+    hook.get("hookEventName")
+    or hook.get("hook_event_name")
+    or hook.get("event")
+    or ""
+).replace("-", "_").lower()
+CONTEXT = (
+    "Simplicio pre-hook ran before the requested tool. "
+    "Use simplicio_map -> simplicio_context -> simplicio_edit when that improves "
+    "the task, but preserve the user's explicit request and allow native and "
+    "third-party tools unchanged."
+)
 
-def warm(root):
-    root = pathlib.Path(root).expanduser()
-    binary = pathlib.Path(runtime_bin)
-    if not root.is_dir() or not binary.is_file() or not os.access(binary, os.X_OK): return
+
+def repo_from_hook() -> str:
+    workspace = hook.get("workspace") or {}
+    if not isinstance(workspace, dict):
+        workspace = {}
+    return str(
+        hook.get("cwd")
+        or hook.get("cwd_path")
+        or workspace.get("current_dir")
+        or os.getcwd()
+    )
+
+
+def repository_generation(root: pathlib.Path) -> str:
+    """Return a cheap generation that changes with HEAD or visible worktree deltas."""
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        status = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "-c",
+                "core.quotepath=false",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=normal",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if head.returncode == 0 and status.returncode == 0:
+            changed = []
+            for row in status.stdout.splitlines():
+                if len(row) < 4:
+                    continue
+                path_text = row[3:].strip()
+                if " -> " in path_text:
+                    path_text = path_text.rsplit(" -> ", 1)[1]
+                path_text = path_text.strip('"')
+                if path_text == ".simplicio" or path_text.startswith(".simplicio/"):
+                    continue
+                path = root / path_text
+                try:
+                    stat = path.stat()
+                    identity = f"{stat.st_mtime_ns}:{stat.st_size}"
+                except OSError:
+                    identity = "missing"
+                changed.append(f"{row[:2]}:{path_text}:{identity}")
+            material = json.dumps(
+                {"head": head.stdout.strip(), "changed": sorted(changed)},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            return hashlib.sha256(material.encode("utf-8")).hexdigest()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        stat = root.stat()
+        material = f"fallback:{root.resolve()}:{stat.st_mtime_ns}:{stat.st_size}"
+    except OSError:
+        material = f"fallback:{root}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def acquire_warm_lock(lock_path: pathlib.Path) -> bool:
+    """Claim one warm worker before spawn; recover only demonstrably stale locks."""
+    for _ in range(2):
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        except FileExistsError:
+            try:
+                if time.time() - lock_path.stat().st_mtime < 120:
+                    return False
+                lock_path.unlink()
+            except OSError:
+                return False
+            continue
+        try:
+            os.write(descriptor, f"{os.getpid()}:{int(time.time())}".encode("ascii"))
+        finally:
+            os.close(descriptor)
+        return True
+    return False
+
+
+def warm_context(repo: str) -> None:
+    """Warm Mapper/Fast at most once for each observable repository generation."""
+    root = pathlib.Path(repo).expanduser()
+    runtime = pathlib.Path(RUNTIME_BIN)
+    if not root.is_dir() or not runtime.is_file() or not os.access(runtime, os.X_OK):
+        return
     state = root / ".simplicio" / "hook-context"
     try:
         state.mkdir(parents=True, exist_ok=True)
-        marker = state / "warm.pid"
-        if marker.is_file():
+        generation = repository_generation(root)
+        receipt_path = state / "warm-receipt.json"
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            if (
+                receipt.get("schema") == "simplicio.hook-context-receipt/v1"
+                and receipt.get("generation") == generation
+                and (
+                    receipt.get("status") == "ready"
+                    or (
+                        receipt.get("status") == "failed"
+                        and int(receipt.get("retry_after_unix", 0)) > int(time.time())
+                    )
+                )
+            ):
+                return
+        except (OSError, ValueError, TypeError):
+            pass
+
+        pid_path = state / "warm.pid"
+        if pid_path.is_file():
             try:
-                os.kill(int(marker.read_text().strip()), 0); return
-            except (ValueError, OSError): pass
+                pid = int(pid_path.read_text().strip())
+                os.kill(pid, 0)
+                return
+            except (ValueError, OSError):
+                pass
+        lock_path = state / "warm.lock"
+        if not acquire_warm_lock(lock_path):
+            return
         worker = (
-            "import pathlib,subprocess,sys\n"
-            "root=pathlib.Path(sys.argv[1]); state=root/'.simplicio'/'hook-context'; state.mkdir(parents=True,exist_ok=True); marker=state/'warm.pid'; marker.write_text(str(__import__('os').getpid()))\n"
+            "import json,os,pathlib,subprocess,sys,time\n"
+            "root=pathlib.Path(sys.argv[1]); generation=sys.argv[2]; state=root/'.simplicio'/'hook-context'; state.mkdir(parents=True,exist_ok=True)\n"
+            "pid=state/'warm.pid'; lock=state/'warm.lock'; pid.write_text(str(os.getpid()))\n"
             "def run(args,out):\n"
             "  tmp=out.with_suffix(out.suffix+'.tmp')\n"
             "  try:\n"
-            "    with open(tmp,'w',encoding='utf-8') as f: subprocess.run(args,stdout=f,stderr=subprocess.DEVNULL,timeout=45,check=False)\n"
+            "    with open(tmp,'w',encoding='utf-8') as f: result=subprocess.run(args,stdout=f,stderr=subprocess.DEVNULL,timeout=45,check=False)\n"
             "    tmp.replace(out)\n"
+            "    return result\n"
             "  except Exception:\n"
             "    try: tmp.unlink()\n"
             "    except OSError: pass\n"
+            "    return None\n"
             "try:\n"
-            "  binary=sys.argv[2]\n"
-            "  run([binary,'map','--repo',str(root),'--for-llm','markdown'],state/'map.md')\n"
-            "  run([binary,'fast','build','--root',str(root),'--max-bytes','32000','--json'],state/'fast-build.json')\n"
-            "  run([binary,'fast','context','--root',str(root),'--max-bytes','32000','--json'],state/'fast-context.json')\n"
+            "  binary=os.environ['SIMPLICIO_BIN']\n"
+            "  results=[\n"
+            "    run([binary,'map','--repo',str(root),'--for-llm','markdown'],state/'map.md'),\n"
+            "    run([binary,'fast','build','--root',str(root),'--max-bytes','32000','--json'],state/'fast-build.json'),\n"
+            "    run([binary,'fast','context','simplicio','--root',str(root),'--max-bytes','32000','--json'],state/'fast-context.json'),\n"
+            "  ]\n"
+            "  success=all(result is not None and result.returncode == 0 for result in results)\n"
+            "  now=int(time.time()); receipt=state/'warm-receipt.json'; tmp=state/'warm-receipt.json.tmp'\n"
+            "  payload={'schema':'simplicio.hook-context-receipt/v1','status':'ready' if success else 'failed','generation':generation,'completed_at_unix':now}\n"
+            "  if not success: payload['retry_after_unix']=now+60\n"
+            "  tmp.write_text(json.dumps(payload,sort_keys=True),encoding='utf-8')\n"
+            "  tmp.replace(receipt)\n"
             "finally:\n"
-            "  try: marker.unlink()\n"
+            "  try: pid.unlink()\n"
+            "  except OSError: pass\n"
+            "  try: lock.unlink()\n"
             "  except OSError: pass\n"
         )
-        subprocess.Popen([sys.executable,"-c",worker,str(root),str(binary)], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
-    except (OSError, ValueError): pass
-
-def packet(root):
-    state = pathlib.Path(root).expanduser()/".simplicio"/"hook-context"
-    parts=[]
-    for name,limit in (("map.md",24000),("fast-context.json",8000)):
         try:
-            value=(state/name).read_text(encoding="utf-8",errors="replace")
-            if value.strip(): parts.append(f"\nSimplicio {name} (background, bounded):\n{value[:limit]}")
-        except OSError: pass
+            subprocess.Popen(
+                [sys.executable, "-c", worker, str(root), generation],
+                env={**os.environ, "SIMPLICIO_BIN": str(runtime)},
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError:
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass
+            raise
+    except (OSError, ValueError):
+        return
+
+
+def context_packet(repo: str) -> str:
+    root = pathlib.Path(repo).expanduser()
+    state = root / ".simplicio" / "hook-context"
+    parts = []
+    map_path = state / "map.md"
+    fast_path = state / "fast-context.json"
+    try:
+        if map_path.is_file():
+            text = map_path.read_text(encoding="utf-8", errors="replace")
+            if text.strip():
+                parts.append("\nSimplicio map (background, bounded):\n" + text[:24000])
+        if fast_path.is_file():
+            text = fast_path.read_text(encoding="utf-8", errors="replace")
+            if text.strip():
+                parts.append("\nSimplicio context packet (background):\n" + text[:8000])
+    except OSError:
+        pass
     return "".join(parts)
 
-events={"sessionstart":"SessionStart","session_start":"SessionStart","userpromptsubmit":"UserPromptSubmit","user_prompt_submit":"UserPromptSubmit","subagentstart":"SubagentStart","subagent_start":"SubagentStart"}
-pre_tool_use = event in {"pretooluse", "pre_tool_use"}
-if event in events:
-    workspace=hook.get("workspace") or {}
-    root=str(hook.get("cwd") or hook.get("cwd_path") or (workspace.get("current_dir") if isinstance(workspace,dict) else "") or os.getcwd())
-    warm(root)
-    print(json.dumps({"hookSpecificOutput":{"hookEventName":events[event],"additionalContext":context+packet(root)}}))
+context_events = {
+    "sessionstart": "SessionStart",
+    "session_start": "SessionStart",
+    "userpromptsubmit": "UserPromptSubmit",
+    "user_prompt_submit": "UserPromptSubmit",
+    "subagentstart": "SubagentStart",
+    "subagent_start": "SubagentStart",
+}
+if event in context_events:
+    repo = repo_from_hook()
+    warm_context(repo)
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": context_events[event],
+            "additionalContext": CONTEXT + context_packet(repo),
+        }
+    }))
     raise SystemExit(0)
 
-def emit_decision(decision, reason=None):
-    if pre_tool_use:
-        specific = {"hookEventName": "PreToolUse", "permissionDecision": decision}
-        if reason: specific["permissionDecisionReason"] = reason
-        print(json.dumps({"hookSpecificOutput": specific}))
-    else:
-        result = {"decision": decision}
-        if reason: result["reason"] = reason
-        print(json.dumps(result))
 
-def allow(): emit_decision("allow"); raise SystemExit(0)
-def deny(detail):
-    reason="[Simplicio MCP required] "+detail+" "+context
-    emit_decision("deny", reason); sys.stderr.write(reason+"\n"); raise SystemExit(2)
+def allow() -> None:
+    # No decision means allow unchanged on Codex and other supported hosts.
+    raise SystemExit(0)
 
-if "simplicio" in tool.lower(): allow()
-command=str(tool_input.get("command") or "")
-path=str(tool_input.get("target_file") or tool_input.get("file_path") or tool_input.get("path") or tool_input.get("file") or "")
-normalized=path.replace("\\","/")
-if normalized.rsplit("/",1)[-1] in {"AGENTS.md","CLAUDE.md","GEMINI.md","USER.md"} or "/.simplicio/hooks/" in normalized: allow()
 
-tokens=command.strip().split(); i=0
-while i<len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=",tokens[i]): i+=1
-lead=os.path.basename(tokens[i]) if i<len(tokens) else ""
-base=re.sub(r"[^a-z0-9_]+","",tool.lower().split("__")[-1].split("/")[-1])
-if base in {"bash","shell","run","runterminalcommand","run_terminal_command","terminal"}:
-    if lead in {"simplicio","simplicio.exe"}:
-        if re.search(r"(?:^|\s)(?:--help|-h)(?:\s|$)",command) or command.strip() in {"simplicio","simplicio.exe"}: deny("Use a specific Simplicio MCP tool; do not dump CLI help or run the bare CLI.")
-        allow()
-    if lead in {"sed", "awk", "perl"}:
-        in_place = re.search(r"(?:^|\s)(?:--in-place|-i|-[A-Za-z]*i[A-Za-z]*)(?:\s|$)", command)
-        if in_place:
-            deny("Use simplicio_edit instead of " + lead + ".")
-        deny("Use simplicio_file_read / simplicio_read / simplicio_search instead of " + lead + ".")
-    deny("Native shell commands are disabled; use simplicio_exec, simplicio_run, or the matching Simplicio MCP tool.")
-deny("Native host tool '"+(tool or "unknown")+"' is disabled; use the matching Simplicio MCP tool.")
+# Advisory pre-hook: begin bounded Simplicio context work before the host tool,
+# then preserve the original native, third-party, or user-requested operation.
+warm_context(repo_from_hook())
+allow()
 PY

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -16,6 +16,8 @@ For each release `vX.Y.Z`, publish:
 - `SHA256SUMS`;
 - `simplicio-update-manifest.json`;
 - matching `version.txt` and `VERSION.md`;
+- `codex/mcp-route.sh` and `codex/mcp-route.ps1`, copied from the same Runtime
+  source commit and committed in the immutable tag;
 - `Simplicio-X.Y.Z-arm64.dmg` and `.zip` when the Desktop build is published;
 - SHA-256 and signing/notarization status for each Desktop artifact.
 
@@ -25,6 +27,11 @@ publish the root `signing_pubkey` exactly as
 `2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok=`.
 Do not publish a new release from a checkout where `version.txt` and the
 manifest disagree.
+
+The Codex hooks are versioned tag files rather than GitHub Release assets.
+Before tagging, execute `bash tests/test_codex_hooks.sh` and require every
+allow-unchanged case to exit zero with empty stdout. A bare
+`permissionDecision: "allow"` without `updatedInput` is release-blocking.
 
 ## Desktop release assets
 

--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -28,6 +28,10 @@ ASSETS = (
     "simplicio-windows-x64.exe",
 )
 META_ASSETS = ("SHA256SUMS", "simplicio-update-manifest.json")
+CODEX_HOOK_FILES = (
+    "codex/mcp-route.sh",
+    "codex/mcp-route.ps1",
+)
 LOCAL_STATE_PREFIXES = (".simplicio/", "pypi/simplicio/build/")
 
 
@@ -65,7 +69,7 @@ def normalize_version(value: str) -> tuple[str, str]:
     return tag, tag[1:]
 
 
-def required_bundle_files() -> list[str]:
+def required_release_assets() -> list[str]:
     files = list(META_ASSETS)
     for asset in ASSETS:
         files.extend((asset, asset + ".sig", asset + ".spdx.json", asset + ".provenance.json"))
@@ -75,7 +79,8 @@ def required_bundle_files() -> list[str]:
 def verify_bundle(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
     if not bundle.is_dir():
         raise PublishError("release bundle does not exist: %s" % bundle)
-    missing = [name for name in required_bundle_files() if not (bundle / name).is_file()]
+    required_public_files = (*required_release_assets(), *CODEX_HOOK_FILES)
+    missing = [name for name in required_public_files if not (bundle / name).is_file()]
     if missing:
         raise PublishError("release bundle is missing: " + ", ".join(missing))
 
@@ -119,7 +124,16 @@ def verify_bundle(bundle: Path, tag: str, version: str, source_commit: str) -> d
         for suffix in (".spdx.json", ".provenance.json"):
             json.loads((bundle / (asset + suffix)).read_text(encoding="utf-8"))
         verified.append({"asset": asset, "sha256": digest, "size": path.stat().st_size})
-    return {"version": version, "source_commit": source_commit, "artifacts": verified}
+    hooks = [
+        {"path": relative, "sha256": sha256(bundle / relative)}
+        for relative in CODEX_HOOK_FILES
+    ]
+    return {
+        "version": version,
+        "source_commit": source_commit,
+        "artifacts": verified,
+        "codex_hooks": hooks,
+    }
 
 
 def is_ignored_local_state(path: str) -> bool:
@@ -204,7 +218,7 @@ def resume_public_preflight(tag: str, version: str, source_commit: str) -> dict:
         for item in release.get("assets", [])
         if isinstance(item, dict) and item.get("name")
     }
-    if release_assets != set(required_bundle_files()):
+    if release_assets != set(required_release_assets()):
         raise PublishError("existing GitHub release asset set is incomplete or unexpected")
 
     existing_pypi = pypi_release_files(version)
@@ -313,11 +327,39 @@ def update_public_metadata(tag: str, version: str, source_commit: str) -> list[P
 
 def stage_bundle(bundle: Path) -> list[Path]:
     staged = []
-    for name in required_bundle_files():
+    for name in required_release_assets():
         destination = ROOT / name
         shutil.copy2(bundle / name, destination)
         staged.append(destination)
     return staged
+
+
+def stage_codex_hooks(bundle: Path) -> list[Path]:
+    staged = []
+    for relative in CODEX_HOOK_FILES:
+        source = bundle / relative
+        destination = ROOT / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        staged.append(destination)
+    return staged
+
+
+def verify_public_codex_hooks(bundle: Path) -> None:
+    mismatched = [
+        relative
+        for relative in CODEX_HOOK_FILES
+        if not (ROOT / relative).is_file()
+        or sha256(ROOT / relative) != sha256(bundle / relative)
+    ]
+    if mismatched:
+        raise PublishError("public Codex hooks differ from release bundle: " + ", ".join(mismatched))
+
+
+def verify_codex_hook_contract() -> None:
+    if shutil.which("pwsh") is None:
+        raise PublishError("PowerShell is required to validate the Windows Codex hook")
+    run(["bash", str(ROOT / "tests/test_codex_hooks.sh")], timeout=60)
 
 
 def prepare_package(version: str) -> list[Path]:
@@ -437,7 +479,7 @@ def commit_public(paths: list[Path], tag: str, source_commit: str) -> str:
 def create_public_release(tag: str, bundle: Path) -> None:
     run([
         "gh", "release", "create", tag,
-        *[str(bundle / name) for name in required_bundle_files()],
+        *[str(bundle / name) for name in required_release_assets()],
         "--repo", PUBLIC_REPOSITORY,
         "--verify-tag",
         "--title", "Simplicio Runtime " + tag,
@@ -465,9 +507,11 @@ def publish(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
     public_preflight(tag, version, require_clean=True)
     bundle_receipt = verify_bundle(bundle, tag, version, source_commit)
     changed = stage_bundle(bundle)
+    changed.extend(stage_codex_hooks(bundle))
     changed.extend(update_public_metadata(tag, version, source_commit))
     changed.extend(prepare_package(version))
 
+    verify_codex_hook_contract()
     run([sys.executable, str(ROOT / "scripts/verify_distribution_consistency.py")])
     run([
         sys.executable, "-m", "pytest", "-q",
@@ -526,7 +570,9 @@ def publish(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
 def resume_publish(bundle: Path, tag: str, version: str, source_commit: str) -> dict:
     resume_state = resume_public_preflight(tag, version, source_commit)
     bundle_receipt = verify_bundle(bundle, tag, version, source_commit)
+    verify_public_codex_hooks(bundle)
 
+    verify_codex_hook_contract()
     run([sys.executable, str(ROOT / "scripts/verify_distribution_consistency.py")])
     run([
         sys.executable, "-m", "pytest", "-q",

--- a/tests/test_codex_hooks.sh
+++ b/tests/test_codex_hooks.sh
@@ -3,8 +3,31 @@ set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HOOK="$ROOT/codex/mcp-route.sh"
+WINDOWS_HOOK="$ROOT/codex/mcp-route.ps1"
 PASS=0
 FAIL=0
+
+valid_output() {
+  [ -z "$1" ] && return 0
+  printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin)
+specific = value.get("hookSpecificOutput") or {}
+event = specific.get("hookEventName")
+if event == "PreToolUse":
+    decision = specific.get("permissionDecision")
+    if decision == "allow" and "updatedInput" not in specific:
+        raise SystemExit("unsupported permissionDecision:allow without updatedInput")
+    if decision == "deny" and not specific.get("permissionDecisionReason"):
+        raise SystemExit("PreToolUse deny missing permissionDecisionReason")
+    if decision not in {"allow", "deny"}:
+        raise SystemExit("unsupported PreToolUse decision")
+elif not specific.get("additionalContext"):
+    raise SystemExit("hook output has no supported context or decision")
+'
+}
 
 run_case() {
   name="$1"
@@ -12,79 +35,85 @@ run_case() {
   want_exit="$3"
   want_token="$4"
   errfile="$(mktemp)"
-  out="$(printf '%s' "$payload" | bash "$HOOK" 2>"$errfile")"
+  out="$(printf '%s' "$payload" | SIMPLICIO_BIN=/nonexistent bash "$HOOK" 2>"$errfile")"
   got=$?
+  err="$(sed -n '1,4p' "$errfile")"
   rm -f "$errfile"
-  if [ "$got" = "$want_exit" ] && printf '%s' "$out" | grep -q "$want_token"; then
+
+  contract_ok=0
+  valid_output "$out" >/dev/null 2>&1 || contract_ok=$?
+  token_ok=1
+  if [ "$want_token" = "__EMPTY__" ]; then
+    [ -z "$out" ] && token_ok=0
+  elif printf '%s' "$out" | grep -Fq -- "$want_token"; then
+    token_ok=0
+  fi
+
+  if [ "$got" = "$want_exit" ] &&
+     [ "$contract_ok" -eq 0 ] &&
+     [ "$token_ok" -eq 0 ]; then
     printf 'PASS %s\n' "$name"
     PASS=$((PASS + 1))
   else
-    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
+    printf 'FAIL %s: exit=%s contract=%s output=%s stderr=%s\n' \
+      "$name" "$got" "$contract_ok" "$out" "$err" >&2
     FAIL=$((FAIL + 1))
   fi
 }
 
-run_case "context" '{"hook_event_name":"SessionStart","source":"startup"}' 0 'SessionStart'
-run_case "allow simplicio tool" '{"toolName":"simplicio__simplicio_read","toolInput":{"path":"x"}}' 0 'allow'
-run_case "deny host read" '{"toolName":"read_file","toolInput":{"file_path":"src/main.rs"}}' 2 'deny'
-run_case "deny native edit" '{"toolName":"search_replace","toolInput":{"file_path":"src/main.rs"}}' 2 'deny'
-run_case "deny native shell" '{"toolName":"Bash","toolInput":{"command":"git status"}}' 2 'deny'
-
-check_pre_tool_use_reason() {
-  name="$1"
-  payload="$2"
-  prefix="$3"
-  out="$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)"
-  got=$?
-  if [ "$got" = 2 ] && printf '%s' "$out" | PREFIX="$prefix" python3 -c '
-import json, os, sys
-reason = json.load(sys.stdin)["hookSpecificOutput"]["permissionDecisionReason"]
-assert reason.startswith(os.environ["PREFIX"])
-'; then
-    printf 'PASS %s\n' "$name"
-    PASS=$((PASS + 1))
-  else
-    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_pre_tool_use_reason "read-only sed points to MCP read" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -n 1,5p src/main.rs"}}' \
-  '[Simplicio MCP required] Use simplicio_file_read'
-check_pre_tool_use_reason "mutating sed points to MCP edit" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -i s/old/new/ src/main.rs"}}' \
-  '[Simplicio MCP required] Use simplicio_edit'
-
-check_pre_tool_use_schema() {
-  name="$1"
-  payload="$2"
-  want_exit="$3"
-  out="$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)"
-  got=$?
-  if [ "$got" = "$want_exit" ] && printf '%s' "$out" | python3 -c '
-import json, sys
-value = json.load(sys.stdin)
-specific = value.get("hookSpecificOutput") or {}
-assert specific.get("hookEventName") == "PreToolUse"
-assert specific.get("permissionDecision") in {"allow", "deny", "ask"}
-'; then
-    printf 'PASS %s\n' "$name"
-    PASS=$((PASS + 1))
-  else
-    printf 'FAIL %s: exit=%s output=%s\n' "$name" "$got" "$out" >&2
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_pre_tool_use_schema "PreToolUse allow schema" \
-  '{"hook_event_name":"PreToolUse","tool_name":"simplicio__simplicio_read","tool_input":{"path":"src/main.rs"},"cwd":"/tmp"}' 0
-check_pre_tool_use_schema "PreToolUse deny schema" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"src/main.rs"},"cwd":"/tmp"}' 2
+run_case "SessionStart context" \
+  '{"hook_event_name":"SessionStart","source":"startup","cwd":"/tmp"}' \
+  0 'SessionStart'
+run_case "allow Simplicio tool unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"simplicio__simplicio_read","tool_input":{"path":"x"},"cwd":"/tmp"}' \
+  0 '__EMPTY__'
+run_case "allow native read unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"read_file","tool_input":{"file_path":"src/main.rs"},"cwd":"/tmp"}' \
+  0 '__EMPTY__'
+run_case "allow native edit unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"search_replace","tool_input":{"file_path":"src/main.rs"},"cwd":"/tmp"}' \
+  0 '__EMPTY__'
+run_case "allow explicit shell unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp"}' \
+  0 '__EMPTY__'
+run_case "allow third-party tool unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"mcp__cloudflare__zones_list","tool_input":{},"cwd":"/tmp"}' \
+  0 '__EMPTY__'
+run_case "fail open on malformed input" 'not-json' 0 '__EMPTY__'
 
 if ! grep -q 'simplicio_map' "$HOOK" || ! grep -q 'simplicio_context' "$HOOK"; then
   printf 'FAIL hook context is missing map/context routing\n' >&2
   FAIL=$((FAIL + 1))
+fi
+if ! grep -q 'Allow-Unchanged' "$WINDOWS_HOOK"; then
+  printf 'FAIL Windows hook is missing empty allow-unchanged contract\n' >&2
+  FAIL=$((FAIL + 1))
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+  scratch="$(mktemp -d)"
+  repo="$scratch/repo"
+  fake_bin="$scratch/simplicio-fake.ps1"
+  mkdir -p "$repo"
+  printf '%s\n' 'exit 0' >"$fake_bin"
+  chmod 0555 "$repo"
+  payload="{\"hookEventName\":\"PreToolUse\",\"toolName\":\"read_file\",\"cwd\":\"$repo\"}"
+  ps_out="$(printf '%s' "$payload" |
+    env SIMPLICIO_BIN="$fake_bin" \
+      pwsh -NoLogo -NoProfile -NonInteractive -File "$WINDOWS_HOOK" 2>/dev/null)"
+  ps_exit=$?
+  chmod 0755 "$repo"
+  rm -rf "$scratch"
+  if [ "$ps_exit" -eq 0 ] && [ -z "$ps_out" ]; then
+    printf 'PASS Windows read-only repository fails open\n'
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL Windows read-only repository exit=%s output=%s\n' \
+      "$ps_exit" "$ps_out" >&2
+    FAIL=$((FAIL + 1))
+  fi
+else
+  printf 'SKIP Windows read-only repository (pwsh unavailable)\n'
 fi
 
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -1,9 +1,32 @@
 """Static contract checks for the public Codex integration."""
 
+import json
+import os
 from pathlib import Path
+import subprocess
 
 
 ROOT = Path(__file__).parents[1]
+
+
+def test_pretooluse_allow_unchanged_emits_no_permission_decision():
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "simplicio__simplicio_read",
+        "tool_input": {"path": "src/main.rs"},
+        "cwd": "/tmp",
+    }
+    completed = subprocess.run(
+        ["bash", str(ROOT / "codex" / "mcp-route.sh")],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+        env={**os.environ, "SIMPLICIO_BIN": "/nonexistent"},
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
 
 
 def test_installers_configure_direct_stdio_and_hooks():
@@ -59,15 +82,20 @@ def test_unix_installer_accepts_release_manifest_target_aliases():
 def test_codex_hooks_have_all_required_lifecycle_events():
     shell_hook = (ROOT / "codex/mcp-route.sh").read_text(encoding="utf-8")
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")
-    # Claude's current PreToolUse protocol rejects the legacy top-level
-    # {decision: allow|deny} response. Both platform hooks must emit the
-    # event-specific permissionDecision envelope.
-    assert "permissionDecision" in shell_hook
-    assert "permissionDecision" in powershell_hook
+    # Codex rejects a bare PreToolUse permissionDecision=allow. Allowing an
+    # unchanged call is represented by successful empty stdout on both hosts.
+    assert "permissionDecision" not in shell_hook
+    assert "permissionDecision" not in powershell_hook
     assert "hookEventName" in shell_hook
     assert "hookEventName" in powershell_hook
-    assert "Use simplicio_file_read / simplicio_read / simplicio_search instead of" in shell_hook
-    assert "Use simplicio_file_read / simplicio_read / simplicio_search instead of" in powershell_hook
+    assert "simplicio-hook-version: 3240-v6" in shell_hook
+    assert "simplicio-hook-version: 3240-v6" in powershell_hook
+    assert "Empty stdout is the portable allow-unchanged contract" in shell_hook
+    assert "No decision means allow unchanged" in shell_hook
+    assert "Allow-Unchanged" in powershell_hook
+    assert "rejects an explicit PreToolUse allow without updatedInput" in powershell_hook
+    assert "Simplicio MCP is mandatory" not in shell_hook
+    assert "Simplicio MCP is mandatory" not in powershell_hook
     for event in ("SessionStart", "UserPromptSubmit", "SubagentStart"):
         assert event in shell_hook
         assert event in powershell_hook
@@ -77,7 +105,7 @@ def test_codex_hooks_have_all_required_lifecycle_events():
     assert "simplicio_context" in shell_hook
     assert 'SIMPLICIO_BIN="${SIMPLICIO_BIN:-${SIMPLICIO_BIN_DIR:-${HOME}/.simplicio/bin}/simplicio}"' in shell_hook
     assert 'which("simplicio")' not in shell_hook
-    assert "Join-Path $env:USERPROFILE '.simplicio\\bin'" in powershell_hook
+    assert "Join-Path (Join-Path $UserHome '.simplicio\\bin') 'simplicio.exe'" in powershell_hook
     assert "Get-Command simplicio" not in powershell_hook
 
 

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -90,6 +90,55 @@ def test_public_publisher_uses_post_release_smoke_cli_contract():
     assert '"core.whitespace=cr-at-eol"' in publisher
 
 
+def test_public_publisher_stages_versioned_codex_hooks(tmp_path, monkeypatch):
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_hooks", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    bundle = tmp_path / "bundle"
+    public = tmp_path / "public"
+    for relative in module.CODEX_HOOK_FILES:
+        source = bundle / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("fixture " + relative + "\n", encoding="utf-8")
+    (bundle / "codex/mcp-route.sh").chmod(0o755)
+
+    monkeypatch.setattr(module, "ROOT", public)
+    changed = module.stage_codex_hooks(bundle)
+
+    assert {path.relative_to(public).as_posix() for path in changed} == set(
+        module.CODEX_HOOK_FILES
+    )
+    for relative in module.CODEX_HOOK_FILES:
+        assert (public / relative).read_bytes() == (bundle / relative).read_bytes()
+    assert (public / "codex/mcp-route.sh").stat().st_mode & 0o111
+
+
+def test_publication_paths_gate_the_executable_codex_hook_contract():
+    publisher = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
+    assert 'shutil.which("pwsh")' in publisher
+    assert 'run(["bash", str(ROOT / "tests/test_codex_hooks.sh")], timeout=60)' in publisher
+    assert publisher.count("verify_codex_hook_contract()") == 3
+
+
+def test_publication_fails_closed_when_powershell_is_unavailable(monkeypatch):
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_pwsh", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+
+    try:
+        module.verify_codex_hook_contract()
+    except module.PublishError as exc:
+        assert "PowerShell is required" in str(exc)
+    else:
+        raise AssertionError("publication accepted a skipped Windows hook contract")
+
+
 def test_public_publisher_requires_pr_merge_before_tagging():
     publisher = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
     assert '"gh", "pr", "create"' in publisher


### PR DESCRIPTION
## Summary

- Replace the stale tagged Codex hooks with the canonical Runtime hook version 3240-v6.
- Return empty stdout for unchanged PreToolUse calls instead of unsupported permissionDecision:allow.
- Preserve lifecycle additionalContext and background Mapper/Fast warming without blocking native, Simplicio, or third-party tools.
- Fail open on Windows when context state cannot be written.
- Require canonical hooks and executable POSIX/PowerShell contract tests before fresh or resumed publication.
- No binaries, product version bump, tag, release, or PyPI publication are included.

## Tracking issue

Related: wesleysimplicio/simplicio-runtime#5053 (customer-reported defect)

## Quality evidence

- [x] Full test suite: 208 passed, 30 subtests passed.
- [x] Regression test fails on the previous Windows hook and passes after the fix.
- [x] Executable hook suite: 8 passed, 0 failed, including PowerShell.
- [x] Hook SHA-256 values are byte-identical to the Runtime canonical files.
- [x] git diff --check.
- [x] Independent Standards review: clean.
- [x] Independent Spec review: clean.
- [ ] No installer dry-run or release matrix execution: the user explicitly requested no binaries or release in this PR.

## Regression test

- tests/test_codex_hooks.sh covers empty allow-unchanged output and read-only Windows fail-open behavior.
- tests/test_codex_install_contract.py rejects any reintroduced explicit decision emitter.
- tests/test_release_local_contract.py requires PowerShell and gates fresh/resumed publication.

## Exceptions

No publication was performed; this PR only repairs source distribution and future release guards.