### PR TITLE
fix(installer): register detected clients automatically

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -255,24 +255,15 @@ simplicio auth login
 simplicio auth status --json
 ```
 
-The installer registers MCP hosts to launch the managed binary directly. To
-refresh versioned MCP registration and managed hooks explicitly:
+The installer automatically asks the installed Runtime to detect and register
+every supported MCP host. Registration uses the installed binary with
+`serve --mcp --stdio`, writes native hooks only for verified host hook APIs,
+preserves existing configuration, and does not depend on Google login.
 
-~~~bash
-SIMPLICIO_INSTALL_CODEX=1 SIMPLICIO_CODEX_HOOK_REF=v3.8.30 sh install.sh
-~~~
-
-The registration points to the installed binary with `serve --mcp --stdio` and
-sets `SIMPLICIO_MCP_URL=http://127.0.0.1:8787/mcp` for HTTP/manual clients. The
-Runtime still requires Google login and active entitlement for every local MCP
-session; never copy tokens into config files. The managed Codex hooks cover all tool events,
-are versioned with the release, preserve existing user hooks, and are updated
-idempotently. The route is mandatory and has no environment-variable escape:
-native reads, edits, shell commands, and directory exploration are denied; use
-the Simplicio MCP tools. Review enabled hooks in Settings → Hooks and verify
-the MCP command with `codex mcp list`. To repair, rerun with
-`SIMPLICIO_INSTALL_CODEX=1`; the integration helper keeps user data separate
-and `.simplicio.bak` copies are created for managed Codex files.
+Protected MCP operations still require an active Google session and entitlement.
+Restart open clients after installation. To inspect or repair the registration,
+run `simplicio mcp register --binary "$(command -v simplicio)" --json`. A
+registration failure terminates the installer instead of reporting success.
 
 ## Building from Source
 

--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -15,22 +15,21 @@ Continue only when the status reports `active: true`. Never copy a password, dev
 
 ## Codex: local STDIO MCP and hooks
 
-Codex integration is opt-in. The base installer leaves Codex unchanged. Enable
-the versioned, reversible integration explicitly:
+The installer automatically invokes the installed Runtime's host registrar.
+There is no Codex opt-in flag and no separately downloaded hook. The Runtime
+detects supported clients, records the absolute managed-binary path, preserves
+existing user configuration, and installs native hooks only where a verified
+native hook API is available.
 
-~~~bash
-SIMPLICIO_INSTALL_CODEX=1 SIMPLICIO_CODEX_HOOK_REF=v3.8.35 sh install.sh
-~~~
+Registration runs before login reporting, so a fresh installation is configured
+even when the user has not authenticated yet. Protected MCP operations still
+validate Google login and entitlement when they are used. Restart every open
+client after installation so it reloads the MCP and hook files.
 
-When enabled, the installer writes the absolute managed-binary path
-automatically. If you inspect or repair `config.toml` manually, copy the block
-for your operating system. MCP clients launch `command` directly, so do not
-use `~` and do not expect shell expansion.
+MCP clients launch `command` directly, so do not use `~` and do not expect
+shell expansion.
 
 #### Windows
-
-Use forward slashes in TOML. Windows accepts them, and they avoid invalid TOML
-escapes such as `\U` in `C:\Users\...`.
 
 ~~~toml
 [mcp_servers.simplicio]
@@ -41,10 +40,7 @@ args = ["serve", "--mcp", "--stdio"]
 SIMPLICIO_MCP_URL = "http://127.0.0.1:8787/mcp"
 ~~~
 
-If you are testing a downloaded asset before installation, the same rule is
-`C:/Users/YourName/Downloads/simplicio-windows-x64.exe`. Never paste
-a raw-backslash Windows path into a double-quoted TOML command; use forward
-slashes as shown above.
+Use forward slashes in Windows TOML paths.
 
 #### macOS
 
@@ -68,25 +64,19 @@ args = ["serve", "--mcp", "--stdio"]
 SIMPLICIO_MCP_URL = "http://127.0.0.1:8787/mcp"
 ~~~
 
-STDIO is the primary local transport and launches the managed binary directly.
-`SIMPLICIO_MCP_URL` keeps the loopback HTTP endpoint discoverable for HTTP-only
-or manual clients, but Codex should not use the URL as its primary registration.
-The Runtime still validates Google login and entitlement on every MCP session.
-Existing user hooks remain preserved; review enabled Simplicio hooks in Settings
-→ Hooks and run codex mcp list. Never paste tokens into either config file.
+STDIO is the primary local transport. The Runtime's JSON registration report
+lists every client it detected and whether the MCP configuration or native hook
+was written. A failed write makes installation fail rather than silently
+continuing.
 
-To verify the registration:
+To inspect or repair the detected integrations:
 
-```bash
-codex mcp list
-```
+~~~bash
+simplicio mcp register --binary "$(command -v simplicio)" --json
+~~~
 
-The hook route is mandatory and has no environment-variable escape hatch.
-Native reads, edits, shell commands, and directory exploration are denied; use
-the Simplicio MCP tools. Rerunning the installer repairs the integration
-idempotently. To repair the managed integration, rerun with
-`SIMPLICIO_INSTALL_CODEX=1`. The integration helper keeps user data separate
-and leaves `.simplicio.bak` copies of the original Codex files.
+Restart Codex and other open clients after registration. Never paste tokens into
+client configuration files.
 
 ## Other clients: local STDIO
 

--- a/README.md
+++ b/README.md
@@ -247,22 +247,24 @@ the table above is a quick orientation, not a substitute for live schemas.
 
 ### Codex: local STDIO MCP and hooks
 
-Codex integration is opt-in. A normal installation does not modify Codex
-configuration or hooks. To enable the versioned, reversible integration:
+A normal installation now invokes the installed Runtime's host registrar
+automatically. No opt-in environment variable or separately downloaded hook is
+required. The Runtime detects supported clients, writes the absolute managed
+binary path, preserves existing user configuration, and installs native hooks
+only on clients whose hook surface is implemented and verified.
 
-~~~bash
-SIMPLICIO_INSTALL_CODEX=1 SIMPLICIO_CODEX_HOOK_REF=v3.8.35 sh install.sh
-~~~
+Registration does not require an active Google session. Authentication is still
+validated when an MCP session uses protected Runtime capabilities. Restart each
+open client after installation so it reloads its MCP server and hook files.
 
-When enabled, the installer writes the absolute managed-binary path
-automatically. If you inspect or repair `config.toml` manually, copy the block
-for your operating system. MCP clients launch `command` directly, so do not
-use `~` and do not expect shell expansion.
+MCP clients launch `command` directly, so do not use `~` and do not expect
+shell expansion. The generated registration uses the following local STDIO MCP
+shape for the current operating system.
 
 #### Windows
 
 Use forward slashes in TOML. Windows accepts them, and they avoid invalid TOML
-escapes such as `\U` in `C:\Users\...`.
+escapes such as `\\U` in `C:\\Users\\...`.
 
 ~~~toml
 [mcp_servers.simplicio]
@@ -272,11 +274,6 @@ args = ["serve", "--mcp", "--stdio"]
 [mcp_servers.simplicio.env]
 SIMPLICIO_MCP_URL = "http://127.0.0.1:8787/mcp"
 ~~~
-
-If you are testing a downloaded asset before installation, the same rule is
-`C:/Users/YourName/Downloads/simplicio-windows-x64.exe`. Never paste
-a raw-backslash Windows path into a double-quoted TOML command; use forward
-slashes as shown above.
 
 #### macOS
 
@@ -300,30 +297,21 @@ args = ["serve", "--mcp", "--stdio"]
 SIMPLICIO_MCP_URL = "http://127.0.0.1:8787/mcp"
 ~~~
 
-This keeps MCP execution local while still exposing the loopback HTTP endpoint as
-`SIMPLICIO_MCP_URL` for HTTP-only/manual clients. The Runtime still enforces
-Google login and entitlement for every MCP session.
-The installer also merges Simplicio `SessionStart`, `UserPromptSubmit`,
-`SubagentStart`, and `PreToolUse` hooks into `~/.codex/hooks.json`; existing
-Codex hooks are preserved and the Simplicio entries are updated idempotently.
-The `PreToolUse` route is mandatory: native host reads, edits, shell commands,
-and directory exploration are denied; use Simplicio MCP. Lifecycle events also
-start a bounded `map -> fast` context warm-up in the background.
-The managed hooks are versioned with the release, and repeated setup is
-idempotent. Review the result in Settings → Hooks and verify the MCP command
-with:
+The Runtime currently registers supported configurations for Codex, Claude
+Code/Desktop, Hermes, Cursor, Windsurf/Next, Kiro, Gemini, Trae, Antigravity,
+Junie, Cline, VS Code, Zed, and OpenCode. Existing files are merged
+idempotently. Codex and Claude receive their verified Runtime-owned native hook
+routes; other clients receive the supported MCP/rules integration.
+
+To inspect or repair every detected integration manually, run:
 
 ~~~bash
-codex mcp list
+simplicio mcp register --binary "$(command -v simplicio)" --json
 ~~~
 
-To repair the integration, rerun the installer with
-`SIMPLICIO_INSTALL_CODEX=1`. The managed integration has a separate
-status/install/uninstall/repair helper in `scripts/codex_integration.py`; user
-data remains separate from the integration. Original `config.toml` and
-`hooks.json` files are kept in `.simplicio.bak` copies on the first managed
-write. There is no environment-variable escape hatch; rerun the installer to
-repair a missing or stale route.
+A failed automatic registration makes the installer fail clearly instead of
+claiming success. Clients not reported by the JSON result are not silently
+treated as configured.
 
 ### Other MCP clients: local STDIO
 

--- a/docs/asolaria-integration.md
+++ b/docs/asolaria-integration.md
@@ -7,8 +7,9 @@
 > histórico e roadmap Host-8/Asolaria. Para instalar o produto atual, prevalecem
 > INSTALL.md, MCP-CONNECT.md, distribution/targets.json e
 > simplicio-update-manifest.json. A release pública é um binário único por
-> target; o instalador verifica SHA256 + Ed25519, exige login Google para MCP,
-> e só configura Codex quando SIMPLICIO_INSTALL_CODEX=1.
+> target; o instalador verifica SHA256 + Ed25519 e registra automaticamente os
+> clientes MCP detectados. O login Google continua obrigatório ao usar recursos
+> protegidos do Runtime, mas não bloqueia a configuração inicial.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -40,7 +40,6 @@ $Asset = "simplicio-windows-x64.exe"
 $Ed25519PublicKey = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 $Ed25519HelperUrl = "https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/scripts/verify_ed25519.py"
 $Ed25519HelperSha256 = "f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
-$CodexRouteHookBase = "https://raw.githubusercontent.com/$Repo"
 $PinnedPublicKey = ([string]$Ed25519PublicKey).Trim()
 $script:Ed25519VerifyError = ""
 $SimplicioMcpUrl = if ($env:SIMPLICIO_MCP_URL) { $env:SIMPLICIO_MCP_URL } else { "http://127.0.0.1:8787/mcp" }
@@ -187,33 +186,15 @@ function Report-LoginState {
   Write-Warning "Google login missing or entitlement inactive; run: `"$DestPath`" auth login"
 }
 
-function Require-ActiveLogin {
-  if (Test-ActiveLogin) { return $true }
-  Write-Warning "MCP handshake deferred: run `"$DestPath`" auth login first"
-  return $false
-}
-
 function Test-McpToolSurface([string]$BinaryPath) {
   if (-not (Test-Path $BinaryPath)) { return $false }
   try {
     $env:SIMPLICIO_MCP_URL = $SimplicioMcpUrl
-    & $BinaryPath mcp register | Out-Null
+    & $BinaryPath mcp register --binary $BinaryPath --json | Out-Null
     return ($LASTEXITCODE -eq 0)
   } catch {
     return $false
   }
-}
-
-function Install-CodexRouteHook {
-  $hookRef = [string]$env:SIMPLICIO_CODEX_HOOK_REF
-  if ([string]::IsNullOrWhiteSpace($hookRef)) {
-    throw "Codex hook opt-in requires SIMPLICIO_CODEX_HOOK_REF pinned to a release tag"
-  }
-  $hookDir = Join-Path $env:USERPROFILE ".simplicio\hooks"
-  $hookPath = Join-Path $hookDir "mcp-route.ps1"
-  $hookUrl = "$CodexRouteHookBase/$hookRef/codex/mcp-route.ps1"
-  New-Item -ItemType Directory -Force -Path $hookDir | Out-Null
-  Invoke-WebRequest -Uri $hookUrl -OutFile $hookPath -UseBasicParsing -ErrorAction Stop
 }
 
 # ─── -Doctor: idempotent, read-only health check ───────────────────────────
@@ -474,29 +455,14 @@ if (-not (Test-RuntimeReleaseContract $DestPath)) {
 }
 Write-Host "  ✓ Runtime release contract verified"
 
-# ─── Login state: defer MCP until the account is authenticated ─────────────
-if (Require-ActiveLogin) {
-  if (Test-McpToolSurface $DestPath) {
-    Write-Host "  ✓ MCP registered by direct command: $DestPath"
-  } else {
-    Write-Warning "could not verify MCP automatically; run: `"$DestPath`" mcp register"
-  }
+# ─── Register MCP and native hooks for every detected client ──────────────
+if (Test-McpToolSurface $DestPath) {
+  Write-Host "  ✓ MCP and hooks registered automatically for detected clients"
 } else {
-  Report-LoginState
-  Write-Warning "MCP handshake remains deferred until Google login is active"
+  Write-Error "Runtime installed, but automatic MCP/hooks registration failed: $DestPath mcp register --binary $DestPath --json"
+  exit 1
 }
-
-# Codex integration is opt-in and requires an explicit, version-pinned hook ref.
-if ($env:SIMPLICIO_INSTALL_CODEX -eq "1") {
-  try {
-    Install-CodexRouteHook
-    Write-Host "  ✓ local MCP hook updated to use $DestPath directly"
-  } catch {
-    Write-Warning "could not update the local MCP hook; Runtime MCP registration remains installed, but Codex integration was not enabled"
-  }
-} else {
-  Write-Host "  ! Codex integration disabled; use SIMPLICIO_INSTALL_CODEX=1 with SIMPLICIO_CODEX_HOOK_REF=vX.Y.Z"
-}
+Report-LoginState
 Write-Host "  ✓ Direct MCP: $DestPath serve --mcp --stdio; SIMPLICIO_MCP_URL=$SimplicioMcpUrl"
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,6 @@ GITHUB="https://github.com/$REPO"
 ED25519_PUBLIC_KEY="2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 ED25519_HELPER_URL="https://raw.githubusercontent.com/$REPO/master/scripts/verify_ed25519.py"
 ED25519_HELPER_SHA256="f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
-# Codex hooks are fetched from an explicit release ref only when opt-in is enabled.
 BIN_NAME="simplicio"
 
 GREEN='\033[0;32m'
@@ -131,30 +130,6 @@ verify_ed25519_signature() {
     --sha256 "$expected_sha256" >/dev/null 2>&1
 }
 
-install_codex_route_hook() {
-  hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-}"
-  if [ -z "$hook_ref" ]; then
-    warn "Codex hook opt-in requires SIMPLICIO_CODEX_HOOK_REF pinned to a release tag"
-    return 1
-  fi
-  CODEX_ROUTE_HOOK_URL="https://raw.githubusercontent.com/$REPO/$hook_ref/codex/mcp-route.sh"
-  hook_url="$CODEX_ROUTE_HOOK_URL"
-  hook_dir="$HOME/.simplicio/hooks"
-  hook_path="$hook_dir/mcp-route.sh"
-  hook_tmp="$(mktemp)"
-  mkdir -p "$hook_dir"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$hook_url" -o "$hook_tmp" || { rm -f "$hook_tmp"; return 1; }
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$hook_url" -O "$hook_tmp" || { rm -f "$hook_tmp"; return 1; }
-  else
-    rm -f "$hook_tmp"
-    return 1
-  fi
-  chmod +x "$hook_tmp"
-  mv -f "$hook_tmp" "$hook_path"
-}
-
 verify_runtime_contract() {
   binary_path="$1"
   if [ ! -x "$binary_path" ] || ! command -v python3 >/dev/null 2>&1; then
@@ -243,18 +218,10 @@ report_login_state() {
   return 0
 }
 
-require_active_login() {
-  if verify_active_login; then
-    return 0
-  fi
-  warn "MCP handshake adiado: faça login com ${DEST_PATH} auth login"
-  return 1
-}
-
 verify_mcp_tools() {
   binary_path="$1"
   [ -x "$binary_path" ] || return 1
-  SIMPLICIO_MCP_URL="$SIMPLICIO_MCP_URL" "$binary_path" mcp register >/dev/null 2>&1
+  SIMPLICIO_MCP_URL="$SIMPLICIO_MCP_URL" "$binary_path" mcp register --binary "$binary_path" --json >/dev/null 2>&1
 }
 
 # ─── --doctor: idempotent, read-only health check ──────────────────────────
@@ -558,28 +525,13 @@ if ! verify_runtime_contract "$DEST_PATH"; then
 fi
 ok "contrato de release do Runtime verificado"
 
-# ─── 2.2 Login state: defer MCP until the account is authenticated ─────────
-if require_active_login; then
-  if verify_mcp_tools "$DEST_PATH"; then
-    ok "MCP registrado por comando direto para $DEST_PATH"
-  else
-    warn "não foi possível verificar o MCP automaticamente; rode: $DEST_PATH mcp register"
-  fi
+# ─── 2.2 Register MCP and native hooks for every detected client ───────────
+if verify_mcp_tools "$DEST_PATH"; then
+  ok "MCP e hooks registrados automaticamente para os clientes detectados"
 else
-  report_login_state
-  warn "MCP handshake permanece adiado até o login Google ficar ativo"
+  err "o Runtime foi instalado, mas o registro automático de MCP/hooks falhou: $DEST_PATH mcp register --binary $DEST_PATH --json"
 fi
-
-# Codex integration is opt-in and requires an explicit, version-pinned hook ref.
-if [ "${SIMPLICIO_INSTALL_CODEX:-}" = "1" ]; then
-  if install_codex_route_hook; then
-    ok "hook MCP local atualizado para usar $DEST_PATH diretamente"
-  else
-    warn "não foi possível atualizar o hook MCP local; integração Codex não foi ativada"
-  fi
-else
-  info "integração Codex não ativada; use SIMPLICIO_INSTALL_CODEX=1 com SIMPLICIO_CODEX_HOOK_REF=vX.Y.Z"
-fi
+report_login_state
 ok "MCP direto: $DEST_PATH serve --mcp --stdio; SIMPLICIO_MCP_URL=${SIMPLICIO_MCP_URL}"
 
 # PATH is optional for MCP because host configs point at $DEST_PATH directly.

--- a/pypi/simplicio/simplicio/__main__.py
+++ b/pypi/simplicio/simplicio/__main__.py
@@ -192,6 +192,34 @@ def _validate_runtime(path: Path, expected_version: str, runner=subprocess.run) 
         )
 
 
+def _register_detected_hosts(path: Path, runner=subprocess.run) -> None:
+    """Register MCP and Runtime-owned hooks for every detected supported client."""
+    try:
+        result = runner(
+            [
+                str(path),
+                "mcp",
+                "register",
+                "--binary",
+                str(path),
+                "--json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        report = json.loads(result.stdout)
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        raise InstallError(
+            "Runtime installed, but automatic MCP/hooks registration failed."
+        ) from exc
+    if not isinstance(report, dict) or report.get("status") != "passed":
+        failed = report.get("failed", []) if isinstance(report, dict) else []
+        detail = ": " + ", ".join(str(item) for item in failed) if failed else ""
+        raise InstallError(
+            "Runtime installed, but automatic MCP/hooks registration failed" + detail + "."
+        )
+
 def do_install(
     client=None,
     install_dir=None,
@@ -239,6 +267,7 @@ def do_install(
         staged_path.chmod(0o755)
         _validate_runtime(staged_path, expected_version, runner)
         os.replace(str(staged_path), str(destination))
+        _register_detected_hosts(destination, runner)
     except InstallError:
         raise
     except OSError as exc:

--- a/scripts/codex_integration.py
+++ b/scripts/codex_integration.py
@@ -106,7 +106,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('--source-root', type=Path, default=Path(__file__).resolve().parents[1])
     parser.add_argument('--binary', default='simplicio')
     parser.add_argument('--version', default=os.environ.get('SIMPLICIO_VERSION', 'unknown'))
-    parser.add_argument('--hook-ref', default=os.environ.get('SIMPLICIO_CODEX_HOOK_REF', ''))
+    parser.add_argument('--hook-ref', default='')
     parser.add_argument('--platform', choices=('unix', 'windows'), default='windows' if os.name == 'nt' else 'unix')
     args = parser.parse_args(argv)
     if args.command == 'status': result = status(args)

--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -275,17 +275,6 @@ def update_public_metadata(tag: str, version: str, source_commit: str) -> list[P
     version_doc.write_text(text, encoding="utf-8")
     changed.append(version_doc)
 
-    for relative in ("README.md", "MCP-CONNECT.md"):
-        path = ROOT / relative
-        body = path.read_text(encoding="utf-8")
-        body = re.sub(
-            r"SIMPLICIO_CODEX_HOOK_REF=v[0-9]+\.[0-9]+\.[0-9]+",
-            "SIMPLICIO_CODEX_HOOK_REF=" + tag,
-            body,
-        )
-        path.write_text(body, encoding="utf-8")
-        changed.append(path)
-
     for relative in (
         "npm/simplicio/package.json",
         "npm/simplicio-installer/package.json",

--- a/tests/install_error_registry.json
+++ b/tests/install_error_registry.json
@@ -81,14 +81,14 @@
       "status": "fixed",
       "severity": "high",
       "source": "full-validation",
-      "symptom": "MCP handshake could run before an active login was established.",
-      "root_cause": "Installers reported login state but registered MCP without an explicit authenticated gate.",
-      "guard": "require_active_login gates verify_mcp_tools after the staged runtime is installed; staging is never probed.",
+      "symptom": "Fresh installations could skip MCP and hook registration until after login.",
+      "root_cause": "The installers coupled local host configuration writes to active authentication.",
+      "guard": "install.sh and install.ps1 register every detected supported host with the installed binary before reporting login state; registration failure is fatal.",
       "regression_tests": [
         "tests/test_clean_install_bootstrap_contract.py::test_shell_defers_mcp_handshake_until_after_login",
         "tests/test_clean_install_bootstrap_contract.py::test_powershell_defers_mcp_handshake_until_after_login"
       ],
-      "fixed_commit": "eef83c7a8abc2b96993928db4780777cab37c9e2"
+      "fixed_commit": "7abc0f0428d65718cda709b57c51bcabb28b92ae"
     },
     {
       "id": "CODEX-HOOK-007",
@@ -96,13 +96,13 @@
       "status": "fixed",
       "severity": "medium",
       "source": "full-validation",
-      "symptom": "Codex integration was installed without an explicit opt-in and hook ref.",
-      "root_cause": "Installers always fetched the route hook and did not require a pinned release ref.",
-      "guard": "SIMPLICIO_INSTALL_CODEX=1 is required and SIMPLICIO_CODEX_HOOK_REF must name a release tag.",
+      "symptom": "Codex integration could remain disabled after a normal installation.",
+      "root_cause": "The public installers required an opt-in environment variable and downloaded a second hook artifact.",
+      "guard": "Every installer delegates automatic host and Runtime-owned hook registration to `simplicio mcp register --binary <installed> --json`; no Codex opt-in remains.",
       "regression_tests": [
         "tests/test_codex_integration_cli.py::test_installers_are_opt_in_and_do_not_use_mutable_master_hook_ref"
       ],
-      "fixed_commit": "eef83c7a8abc2b96993928db4780777cab37c9e2"
+      "fixed_commit": "7abc0f0428d65718cda709b57c51bcabb28b92ae"
     },
     {
       "id": "UNINSTALL-008",
@@ -304,6 +304,21 @@
         "tests/unit/test_pypi_installer.py::test_default_manifest_pin_matches_versioned_checkout"
       ],
       "fixed_commit": "38fe075"
+    },
+    {
+      "id": "AUTO-HOST-021",
+      "platform": "windows-macos-linux",
+      "status": "fixed",
+      "severity": "high",
+      "source": "customer-report",
+      "symptom": "SH and PS1 could defer registration, while the PyPI installer never registered detected clients.",
+      "root_cause": "Host registration was split across installer-specific paths instead of the installed Runtime.",
+      "guard": "SH, PS1, and PyPI all invoke the installed Runtime registrar and fail clearly when its JSON status is not passed.",
+      "regression_tests": [
+        "tests/test_codex_install_contract.py::test_plain_install_registers_all_detected_hosts_without_codex_opt_in",
+        "tests/unit/test_pypi_installer.py::test_install_registers_detected_hosts_with_installed_binary"
+      ],
+      "fixed_commit": "7abc0f0428d65718cda709b57c51bcabb28b92ae"
     }
   ]
 }

--- a/tests/test_clean_install_bootstrap_contract.py
+++ b/tests/test_clean_install_bootstrap_contract.py
@@ -5,14 +5,20 @@ ROOT = Path(__file__).parents[1]
 
 
 def test_shell_defers_mcp_handshake_until_after_login():
-    text = (ROOT / 'install.sh').read_text(encoding='utf-8')
-    assert text.rindex('require_active_login') < text.rindex('verify_mcp_tools \"$DEST_PATH\"')
-    assert 'verify_mcp_tools \"$STAGING_PATH\"' not in text
-    assert 'RELEASE_TAG=\"v${VERSION#v}\"' in text
+    text = (ROOT / "install.sh").read_text(encoding="utf-8")
+    registration = 'verify_mcp_tools "$DEST_PATH"'
+    assert registration in text
+    assert "require_active_login" not in text
+    assert text.index(registration) < text.index("report_login_state", text.index(registration))
+    assert 'verify_mcp_tools "$STAGING_PATH"' not in text
+    assert 'RELEASE_TAG="v${VERSION#v}"' in text
 
 
 def test_powershell_defers_mcp_handshake_until_after_login():
-    text = (ROOT / 'install.ps1').read_text(encoding='utf-8')
-    assert text.rindex('Require-ActiveLogin') < text.rindex('Test-McpToolSurface $DestPath')
-    assert 'Test-McpToolSurface $StagingPath' not in text
-    assert '$ReleaseTag = if ($Version.StartsWith(\"v\"))' in text
+    text = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    registration = "Test-McpToolSurface $DestPath"
+    assert registration in text
+    assert "Require-ActiveLogin" not in text
+    assert text.index(registration) < text.index("Report-LoginState", text.index(registration))
+    assert "Test-McpToolSurface $StagingPath" not in text
+    assert '$ReleaseTag = if ($Version.StartsWith("v"))' in text

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -34,8 +34,23 @@ def test_installers_configure_direct_stdio_and_hooks():
         text = (ROOT / name).read_text(encoding="utf-8")
         assert "SIMPLICIO_MCP_URL" in text
         assert "serve" in text and "--mcp" in text and "--stdio" in text
-        assert "mcp-route" in text
         assert "mcp register" in text
+        assert "--binary" in text
+        assert "--json" in text
+
+def test_plain_install_registers_all_detected_hosts_without_codex_opt_in():
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+    assert "SIMPLICIO_INSTALL_CODEX" not in shell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in shell
+    assert "if require_active_login; then" not in shell
+    assert 'mcp register --binary "$binary_path" --json' in shell
+
+    assert "SIMPLICIO_INSTALL_CODEX" not in powershell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in powershell
+    assert "if (Require-ActiveLogin)" not in powershell
+    assert "mcp register --binary $BinaryPath --json" in powershell
 
 
 def test_installers_preserve_existing_codex_state():
@@ -43,7 +58,7 @@ def test_installers_preserve_existing_codex_state():
     powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
     assert "mcp register" in shell
     assert "mcp register" in powershell
-    assert "Runtime MCP registration remains installed" in powershell
+    assert "automatic MCP/hooks registration failed" in powershell
 
 
 def test_installers_preserve_stable_login_state_during_upgrades():
@@ -57,18 +72,16 @@ def test_installers_preserve_stable_login_state_during_upgrades():
 
 def test_windows_installer_migrates_legacy_unix_hooks():
     powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
-    # The public installer repairs the local route hook after the Runtime's
-    # cross-editor `mcp register` command.
-    assert "mcp-route.ps1" in powershell
-    assert "Install-CodexRouteHook" in powershell
-
+    assert "Install-CodexRouteHook" not in powershell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in powershell
+    assert "mcp register --binary $BinaryPath --json" in powershell
 
 def test_unix_installer_migrates_legacy_hook_events():
     shell = (ROOT / "install.sh").read_text(encoding="utf-8")
-    assert "CODEX_ROUTE_HOOK_URL" in shell
-    assert "install_codex_route_hook" in shell
-    assert ".simplicio/hooks" in shell
-
+    assert "CODEX_ROUTE_HOOK_URL" not in shell
+    assert "install_codex_route_hook" not in shell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in shell
+    assert 'mcp register --binary "$binary_path" --json' in shell
 
 def test_unix_installer_accepts_release_manifest_target_aliases():
     shell = (ROOT / "install.sh").read_text(encoding="utf-8")
@@ -84,16 +97,17 @@ def test_codex_hooks_have_all_required_lifecycle_events():
     powershell_hook = (ROOT / "codex/mcp-route.ps1").read_text(encoding="utf-8")
     # Codex rejects a bare PreToolUse permissionDecision=allow. Allowing an
     # unchanged call is represented by successful empty stdout on both hosts.
-    assert "permissionDecision" not in shell_hook
-    assert "permissionDecision" not in powershell_hook
+    assert '"permissionDecision": "allow"' not in shell_hook
+    assert "permissionDecision = 'allow'" not in powershell_hook
+    assert '"permissionDecision": "deny"' in shell_hook
+    assert "permissionDecision = 'deny'" in powershell_hook
     assert "hookEventName" in shell_hook
     assert "hookEventName" in powershell_hook
-    assert "simplicio-hook-version: 3240-v6" in shell_hook
-    assert "simplicio-hook-version: 3240-v6" in powershell_hook
+    assert "simplicio-hook-version: 3240-v8" in shell_hook
+    assert "simplicio-hook-version: 3240-v8" in powershell_hook
     assert "Empty stdout is the portable allow-unchanged contract" in shell_hook
-    assert "No decision means allow unchanged" in shell_hook
+    assert "No decision means allow unchanged" in powershell_hook
     assert "Allow-Unchanged" in powershell_hook
-    assert "rejects an explicit PreToolUse allow without updatedInput" in powershell_hook
     assert "Simplicio MCP is mandatory" not in shell_hook
     assert "Simplicio MCP is mandatory" not in powershell_hook
     for event in ("SessionStart", "UserPromptSubmit", "SubagentStart"):
@@ -101,7 +115,7 @@ def test_codex_hooks_have_all_required_lifecycle_events():
         assert event in powershell_hook
     assert "mcp register" in (ROOT / "install.sh").read_text(encoding="utf-8")
     assert "mcp register" in (ROOT / "install.ps1").read_text(encoding="utf-8")
-    assert "simplicio_map" in shell_hook
+    assert "result=subprocess.run([binary,'map','--repo'" in shell_hook
     assert "simplicio_context" in shell_hook
     assert 'SIMPLICIO_BIN="${SIMPLICIO_BIN:-${SIMPLICIO_BIN_DIR:-${HOME}/.simplicio/bin}/simplicio}"' in shell_hook
     assert 'which("simplicio")' not in shell_hook

--- a/tests/test_codex_integration_cli.py
+++ b/tests/test_codex_integration_cli.py
@@ -51,8 +51,11 @@ def test_windows_binary_path_is_toml_safe_and_uses_forward_slashes():
 
 
 def test_installers_are_opt_in_and_do_not_use_mutable_master_hook_ref():
-    shell = (ROOT / 'install.sh').read_text(encoding='utf-8')
-    powershell = (ROOT / 'install.ps1').read_text(encoding='utf-8')
-    assert 'SIMPLICIO_INSTALL_CODEX' in shell and 'SIMPLICIO_INSTALL_CODEX' in powershell
-    assert 'hook_ref="${SIMPLICIO_CODEX_HOOK_REF:-master}"' not in shell
-    assert 'else { "master" }' not in powershell
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert "SIMPLICIO_INSTALL_CODEX" not in shell
+    assert "SIMPLICIO_INSTALL_CODEX" not in powershell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in shell
+    assert "SIMPLICIO_CODEX_HOOK_REF" not in powershell
+    assert 'mcp register --binary "$binary_path" --json' in shell
+    assert "mcp register --binary $BinaryPath --json" in powershell

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -8,11 +8,12 @@ def read(name):
     return (ROOT / name).read_text(encoding='utf-8')
 
 
-def test_install_docs_match_opt_in_transactional_contract():
+def test_install_docs_match_automatic_transactional_contract():
     readme = read('README.md')
     install = read('INSTALL.md')
-    assert 'SIMPLICIO_INSTALL_CODEX=1' in readme
-    assert 'SIMPLICIO_INSTALL_CODEX=1' in install
+    assert 'SIMPLICIO_INSTALL_CODEX' not in readme
+    assert 'SIMPLICIO_INSTALL_CODEX' not in install
+    assert 'automatically' in readme
     assert '--uninstall --keep-data' in readme
     assert '--uninstall --purge' in install
     assert 'SIMPLICIO_CONFIRM_PURGE=1' in readme
@@ -23,7 +24,8 @@ def test_mcp_docs_match_local_authentication_contract():
     mcp = read('MCP-CONNECT.md')
     assert 'local STDIO' in mcp
     assert 'Google login' in mcp
-    assert 'SIMPLICIO_INSTALL_CODEX=1' in mcp
+    assert 'SIMPLICIO_INSTALL_CODEX' not in mcp
+    assert 'automatically' in mcp
     assert 'Ed25519' in mcp
 
 

--- a/tests/unit/test_pypi_installer.py
+++ b/tests/unit/test_pypi_installer.py
@@ -87,11 +87,15 @@ def json_bytes(value):
 
 
 def valid_runner(command, **kwargs):
-    assert command[1:] == ["version", "--json"]
     assert kwargs["check"] and kwargs["capture_output"] and kwargs["text"]
-    return subprocess.CompletedProcess(
-        command, 0, json.dumps({"runtime": {"version": CURRENT_VERSION}}), ""
-    )
+    if command[1:] == ["version", "--json"]:
+        return subprocess.CompletedProcess(
+            command, 0, json.dumps({"runtime": {"version": CURRENT_VERSION}}), ""
+        )
+    assert command[1:4] == ["mcp", "register", "--binary"]
+    assert command[4] == command[0]
+    assert command[5:] == ["--json"]
+    return subprocess.CompletedProcess(command, 0, '{"status":"passed"}', "")
 
 
 def test_install_verifies_then_atomically_replaces_binary(tmp_path, monkeypatch):
@@ -111,6 +115,36 @@ def test_install_verifies_then_atomically_replaces_binary(tmp_path, monkeypatch)
     assert destination.read_bytes() == payload
     assert client.downloaded == [installer.MANIFEST_ASSET, "simplicio-linux-x64"]
     assert not list(tmp_path.glob(".simplicio-*"))
+
+
+def test_install_registers_detected_hosts_with_installed_binary(tmp_path, monkeypatch):
+    payload = b"verified runtime"
+    client = FakeReleaseClient(manifest_for(payload), payload)
+    monkeypatch.setattr(installer, "_target", lambda: ("linux-x64", "simplicio-linux-x64"))
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append(list(command))
+        return valid_runner(command, **kwargs)
+
+    installer.do_install(
+        client=client,
+        install_dir=tmp_path,
+        runner=runner,
+        trusted_manifest_sha256=trusted_digest(client.manifest),
+    )
+
+    destination = tmp_path / "simplicio"
+    assert len(calls) == 2
+    assert calls[0][1:] == ["version", "--json"]
+    assert calls[1] == [
+        str(destination),
+        "mcp",
+        "register",
+        "--binary",
+        str(destination),
+        "--json",
+    ]
 
 
 def test_install_rejects_missing_target_without_downloading(tmp_path, monkeypatch):
@@ -351,10 +385,9 @@ def test_windows_staging_uses_exe_suffix(tmp_path, monkeypatch):
     staged_paths = []
 
     def runner(command, **kwargs):
-        staged_paths.append(command[0])
-        return subprocess.CompletedProcess(
-            command, 0, json.dumps({"runtime": {"version": CURRENT_VERSION}}), ""
-        )
+        if command[1:] == ["version", "--json"]:
+            staged_paths.append(command[0])
+        return valid_runner(command, **kwargs)
 
     installer.do_install(client=client, install_dir=tmp_path, runner=runner)
     assert staged_paths[0].endswith(".exe")


### PR DESCRIPTION
## Summary
- make SH, PowerShell, and PyPI installers invoke the installed Runtime registrar automatically
- remove login, Codex opt-in, and pinned-ref gates from host registration
- fail clearly when registration cannot be completed
- align installer documentation and the regression registry

## Validation
- `pytest -q` — 210 passed, 30 subtests
- `sh -n install.sh`
- PowerShell parser validation
- `git diff --check`

Runtime dependency merged in wesleysimplicio/simplicio-runtime#5073.

Refs #139