### PR TITLE
docs: document Codex plugin installation in all READMEs [skip actions]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ optional, not required.**
 
 ## 🚀 Installation
 
+### Install via the Codex plugin
+
+If you use Codex, you can install Simplicio as a plugin. Add the public marketplace, install the plugin, and start a new Codex session; the plugin installs and bootstraps the Simplicio Runtime and exposes its skills and MCP tools.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 The official installers download one canonical asset from the latest
 Runtime release, verify its SHA256 checksum and Ed25519 signature, validate the
 Runtime release contract, and register MCP hosts to launch the installed binary

--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -54,6 +54,15 @@
 
 ## 🚀 التثبيت
 
+### التثبيت عبر إضافة Codex
+
+إذا كنت تستخدم Codex، يمكنك تثبيت Simplicio كإضافة. أضف Marketplace العام، وثبّت الإضافة، ثم ابدأ جلسة Codex جديدة؛ ستثبّت الإضافة Simplicio Runtime وتُشغّله وتوفّر مهاراته وأدوات MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (أي نظام تشغيل)
 
 ```bash

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -54,6 +54,15 @@ opcionales, no obligatorios.**
 
 ## 🚀 Instalación
 
+### Instalar mediante el plugin de Codex
+
+Si usas Codex, puedes instalar Simplicio como un plugin. Añade el Marketplace público, instala el plugin e inicia una nueva sesión de Codex; el plugin instala e inicia el Runtime de Simplicio y expone sus skills y herramientas MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (cualquier SO)
 
 ```bash

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -54,6 +54,15 @@ sont facultatifs, pas obligatoires.**
 
 ## 🚀 Installation
 
+### Installer via le plugin Codex
+
+Si vous utilisez Codex, vous pouvez installer Simplicio comme un plugin. Ajoutez le Marketplace public, installez le plugin et démarrez une nouvelle session Codex ; le plugin installe et démarre le Runtime Simplicio et expose ses skills et outils MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (tout OS)
 
 ```bash

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -54,6 +54,15 @@
 
 ## 🚀 התקנה
 
+### התקנה דרך התוסף של Codex
+
+אם אתם משתמשים ב-Codex, תוכלו להתקין את Simplicio כתוסף. הוסיפו את ה-Marketplace הציבורי, התקינו את התוסף והתחילו סשן Codex חדש; התוסף יתקין ויאותחל את Simplicio Runtime ויעמיד לרשותכם את ה-skills וכלי ה-MCP שלו.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (כל מערכת הפעלה)
 
 ```bash

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -54,6 +54,15 @@ AI-सहायित विकास कार्यप्रवाह को �
 
 ## 🚀 इंस्टॉलेशन
 
+### Codex प्लगइन से इंस्टॉल करें
+
+यदि आप Codex का उपयोग करते हैं, तो Simplicio को प्लगइन के रूप में इंस्टॉल कर सकते हैं। सार्वजनिक Marketplace जोड़ें, प्लगइन इंस्टॉल करें और नया Codex सत्र शुरू करें; प्लगइन Simplicio Runtime को इंस्टॉल और बूटस्ट्रैप करता है तथा उसकी skills और MCP टूल उपलब्ध कराता है।
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (किसी भी OS पर)
 
 ```bash

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -54,6 +54,15 @@ bersifat opsional, tidak wajib.**
 
 ## 🚀 Instalasi
 
+### Instal melalui plugin Codex
+
+Jika Anda menggunakan Codex, Anda dapat menginstal Simplicio sebagai plugin. Tambahkan Marketplace publik, instal plugin, lalu mulai sesi Codex baru; plugin akan menginstal dan melakukan bootstrap Simplicio Runtime serta menyediakan skills dan alat MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (OS apa saja)
 
 ```bash

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -54,6 +54,15 @@ opzionali, non obbligatori.**
 
 ## 🚀 Installazione
 
+### Installa tramite il plugin Codex
+
+Se usi Codex, puoi installare Simplicio come plugin. Aggiungi il Marketplace pubblico, installa il plugin e avvia una nuova sessione Codex; il plugin installa e avvia il Runtime Simplicio e rende disponibili le sue skills e gli strumenti MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (qualsiasi OS)
 
 ```bash

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -50,6 +50,15 @@
 
 ## 🚀 インストール
 
+### Codex プラグインからインストール
+
+Codex を使う場合は、Simplicio をプラグインとしてインストールできます。公開 Marketplace を追加してプラグインをインストールし、新しい Codex セッションを開始してください。プラグインが Simplicio Runtime をインストールして起動し、skills と MCP ツールを利用できるようにします。
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx（全OS対応）
 
 ```bash

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -53,6 +53,15 @@
 
 ## 🚀 설치
 
+### Codex 플러그인으로 설치
+
+Codex를 사용한다면 Simplicio를 플러그인으로 설치할 수 있습니다. 공개 Marketplace를 추가하고 플러그인을 설치한 뒤 새 Codex 세션을 시작하세요. 플러그인이 Simplicio Runtime을 설치하고 부트스트랩하며 skills와 MCP 도구를 제공합니다.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (모든 OS)
 
 ```bash

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -54,6 +54,15 @@ jarak jauh adalah pilihan, bukan keperluan.**
 
 ## 🚀 Pemasangan
 
+### Pasang melalui pemalam Codex
+
+Jika anda menggunakan Codex, anda boleh memasang Simplicio sebagai pemalam. Tambahkan Marketplace awam, pasang pemalam dan mulakan sesi Codex baharu; pemalam memasang serta memulakan Simplicio Runtime dan menyediakan skills serta alat MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (sebarang OS)
 
 ```bash

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -54,6 +54,15 @@ opcjonalne, nie wymagane.**
 
 ## 🚀 Instalacja
 
+### Instalacja przez wtyczkę Codex
+
+Jeśli używasz Codex, możesz zainstalować Simplicio jako wtyczkę. Dodaj publiczny Marketplace, zainstaluj wtyczkę i uruchom nową sesję Codex; wtyczka zainstaluje i uruchomi Simplicio Runtime oraz udostępni jego skills i narzędzia MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (dowolny system)
 
 ```bash

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -54,6 +54,15 @@ opcionais, não obrigatórios.**
 
 ## 🚀 Instalação
 
+### Instalar pelo plugin do Codex
+
+Se você usa o Codex, pode instalar o Simplicio como um plugin. Adicione o Marketplace público, instale o plugin e inicie uma nova sessão do Codex; o plugin instala e inicializa o Runtime do Simplicio e disponibiliza suas skills e ferramentas MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 Use o pacote oficial do PyPI. Ele instala o launcher Python, valida a release
 assinada do Runtime e instala o binário correto para macOS, Linux ou Windows.
 

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -54,6 +54,15 @@
 
 ## 🚀 Установка
 
+### Установка через плагин Codex
+
+Если вы используете Codex, Simplicio можно установить как плагин. Добавьте публичный Marketplace, установите плагин и запустите новый сеанс Codex; плагин установит и запустит Simplicio Runtime и предоставит его skills и инструменты MCP.
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx (любая ОС)
 
 ```bash

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -54,6 +54,15 @@
 
 ## 🚀 安装
 
+### 通过 Codex 插件安装
+
+如果你使用 Codex，可以将 Simplicio 作为插件安装。添加公共 Marketplace、安装插件，然后启动新的 Codex 会话；插件会安装并引导启动 Simplicio Runtime，并提供其 skills 和 MCP 工具。
+
+```bash
+codex plugin marketplace add wesleysimplicio/simplicio --ref master
+codex plugin add simplicio@simplicio-codex
+```
+
 ### npm / npx（支持所有操作系统）
 
 ```bash


### PR DESCRIPTION
Adds localized Codex plugin installation instructions to README.md and all 14 translated READMEs. Each language documents adding wesleysimplicio/simplicio at master, installing simplicio@simplicio-codex, and starting a new Codex session. Validation: 15 files, 135 insertions, git diff --cached --check passed.