### PR TITLE
fix(codex): enforce v3.8.35 hook contract

### DIFF
--- a/codex/mcp-route.ps1
+++ b/codex/mcp-route.ps1
@@ -1,8 +1,11 @@
-# Simplicio MCP route — advisory PreToolUse context for Windows hosts.
-# simplicio-hook-version: 3240-v6
+# Simplicio MCP route — advisory Map cache for Windows hosts.
+# simplicio-hook-version: 3240-v8
+# Native shell/terminal is denied unless it directly invokes Simplicio.
 param([switch]$WarmWorker)
 
 $ErrorActionPreference = 'Stop'
+$MapReceiptSchema = 'simplicio.hook-map-receipt/v1'
+$InjectionReceiptSchema = 'simplicio.hook-context-injection/v1'
 $UserHome = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
 $overrideBin = [Environment]::GetEnvironmentVariable('SIMPLICIO_BIN')
 $script:SimplicioBin = if (-not [string]::IsNullOrWhiteSpace($overrideBin)) {
@@ -13,91 +16,94 @@ $script:SimplicioBin = if (-not [string]::IsNullOrWhiteSpace($overrideBin)) {
   Join-Path (Join-Path $UserHome '.simplicio\bin') 'simplicio.exe'
 }
 
+function ConvertTo-ProcessArgument([string]$Value) {
+  if ($null -eq $Value -or $Value.Length -eq 0) { return '""' }
+  if ($Value -notmatch '[\s"]') { return $Value }
+  $quoted = '"'
+  $slashes = 0
+  foreach ($character in $Value.ToCharArray()) {
+    if ($character -eq '\') {
+      $slashes += 1
+      continue
+    }
+    if ($character -eq '"') {
+      $quoted += ('\' * ($slashes * 2 + 1)) + '"'
+      $slashes = 0
+      continue
+    }
+    if ($slashes -gt 0) {
+      $quoted += '\' * $slashes
+      $slashes = 0
+    }
+    $quoted += $character
+  }
+  if ($slashes -gt 0) { $quoted += '\' * ($slashes * 2) }
+  return $quoted + '"'
+}
+
+function Invoke-MapStep([string]$Repo, [string]$OutputPath) {
+  $tmp = $OutputPath + '.tmp'
+  $program = $script:SimplicioBin
+  $processArguments = @('map', '--repo', $Repo, '--for-llm', 'markdown')
+  if ([IO.Path]::GetExtension($program) -ieq '.ps1') {
+    $processArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-File', $program) + $processArguments
+    $program = (Get-Process -Id $PID -ErrorAction Stop).Path
+  }
+
+  $start = [Diagnostics.ProcessStartInfo]::new()
+  $start.FileName = $program
+  $start.UseShellExecute = $false
+  $start.CreateNoWindow = $true
+  $start.RedirectStandardOutput = $true
+  $start.RedirectStandardError = $true
+  if ($start.PSObject.Properties.Name -contains 'ArgumentList') {
+    foreach ($argument in $processArguments) {
+      [void]$start.ArgumentList.Add([string]$argument)
+    }
+  } else {
+    $start.Arguments = (($processArguments | ForEach-Object {
+      ConvertTo-ProcessArgument ([string]$_)
+    }) -join ' ')
+  }
+
+  $process = [Diagnostics.Process]::new()
+  try {
+    $process.StartInfo = $start
+    if (-not $process.Start()) { return $false }
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    if (-not $process.WaitForExit(120000)) {
+      try { $process.Kill() } catch {}
+      try { $process.WaitForExit() } catch {}
+      try { $stdoutTask.GetAwaiter().GetResult() | Out-Null } catch {}
+      try { $stderrTask.GetAwaiter().GetResult() | Out-Null } catch {}
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+      return $false
+    }
+    $process.WaitForExit()
+    $stdout = $stdoutTask.GetAwaiter().GetResult()
+    $stderrTask.GetAwaiter().GetResult() | Out-Null
+    if ($process.ExitCode -ne 0 -or [string]::IsNullOrEmpty($stdout)) {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+      return $false
+    }
+    [IO.File]::WriteAllText($tmp, $stdout, [Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $tmp -Destination $OutputPath -Force
+    return $true
+  } catch {
+    Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    return $false
+  } finally {
+    $process.Dispose()
+  }
+}
+
 if ($WarmWorker) {
   $repo = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_REPO')
   $outDir = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_OUT_DIR')
   $marker = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_MARKER')
   $lock = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_LOCK')
   $generationValue = [Environment]::GetEnvironmentVariable('SIMPLICIO_HOOK_WARM_GENERATION')
-
-  function ConvertTo-ProcessArgument([string]$Value) {
-    if ($null -eq $Value -or $Value.Length -eq 0) { return '""' }
-    if ($Value -notmatch '[\s"]') { return $Value }
-    $quoted = '"'
-    $slashes = 0
-    foreach ($character in $Value.ToCharArray()) {
-      if ($character -eq '\') {
-        $slashes += 1
-        continue
-      }
-      if ($character -eq '"') {
-        $quoted += ('\' * ($slashes * 2 + 1)) + '"'
-        $slashes = 0
-        continue
-      }
-      if ($slashes -gt 0) {
-        $quoted += '\' * $slashes
-        $slashes = 0
-      }
-      $quoted += $character
-    }
-    if ($slashes -gt 0) { $quoted += '\' * ($slashes * 2) }
-    return $quoted + '"'
-  }
-
-  function Invoke-WarmStep([string[]]$Arguments, [string]$OutputPath) {
-    $tmp = $OutputPath + '.tmp'
-    $program = $script:SimplicioBin
-    $processArguments = @($Arguments)
-    if ([IO.Path]::GetExtension($program) -ieq '.ps1') {
-      $processArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-File', $program) + $processArguments
-      $program = (Get-Process -Id $PID -ErrorAction Stop).Path
-    }
-
-    $start = [Diagnostics.ProcessStartInfo]::new()
-    $start.FileName = $program
-    $start.UseShellExecute = $false
-    $start.CreateNoWindow = $true
-    $start.RedirectStandardOutput = $true
-    $start.RedirectStandardError = $true
-    if ($start.PSObject.Properties.Name -contains 'ArgumentList') {
-      foreach ($argument in $processArguments) {
-        [void]$start.ArgumentList.Add([string]$argument)
-      }
-    } else {
-      $start.Arguments = (($processArguments | ForEach-Object {
-        ConvertTo-ProcessArgument ([string]$_)
-      }) -join ' ')
-    }
-
-    $process = [Diagnostics.Process]::new()
-    try {
-      $process.StartInfo = $start
-      if (-not $process.Start()) { return $false }
-      $stdoutTask = $process.StandardOutput.ReadToEndAsync()
-      $stderrTask = $process.StandardError.ReadToEndAsync()
-      if (-not $process.WaitForExit(45000)) {
-        try { $process.Kill() } catch {}
-        try { $process.WaitForExit() } catch {}
-        try { $stdoutTask.GetAwaiter().GetResult() | Out-Null } catch {}
-        try { $stderrTask.GetAwaiter().GetResult() | Out-Null } catch {}
-        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
-        return $false
-      }
-      $process.WaitForExit()
-      $stdout = $stdoutTask.GetAwaiter().GetResult()
-      $stderrTask.GetAwaiter().GetResult() | Out-Null
-      [IO.File]::WriteAllText($tmp, $stdout)
-      Move-Item -LiteralPath $tmp -Destination $OutputPath -Force
-      return $process.ExitCode -eq 0
-    } catch {
-      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
-      return $false
-    } finally {
-      $process.Dispose()
-    }
-  }
-
   $success = $false
   try {
     if (
@@ -106,33 +112,30 @@ if ($WarmWorker) {
       [string]::IsNullOrWhiteSpace($marker) -or
       [string]::IsNullOrWhiteSpace($lock) -or
       [string]::IsNullOrWhiteSpace($generationValue)
-    ) { throw 'missing warm worker environment' }
+    ) { throw 'missing Map worker environment' }
 
     New-Item -ItemType Directory -Force -Path $outDir | Out-Null
     Set-Content -LiteralPath $marker -Value $PID -NoNewline
-    $success = $true
-    foreach ($item in @(
-      @('map','--repo',$repo,'--for-llm','markdown','map.md'),
-      @('fast','build','--root',$repo,'--max-bytes','32000','--json','fast-build.json'),
-      @('fast','context','simplicio','--root',$repo,'--max-bytes','32000','--json','fast-context.json')
-    )) {
-      $name = $item[-1]
-      $arguments = [string[]]$item[0..($item.Length - 2)]
-      $stepOk = Invoke-WarmStep $arguments (Join-Path $outDir $name)
-      if (-not $stepOk) { $success = $false }
-    }
+    $mapPath = Join-Path $outDir 'map.md'
+    $success = Invoke-MapStep $repo $mapPath
   } catch {
     $success = $false
   } finally {
     try {
       $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
       $payload = [ordered]@{
-        schema = 'simplicio.hook-context-receipt/v1'
+        schema = $MapReceiptSchema
         status = if ($success) { 'ready' } else { 'failed' }
         generation = $generationValue
         completed_at_unix = $now
       }
-      if (-not $success) { $payload['retry_after_unix'] = $now + 60 }
+      if ($success) {
+        $mapItem = Get-Item -LiteralPath $mapPath -ErrorAction Stop
+        $payload['map_sha256'] = (Get-FileHash -LiteralPath $mapPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        $payload['map_bytes'] = [long]$mapItem.Length
+      } else {
+        $payload['retry_after_unix'] = $now + 900
+      }
       $receipt = Join-Path $outDir 'warm-receipt.json'
       $tmpReceipt = $receipt + '.tmp'
       $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath $tmpReceipt -NoNewline
@@ -149,7 +152,7 @@ if ($WarmWorker) {
 }
 
 function Allow-Unchanged {
-  # Codex 0.150.0 rejects an explicit PreToolUse allow without updatedInput.
+  # No decision means allow unchanged on Codex and other supported hosts.
   exit 0
 }
 
@@ -157,46 +160,119 @@ $raw = (@($input) -join [Environment]::NewLine)
 if ([string]::IsNullOrWhiteSpace($raw)) {
   $raw = [Console]::In.ReadToEnd()
 }
-if ([string]::IsNullOrWhiteSpace($raw)) {
-  Allow-Unchanged
-}
-
-try { $hook = $raw | ConvertFrom-Json } catch {
-  Allow-Unchanged
-}
+if ([string]::IsNullOrWhiteSpace($raw)) { Allow-Unchanged }
+try { $hook = $raw | ConvertFrom-Json } catch { Allow-Unchanged }
 if ($null -eq $hook) { Allow-Unchanged }
 
 $event = [string]($hook.hookEventName)
 if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]($hook.hook_event_name) }
 if ([string]::IsNullOrWhiteSpace($event)) { $event = [string]($hook.event) }
 $event = $event.Replace('-', '_').ToLowerInvariant()
-$context = 'Simplicio pre-hook ran before the requested tool. Use simplicio_map -> simplicio_context -> simplicio_edit when that improves the task, but preserve the user explicit request and allow native and third-party tools unchanged.'
 $contextEvents = @{
   'sessionstart' = 'SessionStart'; 'session_start' = 'SessionStart'
   'userpromptsubmit' = 'UserPromptSubmit'; 'user_prompt_submit' = 'UserPromptSubmit'
   'subagentstart' = 'SubagentStart'; 'subagent_start' = 'SubagentStart'
 }
 
-function Emit-Context([string]$name, [string]$body) {
-  @{ hookSpecificOutput = @{ hookEventName = $name; additionalContext = $body } } | ConvertTo-Json -Compress
+function Emit-Context([string]$Name, [string]$Body) {
+  @{ hookSpecificOutput = @{ hookEventName = $Name; additionalContext = $Body } } |
+    ConvertTo-Json -Compress
   exit 0
 }
 
-function Get-Sha256Text([string]$text) {
+function Emit-DenyNativeShell {
+  @{
+    hookSpecificOutput = @{
+      hookEventName = 'PreToolUse'
+      permissionDecision = 'deny'
+      permissionDecisionReason = (
+        'Native shell/terminal is disabled; use a Simplicio MCP tool or ' +
+        'invoke the command directly through simplicio.'
+      )
+    }
+  } | ConvertTo-Json -Compress
+  exit 0
+}
+
+function Get-HookToolName {
+  $name = [string]($hook.toolName)
+  if ([string]::IsNullOrWhiteSpace($name)) { $name = [string]($hook.tool_name) }
+  if ([string]::IsNullOrWhiteSpace($name)) { $name = [string]($hook.name) }
+  return $name
+}
+
+function Test-NativeShellTool([string]$Name) {
+  $normalized = $Name.Trim().ToLowerInvariant().Replace('-', '_')
+  if (
+    [string]::IsNullOrWhiteSpace($normalized) -or
+    $normalized.StartsWith('mcp__') -or
+    $normalized.StartsWith('app__') -or
+    $normalized.StartsWith('plugin__')
+  ) { return $false }
+  $parts = @($normalized -split '(?:__|::|\.)')
+  $leaf = if ($parts.Count -gt 0) { $parts[-1] } else { $normalized }
+  $shellNames = @(
+    'bash', 'cmd', 'exec_command', 'execute_command', 'powershell', 'pwsh',
+    'run_command', 'run_shell_command', 'run_terminal_command', 'shell',
+    'shell_command', 'terminal', 'terminal_command', 'write_stdin'
+  )
+  return $shellNames -contains $leaf
+}
+
+function Get-HookCommand {
+  $toolInput = $hook.toolInput
+  if ($null -eq $toolInput) { $toolInput = $hook.tool_input }
+  if ($null -eq $toolInput) { $toolInput = $hook.input }
+  if ($null -eq $toolInput) { return '' }
+  foreach ($key in @('command', 'cmd', 'script')) {
+    $property = $toolInput.PSObject.Properties[$key]
+    if ($null -ne $property -and $property.Value -is [string]) {
+      return [string]$property.Value
+    }
+  }
+  return ''
+}
+
+function Test-DirectSimplicioCommand([string]$Command) {
+  if ([string]::IsNullOrWhiteSpace($Command)) { return $false }
+  $value = $Command.Trim()
+  if ($value.StartsWith('&')) { $value = $value.Substring(1).TrimStart() }
+  if ([string]::IsNullOrWhiteSpace($value)) { return $false }
+  foreach ($marker in @("`r", "`n", ';', '&&', '||', '|', '`', '$(', '>', '<', '&')) {
+    if ($value.Contains($marker)) { return $false }
+  }
+
+  $executable = ''
+  if ($value[0] -eq '"' -or $value[0] -eq "'") {
+    $quote = $value[0]
+    $end = $value.IndexOf($quote, 1)
+    if ($end -lt 2) { return $false }
+    $executable = $value.Substring(1, $end - 1)
+  } else {
+    $match = [regex]::Match($value, '^\S+')
+    if (-not $match.Success) { return $false }
+    $executable = $match.Value
+  }
+  $parts = @(($executable.Replace('\', '/')) -split '/')
+  $leaf = if ($parts.Count -gt 0) { $parts[-1].ToLowerInvariant() } else { '' }
+  return $leaf -eq 'simplicio' -or $leaf -eq 'simplicio.exe'
+}
+
+function Get-Sha256Text([string]$Text) {
   $sha = [Security.Cryptography.SHA256]::Create()
   try {
-    $bytes = [Text.Encoding]::UTF8.GetBytes($text)
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Text)
     return -join ($sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') })
   } finally {
     $sha.Dispose()
   }
 }
 
-function Get-RepoGeneration([string]$root) {
+function Get-RepoGeneration([string]$Root) {
   try {
-    $headOutput = @(& git -C $root rev-parse HEAD 2>$null)
+    $headOutput = @(& git -C $Root rev-parse HEAD 2>$null)
     $headExit = $LASTEXITCODE
-    $statusOutput = @(& git -C $root -c core.quotepath=false status --porcelain=v1 --untracked-files=normal 2>$null)
+    $statusOutput = @(& git -C $Root -c core.quotepath=false status --porcelain=v1 --untracked-files=normal 2>$null)
     $statusExit = $LASTEXITCODE
     if ($headExit -eq 0 -and $statusExit -eq 0) {
       $changed = @()
@@ -204,13 +280,15 @@ function Get-RepoGeneration([string]$root) {
         $row = [string]$rowValue
         if ($row.Length -lt 4) { continue }
         $pathText = $row.Substring(3).Trim()
-        if ($pathText.Contains(' -> ')) { $pathText = $pathText.Split(@(' -> '), [StringSplitOptions]::None)[-1] }
+        if ($pathText.Contains(' -> ')) {
+          $pathText = $pathText.Split(@(' -> '), [StringSplitOptions]::None)[-1]
+        }
         $pathText = $pathText.Trim('"')
         $normalized = $pathText.Replace('\', '/')
         if ($normalized -eq '.simplicio' -or $normalized.StartsWith('.simplicio/')) { continue }
         $identity = 'missing'
         try {
-          $item = Get-Item -LiteralPath (Join-Path $root $pathText) -ErrorAction Stop
+          $item = Get-Item -LiteralPath (Join-Path $Root $pathText) -ErrorAction Stop
           $size = if ($item.PSIsContainer) { 0 } else { [long]$item.Length }
           $identity = '{0}:{1}' -f $item.LastWriteTimeUtc.Ticks, $size
         } catch {}
@@ -224,26 +302,26 @@ function Get-RepoGeneration([string]$root) {
     }
   } catch {}
   try {
-    $item = Get-Item -LiteralPath $root -ErrorAction Stop
+    $item = Get-Item -LiteralPath $Root -ErrorAction Stop
     return Get-Sha256Text ('fallback:{0}:{1}' -f $item.FullName, $item.LastWriteTimeUtc.Ticks)
   } catch {
-    return Get-Sha256Text ('fallback:{0}' -f $root)
+    return Get-Sha256Text ('fallback:{0}' -f $Root)
   }
 }
 
-function Try-AcquireWarmLock([string]$lockPath) {
+function Try-AcquireLock([string]$LockPath, [int]$StaleAfterSeconds) {
   foreach ($attempt in 1..2) {
     $stream = $null
     try {
-      $stream = [IO.File]::Open($lockPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+      $stream = [IO.File]::Open($LockPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
       $payload = [Text.Encoding]::ASCII.GetBytes(('{0}:{1}' -f $PID, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()))
       $stream.Write($payload, 0, $payload.Length)
       return $true
     } catch [IO.IOException] {
       try {
-        $age = ([DateTime]::UtcNow - (Get-Item -LiteralPath $lockPath -ErrorAction Stop).LastWriteTimeUtc).TotalSeconds
-        if ($age -lt 120) { return $false }
-        Remove-Item -LiteralPath $lockPath -Force -ErrorAction Stop
+        $age = ([DateTime]::UtcNow - (Get-Item -LiteralPath $LockPath -ErrorAction Stop).LastWriteTimeUtc).TotalSeconds
+        if ($age -lt $StaleAfterSeconds) { return $false }
+        Remove-Item -LiteralPath $LockPath -Force -ErrorAction Stop
       } catch {
         return $false
       }
@@ -254,105 +332,179 @@ function Try-AcquireWarmLock([string]$lockPath) {
   return $false
 }
 
-function Start-WarmContext([string]$root) {
+function Get-ReadyReceipt([string]$State, [string]$Generation) {
   try {
-  if ([string]::IsNullOrWhiteSpace($root) -or -not (Test-Path -LiteralPath $root -PathType Container)) { return }
-  if ([string]::IsNullOrWhiteSpace($script:SimplicioBin) -or -not (Test-Path -LiteralPath $script:SimplicioBin -PathType Leaf)) { return }
-  $state = Join-Path $root '.simplicio/hook-context'
-  New-Item -ItemType Directory -Force -Path $state | Out-Null
-  $generation = Get-RepoGeneration $root
-  $receiptPath = Join-Path $state 'warm-receipt.json'
-  if (Test-Path -LiteralPath $receiptPath -PathType Leaf) {
+    $receiptPath = Join-Path $State 'warm-receipt.json'
+    $mapPath = Join-Path $State 'map.md'
+    $receipt = Get-Content -LiteralPath $receiptPath -Raw -ErrorAction Stop | ConvertFrom-Json
+    $mapItem = Get-Item -LiteralPath $mapPath -ErrorAction Stop
+    if (
+      $receipt.schema -eq $MapReceiptSchema -and
+      $receipt.status -eq 'ready' -and
+      $receipt.generation -eq $Generation -and
+      ([string]$receipt.map_sha256).Length -eq 64 -and
+      [long]$receipt.map_bytes -gt 0 -and
+      [long]$receipt.map_bytes -eq [long]$mapItem.Length
+    ) { return $receipt }
+  } catch {}
+  return $null
+}
+
+function Start-WarmContext([string]$Root) {
+  try {
+    if ([string]::IsNullOrWhiteSpace($Root) -or -not (Test-Path -LiteralPath $Root -PathType Container)) {
+      return $null
+    }
+    $generation = Get-RepoGeneration $Root
+    $result = [pscustomobject]@{ Root = $Root; Generation = $generation }
+    if ([string]::IsNullOrWhiteSpace($script:SimplicioBin) -or -not (Test-Path -LiteralPath $script:SimplicioBin -PathType Leaf)) {
+      return $result
+    }
+    $state = Join-Path $Root '.simplicio/hook-context'
+    New-Item -ItemType Directory -Force -Path $state | Out-Null
+    if ($null -ne (Get-ReadyReceipt $state $generation)) { return $result }
+
+    $receiptPath = Join-Path $state 'warm-receipt.json'
+    if (Test-Path -LiteralPath $receiptPath -PathType Leaf) {
+      try {
+        $receipt = Get-Content -LiteralPath $receiptPath -Raw -ErrorAction Stop | ConvertFrom-Json
+        $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+        if (
+          $receipt.schema -eq $MapReceiptSchema -and
+          $receipt.generation -eq $generation -and
+          $receipt.status -eq 'failed' -and
+          [long]$receipt.retry_after_unix -gt $now
+        ) { return $result }
+      } catch {}
+    }
+
+    $pidPath = Join-Path $state 'warm.pid'
+    if (Test-Path $pidPath) {
+      try {
+        if (Get-Process -Id ([int](Get-Content $pidPath -Raw)) -ErrorAction Stop) { return $result }
+      } catch {
+        Remove-Item $pidPath -Force -ErrorAction SilentlyContinue
+      }
+    }
+    $lockPath = Join-Path $state 'warm.lock'
+    if (-not (Try-AcquireLock $lockPath 300)) { return $result }
+
+    $environment = [ordered]@{
+      SIMPLICIO_BIN = $script:SimplicioBin
+      SIMPLICIO_HOOK_SELF = $PSCommandPath
+      SIMPLICIO_HOOK_WARM_REPO = $Root
+      SIMPLICIO_HOOK_WARM_OUT_DIR = $state
+      SIMPLICIO_HOOK_WARM_MARKER = $pidPath
+      SIMPLICIO_HOOK_WARM_LOCK = $lockPath
+      SIMPLICIO_HOOK_WARM_GENERATION = $generation
+    }
+    $previous = @{}
     try {
-      $receipt = Get-Content -LiteralPath $receiptPath -Raw -ErrorAction Stop | ConvertFrom-Json
-      $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-      if (
-        $receipt.schema -eq 'simplicio.hook-context-receipt/v1' -and
-        $receipt.generation -eq $generation -and
-        (
-          $receipt.status -eq 'ready' -or
-          ($receipt.status -eq 'failed' -and [long]$receipt.retry_after_unix -gt $now)
+      foreach ($entry in $environment.GetEnumerator()) {
+        $previous[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key, 'Process')
+        [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, 'Process')
+      }
+      $shellPath = (Get-Process -Id $PID -ErrorAction Stop).Path
+      $encodedWorker = [Convert]::ToBase64String(
+        [Text.Encoding]::Unicode.GetBytes('& $env:SIMPLICIO_HOOK_SELF -WarmWorker')
+      )
+      $launch = @{
+        FilePath = $shellPath
+        ArgumentList = @(
+          '-NoLogo', '-NoProfile', '-NonInteractive',
+          '-ExecutionPolicy', 'Bypass',
+          '-EncodedCommand', $encodedWorker
         )
-      ) { return }
-    } catch {}
+        PassThru = $true
+      }
+      if ($env:OS -eq 'Windows_NT') { $launch['WindowStyle'] = 'Hidden' }
+      Start-Process @launch | Out-Null
+    } catch {
+      Remove-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
+    } finally {
+      foreach ($entry in $environment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $previous[$entry.Key], 'Process')
+      }
+    }
+    return $result
+  } catch {
+    # Warming is advisory and must never block the host operation.
+    return $null
   }
+}
 
-  $pidPath = Join-Path $state 'warm.pid'
-  if (Test-Path $pidPath) {
-    try { if (Get-Process -Id ([int](Get-Content $pidPath -Raw)) -ErrorAction Stop) { return } } catch { Remove-Item $pidPath -Force -ErrorAction SilentlyContinue }
-  }
-  $lockPath = Join-Path $state 'warm.lock'
-  if (-not (Try-AcquireWarmLock $lockPath)) { return }
-
-  $environment = [ordered]@{
-    SIMPLICIO_BIN = $script:SimplicioBin
-    SIMPLICIO_HOOK_SELF = $PSCommandPath
-    SIMPLICIO_HOOK_WARM_REPO = $root
-    SIMPLICIO_HOOK_WARM_OUT_DIR = $state
-    SIMPLICIO_HOOK_WARM_MARKER = $pidPath
-    SIMPLICIO_HOOK_WARM_LOCK = $lockPath
-    SIMPLICIO_HOOK_WARM_GENERATION = $generation
-  }
-  $previous = @{}
+function Get-CompactSummaryOnce([string]$Root, [string]$Generation) {
+  $state = Join-Path $Root '.simplicio/hook-context'
+  $receipt = Get-ReadyReceipt $state $Generation
+  if ($null -eq $receipt) { return '' }
   try {
-    foreach ($entry in $environment.GetEnumerator()) {
-      $previous[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key, 'Process')
-      [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, 'Process')
+    $marker = Join-Path $state 'summary-receipt.json'
+    $lock = Join-Path $state 'summary-receipt.lock'
+    if (-not (Try-AcquireLock $lock 30)) { return '' }
+    try {
+      if (Test-Path -LiteralPath $marker -PathType Leaf) {
+        try {
+          $prior = Get-Content -LiteralPath $marker -Raw -ErrorAction Stop | ConvertFrom-Json
+          if (
+            $prior.schema -eq $InjectionReceiptSchema -and
+            $prior.generation -eq $Generation -and
+            $prior.map_sha256 -eq $receipt.map_sha256
+          ) { return '' }
+        } catch {}
+      }
+      $markerTmp = $marker + '.tmp'
+      [ordered]@{
+        schema = $InjectionReceiptSchema
+        generation = $Generation
+        map_sha256 = [string]$receipt.map_sha256
+      } | ConvertTo-Json -Compress | Set-Content -LiteralPath $markerTmp -NoNewline
+      Move-Item -LiteralPath $markerTmp -Destination $marker -Force
+    } finally {
+      Remove-Item -LiteralPath $lock -Force -ErrorAction SilentlyContinue
     }
-    $shellPath = (Get-Process -Id $PID -ErrorAction Stop).Path
-    $encodedWorker = [Convert]::ToBase64String(
-      [Text.Encoding]::Unicode.GetBytes('& $env:SIMPLICIO_HOOK_SELF -WarmWorker')
-    )
-    $launch = @{
-      FilePath = $shellPath
-      ArgumentList = @(
-        '-NoLogo', '-NoProfile', '-NonInteractive',
-        '-ExecutionPolicy', 'Bypass',
-        '-EncodedCommand', $encodedWorker
-      )
-      PassThru = $true
-    }
-    if ($env:OS -eq 'Windows_NT') { $launch['WindowStyle'] = 'Hidden' }
-    Start-Process @launch | Out-Null
   } catch {
-    Remove-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
-  } finally {
-    foreach ($entry in $environment.GetEnumerator()) {
-      [Environment]::SetEnvironmentVariable(
-        $entry.Key,
-        $previous[$entry.Key],
-        'Process'
-      )
-    }
+    return ''
   }
-  } catch {
-    # Context warming is advisory and must never block the requested host tool.
-    return
-  }
+
+  return (
+    'Simplicio Map cache: generation={0} map_sha256={1} map_bytes={2}. ' +
+    'The complete generated Map is available on demand via simplicio_context; ' +
+    'Map content is not injected into the prompt. Native shell/terminal tools ' +
+    'are disabled unless routed directly through Simplicio; third-party MCP/apps ' +
+    'and non-shell native tools remain allowed. Agent fan-out is off by default; ' +
+    'one optional subagent may be used economically through Simplicio MCP.'
+  ) -f $Generation, $receipt.map_sha256, $receipt.map_bytes
 }
 
-if ($contextEvents.ContainsKey($event)) {
+function Get-RepoFromHook {
   $repo = [string]($hook.cwd)
-  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = [string]$hook.cwd_path }
-  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = (Get-Location).Path }
-  Start-WarmContext $repo
-  $parts = @($context)
-  $state = Join-Path $repo '.simplicio/hook-context'
-  foreach ($item in @(@('map.md',24000), @('fast-context.json',8000))) {
-    $file = Join-Path $state $item[0]
-    if (Test-Path $file) {
-      $content = Get-Content -LiteralPath $file -Raw -ErrorAction SilentlyContinue
-      if ($content) { $parts += "`nSimplicio $($item[0]) (background, bounded):`n" + $content.Substring(0, [Math]::Min([int]$item[1], $content.Length)) }
-    }
+  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = [string]($hook.cwd_path) }
+  if ([string]::IsNullOrWhiteSpace($repo) -and $hook.workspace) {
+    $repo = [string]($hook.workspace.current_dir)
   }
-  Emit-Context $contextEvents[$event] ($parts -join '')
+  if ([string]::IsNullOrWhiteSpace($repo)) { $repo = (Get-Location).Path }
+  return $repo
 }
 
-# Advisory pre-hook: begin bounded Simplicio context work before the host tool,
-# then preserve the original native, third-party, or user-requested operation.
-$repo = [string]($hook.cwd)
-if ([string]::IsNullOrWhiteSpace($repo)) { $repo = [string]$hook.cwd_path }
-if ([string]::IsNullOrWhiteSpace($repo) -and $hook.workspace) { $repo = [string]$hook.workspace.current_dir }
-if ([string]::IsNullOrWhiteSpace($repo)) { $repo = (Get-Location).Path }
-Start-WarmContext $repo
+$repo = Get-RepoFromHook
+if ($contextEvents.ContainsKey($event)) {
+  $warmed = Start-WarmContext $repo
+  if ($null -ne $warmed) {
+    $summary = Get-CompactSummaryOnce $warmed.Root $warmed.Generation
+    if (-not [string]::IsNullOrWhiteSpace($summary)) {
+      Emit-Context $contextEvents[$event] $summary
+    }
+  }
+  Allow-Unchanged
+}
+
+# Deny native terminal execution unless the command enters through the governed
+# Simplicio CLI. Third-party MCP/apps and non-shell native tools pass unchanged.
+if (
+  @('', 'pretooluse', 'pre_tool_use') -contains $event -and
+  (Test-NativeShellTool (Get-HookToolName)) -and
+  -not (Test-DirectSimplicioCommand (Get-HookCommand))
+) { Emit-DenyNativeShell }
+
+Start-WarmContext $repo | Out-Null
 Allow-Unchanged

--- a/codex/mcp-route.sh
+++ b/codex/mcp-route.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Simplicio MCP route — advisory PreToolUse context for every supported host.
-# simplicio-hook-version: 3240-v6
+# Simplicio MCP route — advisory Map cache for every supported host.
+# simplicio-hook-version: 3240-v8
 #
-# Simplicio starts first to warm bounded context, then the original native,
-# user-requested, or third-party tool is always allowed unchanged.
+# Native shell/terminal is denied unless it directly invokes Simplicio.
+# Third-party MCP/apps and non-shell native tools remain allowed unchanged.
+# The hook builds one complete Map artifact per repository generation and emits
+# only a compact content-addressed receipt once per repository generation.
 set -uo pipefail
 
 SIMPLICIO_BIN="${SIMPLICIO_BIN:-${SIMPLICIO_BIN_DIR:-${HOME}/.simplicio/bin}/simplicio}"
@@ -11,7 +13,7 @@ export SIMPLICIO_BIN
 
 INPUT="$(cat 2>/dev/null || true)"
 # Codex 0.150.0 rejects an explicit PreToolUse allow without updatedInput.
-# Empty stdout is the portable allow-unchanged contract; deny remains JSON.
+# Empty stdout is the portable allow-unchanged contract.
 [ -n "$INPUT" ] || exit 0
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -30,13 +32,16 @@ import sys
 import time
 
 raw = os.environ.get("SIMPLICIO_MCP_ROUTE_INPUT", "")
-RUNTIME_BIN = os.environ.get("SIMPLICIO_BIN") or str(pathlib.Path.home() / ".simplicio" / "bin" / "simplicio")
-
+RUNTIME_BIN = os.environ.get("SIMPLICIO_BIN") or str(
+    pathlib.Path.home() / ".simplicio" / "bin" / "simplicio"
+)
+MAP_RECEIPT_SCHEMA = "simplicio.hook-map-receipt/v1"
+INJECTION_RECEIPT_SCHEMA = "simplicio.hook-context-injection/v1"
 
 try:
     hook = json.loads(raw)
 except Exception:
-    # Hooks are advisory: malformed third-party payloads must never block.
+    # Advisory hooks fail open for malformed third-party payloads.
     raise SystemExit(0)
 
 event = (
@@ -45,12 +50,6 @@ event = (
     or hook.get("event")
     or ""
 ).replace("-", "_").lower()
-CONTEXT = (
-    "Simplicio pre-hook ran before the requested tool. "
-    "Use simplicio_map -> simplicio_context -> simplicio_edit when that improves "
-    "the task, but preserve the user's explicit request and allow native and "
-    "third-party tools unchanged."
-)
 
 
 def repo_from_hook() -> str:
@@ -65,8 +64,96 @@ def repo_from_hook() -> str:
     )
 
 
+def hook_tool_name() -> str:
+    return str(
+        hook.get("toolName")
+        or hook.get("tool_name")
+        or hook.get("name")
+        or ""
+    )
+
+
+def hook_tool_input() -> dict:
+    value = hook.get("toolInput") or hook.get("tool_input") or hook.get("input") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def is_native_shell_tool(name: str) -> bool:
+    normalized = name.strip().lower().replace("-", "_")
+    if not normalized or normalized.startswith(("mcp__", "app__", "plugin__")):
+        return False
+    leaf = re.split(r"(?:::|__|\.)", normalized)[-1]
+    shell_names = {
+        "bash",
+        "cmd",
+        "exec_command",
+        "execute_command",
+        "powershell",
+        "pwsh",
+        "run_command",
+        "run_shell_command",
+        "run_terminal_command",
+        "shell",
+        "shell_command",
+        "terminal",
+        "terminal_command",
+        "write_stdin",
+    }
+    return normalized in shell_names or leaf in shell_names
+
+
+def requested_command() -> str:
+    values = hook_tool_input()
+    for key in ("command", "cmd", "script"):
+        value = values.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def is_direct_simplicio_command(command: str) -> bool:
+    value = command.strip()
+    if not value:
+        return False
+    if value.startswith("&"):
+        value = value[1:].lstrip()
+    if not value or any(marker in value for marker in (
+        "\r", "\n", ";", "&&", "||", "|", "`", "$(", ">", "<", "&"
+    )):
+        return False
+    if value[0] in ("'", '"'):
+        quote = value[0]
+        end = value.find(quote, 1)
+        if end < 2:
+            return False
+        executable = value[1:end]
+    else:
+        executable = value.split(None, 1)[0]
+    leaf = re.split(r"[\\/]", executable)[-1].lower()
+    return leaf in {"simplicio", "simplicio.exe"}
+
+
+def deny_native_shell() -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "Native shell/terminal is disabled; use a Simplicio MCP "
+                        "tool or invoke the command directly through simplicio."
+                    ),
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+    raise SystemExit(0)
+
+
 def repository_generation(root: pathlib.Path) -> str:
-    """Return a cheap generation that changes with HEAD or visible worktree deltas."""
+    """Cheap content generation: HEAD plus visible non-Simplicio deltas."""
     try:
         head = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "HEAD"],
@@ -125,8 +212,7 @@ def repository_generation(root: pathlib.Path) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
-def acquire_warm_lock(lock_path: pathlib.Path) -> bool:
-    """Claim one warm worker before spawn; recover only demonstrably stale locks."""
+def acquire_lock(lock_path: pathlib.Path, stale_after: int) -> bool:
     for _ in range(2):
         try:
             descriptor = os.open(
@@ -136,7 +222,7 @@ def acquire_warm_lock(lock_path: pathlib.Path) -> bool:
             )
         except FileExistsError:
             try:
-                if time.time() - lock_path.stat().st_mtime < 120:
+                if time.time() - lock_path.stat().st_mtime < stale_after:
                     return False
                 lock_path.unlink()
             except OSError:
@@ -150,31 +236,52 @@ def acquire_warm_lock(lock_path: pathlib.Path) -> bool:
     return False
 
 
-def warm_context(repo: str) -> None:
-    """Warm Mapper/Fast at most once for each observable repository generation."""
+def read_ready_receipt(state: pathlib.Path, generation: str) -> dict | None:
+    try:
+        receipt = json.loads((state / "warm-receipt.json").read_text(encoding="utf-8"))
+        map_path = state / "map.md"
+        if (
+            receipt.get("schema") == MAP_RECEIPT_SCHEMA
+            and receipt.get("status") == "ready"
+            and receipt.get("generation") == generation
+            and isinstance(receipt.get("map_sha256"), str)
+            and len(receipt["map_sha256"]) == 64
+            and isinstance(receipt.get("map_bytes"), int)
+            and receipt["map_bytes"] > 0
+            and map_path.is_file()
+            and map_path.stat().st_size == receipt["map_bytes"]
+        ):
+            return receipt
+    except (OSError, ValueError, TypeError):
+        pass
+    return None
+
+
+def warm_context(repo: str) -> tuple[pathlib.Path, str] | None:
+    """Build one full Map artifact per generation; never run Fast here."""
     root = pathlib.Path(repo).expanduser()
     runtime = pathlib.Path(RUNTIME_BIN)
-    if not root.is_dir() or not runtime.is_file() or not os.access(runtime, os.X_OK):
-        return
+    if not root.is_dir():
+        return None
+    generation = repository_generation(root)
+    if not runtime.is_file() or not os.access(runtime, os.X_OK):
+        return root, generation
     state = root / ".simplicio" / "hook-context"
     try:
         state.mkdir(parents=True, exist_ok=True)
-        generation = repository_generation(root)
-        receipt_path = state / "warm-receipt.json"
+        if read_ready_receipt(state, generation) is not None:
+            return root, generation
         try:
-            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt = json.loads(
+                (state / "warm-receipt.json").read_text(encoding="utf-8")
+            )
             if (
-                receipt.get("schema") == "simplicio.hook-context-receipt/v1"
+                receipt.get("schema") == MAP_RECEIPT_SCHEMA
                 and receipt.get("generation") == generation
-                and (
-                    receipt.get("status") == "ready"
-                    or (
-                        receipt.get("status") == "failed"
-                        and int(receipt.get("retry_after_unix", 0)) > int(time.time())
-                    )
-                )
+                and receipt.get("status") == "failed"
+                and int(receipt.get("retry_after_unix", 0)) > int(time.time())
             ):
-                return
+                return root, generation
         except (OSError, ValueError, TypeError):
             pass
 
@@ -183,39 +290,35 @@ def warm_context(repo: str) -> None:
             try:
                 pid = int(pid_path.read_text().strip())
                 os.kill(pid, 0)
-                return
+                return root, generation
             except (ValueError, OSError):
                 pass
         lock_path = state / "warm.lock"
-        if not acquire_warm_lock(lock_path):
-            return
+        if not acquire_lock(lock_path, stale_after=300):
+            return root, generation
         worker = (
-            "import json,os,pathlib,subprocess,sys,time\n"
+            "import hashlib,json,os,pathlib,subprocess,sys,time\n"
             "root=pathlib.Path(sys.argv[1]); generation=sys.argv[2]; state=root/'.simplicio'/'hook-context'; state.mkdir(parents=True,exist_ok=True)\n"
             "pid=state/'warm.pid'; lock=state/'warm.lock'; pid.write_text(str(os.getpid()))\n"
-            "def run(args,out):\n"
-            "  tmp=out.with_suffix(out.suffix+'.tmp')\n"
+            "out=state/'map.md'; tmp=state/'map.md.tmp'; success=False; digest=None; size=None\n"
+            "try:\n"
+            "  binary=os.environ['SIMPLICIO_BIN']\n"
             "  try:\n"
-            "    with open(tmp,'w',encoding='utf-8') as f: result=subprocess.run(args,stdout=f,stderr=subprocess.DEVNULL,timeout=45,check=False)\n"
-            "    tmp.replace(out)\n"
-            "    return result\n"
+            "    with open(tmp,'wb') as stream: result=subprocess.run([binary,'map','--repo',str(root),'--for-llm','markdown'],stdout=stream,stderr=subprocess.DEVNULL,timeout=120,check=False)\n"
+            "    success=result.returncode == 0 and tmp.stat().st_size > 0\n"
+            "    if success:\n"
+            "      data=tmp.read_bytes(); digest=hashlib.sha256(data).hexdigest(); size=len(data); tmp.replace(out)\n"
+            "    else:\n"
+            "      try: tmp.unlink()\n"
+            "      except OSError: pass\n"
             "  except Exception:\n"
             "    try: tmp.unlink()\n"
             "    except OSError: pass\n"
-            "    return None\n"
-            "try:\n"
-            "  binary=os.environ['SIMPLICIO_BIN']\n"
-            "  results=[\n"
-            "    run([binary,'map','--repo',str(root),'--for-llm','markdown'],state/'map.md'),\n"
-            "    run([binary,'fast','build','--root',str(root),'--max-bytes','32000','--json'],state/'fast-build.json'),\n"
-            "    run([binary,'fast','context','simplicio','--root',str(root),'--max-bytes','32000','--json'],state/'fast-context.json'),\n"
-            "  ]\n"
-            "  success=all(result is not None and result.returncode == 0 for result in results)\n"
-            "  now=int(time.time()); receipt=state/'warm-receipt.json'; tmp=state/'warm-receipt.json.tmp'\n"
-            "  payload={'schema':'simplicio.hook-context-receipt/v1','status':'ready' if success else 'failed','generation':generation,'completed_at_unix':now}\n"
-            "  if not success: payload['retry_after_unix']=now+60\n"
-            "  tmp.write_text(json.dumps(payload,sort_keys=True),encoding='utf-8')\n"
-            "  tmp.replace(receipt)\n"
+            "  now=int(time.time()); receipt=state/'warm-receipt.json'; receipt_tmp=state/'warm-receipt.json.tmp'\n"
+            "  payload={'schema':'simplicio.hook-map-receipt/v1','status':'ready' if success else 'failed','generation':generation,'completed_at_unix':now}\n"
+            "  if success: payload.update({'map_sha256':digest,'map_bytes':size})\n"
+            "  else: payload['retry_after_unix']=now+900\n"
+            "  receipt_tmp.write_text(json.dumps(payload,sort_keys=True,separators=(',',':')),encoding='utf-8'); receipt_tmp.replace(receipt)\n"
             "finally:\n"
             "  try: pid.unlink()\n"
             "  except OSError: pass\n"
@@ -236,29 +339,65 @@ def warm_context(repo: str) -> None:
                 lock_path.unlink()
             except OSError:
                 pass
-            raise
     except (OSError, ValueError):
-        return
-
-
-def context_packet(repo: str) -> str:
-    root = pathlib.Path(repo).expanduser()
-    state = root / ".simplicio" / "hook-context"
-    parts = []
-    map_path = state / "map.md"
-    fast_path = state / "fast-context.json"
-    try:
-        if map_path.is_file():
-            text = map_path.read_text(encoding="utf-8", errors="replace")
-            if text.strip():
-                parts.append("\nSimplicio map (background, bounded):\n" + text[:24000])
-        if fast_path.is_file():
-            text = fast_path.read_text(encoding="utf-8", errors="replace")
-            if text.strip():
-                parts.append("\nSimplicio context packet (background):\n" + text[:8000])
-    except OSError:
         pass
-    return "".join(parts)
+    return root, generation
+
+
+def compact_summary_once(root: pathlib.Path, generation: str) -> str:
+    state = root / ".simplicio" / "hook-context"
+    receipt = read_ready_receipt(state, generation)
+    if receipt is None:
+        return ""
+    try:
+        marker = state / "summary-receipt.json"
+        lock = state / "summary-receipt.lock"
+        if not acquire_lock(lock, stale_after=30):
+            return ""
+        try:
+            try:
+                prior = json.loads(marker.read_text(encoding="utf-8"))
+                if (
+                    prior.get("schema") == INJECTION_RECEIPT_SCHEMA
+                    and prior.get("generation") == generation
+                    and prior.get("map_sha256") == receipt["map_sha256"]
+                ):
+                    return ""
+            except (OSError, ValueError, TypeError):
+                pass
+            marker_tmp = marker.with_suffix(".json.tmp")
+            marker_tmp.write_text(
+                json.dumps(
+                    {
+                        "schema": INJECTION_RECEIPT_SCHEMA,
+                        "generation": generation,
+                        "map_sha256": receipt["map_sha256"],
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                encoding="utf-8",
+            )
+            marker_tmp.replace(marker)
+        finally:
+            try:
+                lock.unlink()
+            except OSError:
+                pass
+    except OSError:
+        return ""
+
+    return (
+        "Simplicio Map cache: "
+        f"generation={generation} map_sha256={receipt['map_sha256']} "
+        f"map_bytes={receipt['map_bytes']}. "
+        "The complete generated Map is available on demand via simplicio_context; "
+        "Map content is not injected into the prompt. Native shell/terminal tools "
+        "are disabled unless routed directly through Simplicio; third-party MCP/apps "
+        "and non-shell native tools remain allowed. Agent fan-out is off by default; "
+        "one optional subagent may be used economically through Simplicio MCP."
+    )
+
 
 context_events = {
     "sessionstart": "SessionStart",
@@ -269,24 +408,31 @@ context_events = {
     "subagent_start": "SubagentStart",
 }
 if event in context_events:
-    repo = repo_from_hook()
-    warm_context(repo)
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": context_events[event],
-            "additionalContext": CONTEXT + context_packet(repo),
-        }
-    }))
+    warmed = warm_context(repo_from_hook())
+    if warmed is not None:
+        root, generation = warmed
+        summary = compact_summary_once(root, generation)
+        if summary:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": context_events[event],
+                            "additionalContext": summary,
+                        }
+                    },
+                    separators=(",", ":"),
+                )
+            )
     raise SystemExit(0)
 
 
-def allow() -> None:
-    # No decision means allow unchanged on Codex and other supported hosts.
-    raise SystemExit(0)
+# PreToolUse blocks native terminal execution unless the command enters through
+# the governed Simplicio CLI. Third-party MCP/apps and non-shell native tools pass.
+if event in {"", "pretooluse", "pre_tool_use"} and is_native_shell_tool(hook_tool_name()):
+    if not is_direct_simplicio_command(requested_command()):
+        deny_native_shell()
 
-
-# Advisory pre-hook: begin bounded Simplicio context work before the host tool,
-# then preserve the original native, third-party, or user-requested operation.
 warm_context(repo_from_hook())
-allow()
+raise SystemExit(0)
 PY

--- a/tests/test_codex_hooks.sh
+++ b/tests/test_codex_hooks.sh
@@ -61,9 +61,9 @@ run_case() {
   fi
 }
 
-run_case "SessionStart context" \
+run_case "SessionStart without repository is empty" \
   '{"hook_event_name":"SessionStart","source":"startup","cwd":"/tmp"}' \
-  0 'SessionStart'
+  0 '__EMPTY__'
 run_case "allow Simplicio tool unchanged" \
   '{"hook_event_name":"PreToolUse","tool_name":"simplicio__simplicio_read","tool_input":{"path":"x"},"cwd":"/tmp"}' \
   0 '__EMPTY__'
@@ -73,16 +73,24 @@ run_case "allow native read unchanged" \
 run_case "allow native edit unchanged" \
   '{"hook_event_name":"PreToolUse","tool_name":"search_replace","tool_input":{"file_path":"src/main.rs"},"cwd":"/tmp"}' \
   0 '__EMPTY__'
-run_case "allow explicit shell unchanged" \
+run_case "deny native shell" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp"}' \
+  0 'Native shell/terminal is disabled'
+run_case "allow direct Simplicio shell unchanged" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"simplicio status --json"},"cwd":"/tmp"}' \
   0 '__EMPTY__'
+run_case "deny shell wrapper around Simplicio" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"bash -lc '\''simplicio status --json'\''"},"cwd":"/tmp"}' \
+  0 'Native shell/terminal is disabled'
 run_case "allow third-party tool unchanged" \
   '{"hook_event_name":"PreToolUse","tool_name":"mcp__cloudflare__zones_list","tool_input":{},"cwd":"/tmp"}' \
   0 '__EMPTY__'
 run_case "fail open on malformed input" 'not-json' 0 '__EMPTY__'
 
-if ! grep -q 'simplicio_map' "$HOOK" || ! grep -q 'simplicio_context' "$HOOK"; then
-  printf 'FAIL hook context is missing map/context routing\n' >&2
+if ! grep -q 'Simplicio Map cache:' "$HOOK" ||
+   ! grep -q 'map_sha256' "$HOOK" ||
+   ! grep -q 'simplicio_context' "$HOOK"; then
+  printf 'FAIL hook context is missing compact Map receipt/context routing\n' >&2
   FAIL=$((FAIL + 1))
 fi
 if ! grep -q 'Allow-Unchanged' "$WINDOWS_HOOK"; then


### PR DESCRIPTION
## Resumo
- publica as hooks canônicas do Runtime v3.8.35
- bloqueia shell/terminal nativo e permite somente comando que invoque `simplicio` diretamente
- preserva MCP/apps de terceiros e ferramentas nativas que não sejam shell
- atualiza o contrato público para o resumo compacto do Map e conteúdo completo sob demanda

## Validação
- `bash tests/test_codex_hooks.sh` — 10 passed, 0 failed
- hashes das hooks iguais ao bundle v3.8.35
- `git diff --check`