### PR TITLE
feat(installer): add evidence-backed multi-host registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ A failed automatic registration makes the installer fail clearly instead of
 claiming success. Clients not reported by the JSON result are not silently
 treated as configured.
 
+The installer also writes the redacted multi-host detection/registration
+receipt to `simplicio-host-integrations.json` beside the managed binary. See
+[`docs/HOST_INTEGRATIONS.md`](docs/HOST_INTEGRATIONS.md) for the supported
+matrix, exact-probe policy, opt-outs, and receipt schema.
+
 ### Other MCP clients: local STDIO
 
 For Claude Code, Cursor, VS Code, Cline, Continue, and similar clients, add a

--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -1,0 +1,55 @@
+# Host integration registry
+
+The public installer distributes one verified Simplicio Runtime. It does not
+copy credentials, download arbitrary editor plugins, or maintain a second MCP
+writer for every host. After the binary is staged and its release contract is
+verified, the installer invokes:
+
+```text
+simplicio mcp register --binary <absolute-path> --json
+```
+
+The Runtime owns the transactional host edits and native hook decisions. The
+launcher records the redacted result in
+`<binary-directory>/simplicio-host-integrations.json`.
+
+## Detection policy
+
+Detection is non-invasive. It checks an exact executable name or a documented
+application path and never starts a host session. A configuration file by
+itself is not enough to mark a host as installed because stale files are common.
+Unknown products have no automatic executable probe until their official
+contract is verified; they are reported as `unsupported` instead of producing
+a false positive.
+
+The current Runtime-delegated entries are Claude Code, Cursor, OpenCode, VS
+Code, Kiro, Pi, and oh-my-pi. Orca is reported through the documented portable
+CLI path. DeepSeek Harness, Antigravity, Command Code, and the remaining
+compatibility-matrix entries remain explicit `unsupported`/`unverified` until
+their canonical upstream contract is confirmed.
+
+## Opt-out and scope
+
+Skip every host with a comma-separated list or one host with an environment
+variable:
+
+```text
+SIMPLICIO_SKIP_HOSTS=cursor,kiro
+SIMPLICIO_SKIP_CURSOR=1
+```
+
+These controls affect detection/registration reporting only; they never remove
+existing user configuration. Re-running the installer is safe and delegates
+idempotent reconciliation to the Runtime.
+
+## Receipt shape
+
+The receipt uses `simplicio.host-integration/v1` and contains the Runtime
+registration status, one row for every matrix entry, exact detected evidence,
+the capability (`runtime-mcp`, `portable-cli`, or `unsupported`), and the
+primary documentation URL. It contains no tokens or provider credentials and
+is written atomically with mode `0600`.
+
+The receipt is evidence of what the installer observed; a host is marked
+`registered` only when the Runtime JSON result names it as registered. File
+presence alone is never promoted to a successful integration.

--- a/pypi/simplicio/simplicio/__main__.py
+++ b/pypi/simplicio/simplicio/__main__.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 from . import __version__
+from .host_integrations import build_summary, write_summary
 
 INSTALL_DIR = os.path.expanduser("~/.local/bin")
 BINARY_NAME = "simplicio" + (".exe" if platform.system() == "Windows" else "")
@@ -192,7 +193,7 @@ def _validate_runtime(path: Path, expected_version: str, runner=subprocess.run) 
         )
 
 
-def _register_detected_hosts(path: Path, runner=subprocess.run) -> None:
+def _register_detected_hosts(path: Path, runner=subprocess.run) -> dict:
     """Register MCP and Runtime-owned hooks for every detected supported client."""
     try:
         result = runner(
@@ -219,6 +220,20 @@ def _register_detected_hosts(path: Path, runner=subprocess.run) -> None:
         raise InstallError(
             "Runtime installed, but automatic MCP/hooks registration failed" + detail + "."
         )
+    return report
+
+
+def _write_host_integration_summary(binary_path: Path, runtime_report: dict) -> Path:
+    """Persist the redacted multi-host receipt next to the managed binary."""
+    configured = os.environ.get("SIMPLICIO_HOST_SUMMARY")
+    summary_path = Path(configured) if configured else binary_path.parent / "simplicio-host-integrations.json"
+    try:
+        write_summary(summary_path, build_summary(runtime_report=runtime_report))
+    except OSError as exc:
+        raise InstallError(
+            "Runtime registered successfully, but the host integration receipt could not be written."
+        ) from exc
+    return summary_path
 
 def do_install(
     client=None,
@@ -267,7 +282,8 @@ def do_install(
         staged_path.chmod(0o755)
         _validate_runtime(staged_path, expected_version, runner)
         os.replace(str(staged_path), str(destination))
-        _register_detected_hosts(destination, runner)
+        registration = _register_detected_hosts(destination, runner)
+        _write_host_integration_summary(destination, registration)
     except InstallError:
         raise
     except OSError as exc:

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -1,0 +1,331 @@
+"""Deterministic host discovery and Runtime-registration receipts.
+
+The public installer owns distribution of one Runtime binary.  It must not
+reimplement every editor's MCP writer or silently guess a third-party CLI.
+This module therefore keeps the host matrix in one place, performs exact
+non-invasive probes, and records the Runtime's registration result alongside
+the detected hosts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+SCHEMA = "simplicio.host-integration/v1"
+TRUTHY = frozenset(("1", "true", "yes", "on"))
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    """A host entry with only evidence-safe detection metadata."""
+
+    host_id: str
+    name: str
+    executable_names: Tuple[str, ...] = ()
+    app_paths: Tuple[str, ...] = ()
+    config_paths: Tuple[str, ...] = ()
+    capability: str = "unsupported"
+    contract: str = "unknown"
+    documentation: str = ""
+    reason: str = ""
+
+
+def _runtime_mcp(
+    host_id: str,
+    name: str,
+    executable_names: Sequence[str],
+    config_paths: Sequence[str],
+    documentation: str,
+) -> HostSpec:
+    return HostSpec(
+        host_id=host_id,
+        name=name,
+        executable_names=tuple(executable_names),
+        config_paths=tuple(config_paths),
+        capability="runtime-mcp",
+        contract="delegated-to-runtime",
+        documentation=documentation,
+        reason="The Runtime owns the atomic MCP/native-hook registration.",
+    )
+
+
+def _unverified(host_id: str, name: str, documentation: str, reason: str) -> HostSpec:
+    # No executable is intentionally listed until the upstream product contract
+    # is verified.  An empty probe is safer than a false positive from a
+    # similarly named command.
+    return HostSpec(
+        host_id=host_id,
+        name=name,
+        capability="unsupported",
+        contract="unverified",
+        documentation=documentation,
+        reason=reason,
+    )
+
+
+HOSTS: Tuple[HostSpec, ...] = (
+    _runtime_mcp(
+        "claude-code",
+        "Claude Code",
+        ("claude",),
+        ("~/.claude/settings.json", "~/.claude/.mcp.json"),
+        "https://docs.anthropic.com/claude/docs/claude-code",
+    ),
+    _runtime_mcp(
+        "cursor",
+        "Cursor",
+        ("cursor",),
+        ("~/.cursor/mcp.json", ".cursor/mcp.json"),
+        "https://cursor.com/cli",
+    ),
+    _unverified(
+        "deepseek-harness",
+        "DeepSeek Harness",
+        "",
+        "The canonical harness executable and plugin/MCP contract are not verified.",
+    ),
+    _runtime_mcp(
+        "opencode",
+        "OpenCode",
+        ("opencode",),
+        ("~/.config/opencode/opencode.json", "opencode.json"),
+        "https://opencode.ai/docs/cli/",
+    ),
+    _runtime_mcp(
+        "vscode",
+        "Visual Studio Code",
+        ("code", "code-insiders"),
+        ("~/.vscode/mcp.json", ".vscode/mcp.json"),
+        "https://code.visualstudio.com/docs/copilot/chat/mcp-servers",
+    ),
+    _unverified(
+        "antigravity",
+        "Google Antigravity",
+        "https://antigravity.google/docs/cli-overview",
+        "The canonical executable and public extension/MCP contract are not verified.",
+    ),
+    _runtime_mcp(
+        "kiro",
+        "Kiro",
+        ("kiro-cli",),
+        ("~/.kiro/settings/mcp.json", ".kiro/settings/mcp.json"),
+        "https://kiro.dev/docs/cli/",
+    ),
+    _runtime_mcp(
+        "pi",
+        "Pi",
+        ("pi",),
+        ("~/.pi/agent",),
+        "https://pi.dev/",
+    ),
+    _runtime_mcp(
+        "oh-my-pi",
+        "oh-my-pi",
+        ("omp",),
+        ("~/.omp",),
+        "https://omp.sh/",
+    ),
+    HostSpec(
+        host_id="orca",
+        name="OrcaDev / Orca ADE",
+        executable_names=("orca",),
+        capability="portable-cli",
+        contract="documented-cli",
+        documentation="https://www.onorca.dev/docs/cli/overview",
+        reason="Use the documented Orca skills/MCP path; do not alter worktrees.",
+    ),
+    _unverified(
+        "command-code",
+        "Command Code",
+        "https://commandcode.ai/docs/quickstart",
+        "The canonical executable and official integration contract are not verified.",
+    ),
+)
+
+
+REMAINING_HOSTS: Tuple[Tuple[str, str, str], ...] = (
+    ("grok", "Grok", "https://github.com/wesleysimplicio/simplicio"),
+    ("github-copilot", "GitHub Copilot", "https://github.com/features/copilot"),
+    ("mimo-code", "MiMo Code", "https://github.com/wesleysimplicio/simplicio"),
+    ("amp", "Amp", "https://github.com/wesleysimplicio/simplicio"),
+    ("openclaude", "OpenClaude", "https://github.com/wesleysimplicio/simplicio"),
+    ("hermes-agent", "Hermes Agent", "https://github.com/wesleysimplicio/simplicio"),
+    ("devin", "Devin", "https://github.com/wesleysimplicio/simplicio"),
+    ("goose", "Goose", "https://github.com/block/goose"),
+    ("auggie", "Auggie", "https://github.com/wesleysimplicio/simplicio"),
+    ("autohand-code", "Autohand Code", "https://github.com/wesleysimplicio/simplicio"),
+    ("charm-crush", "Charm/Crush", "https://github.com/charmbracelet/crush"),
+    ("cline", "Cline", "https://github.com/cline/cline"),
+    ("codebuff", "Codebuff", "https://github.com/wesleysimplicio/simplicio"),
+    ("continue", "Continue", "https://github.com/continuedev/continue"),
+    ("droid", "Droid", "https://github.com/wesleysimplicio/simplicio"),
+    ("kilocode", "Kilocode", "https://github.com/Kilo-Org/kilocode"),
+    ("kimi", "Kimi", "https://github.com/wesleysimplicio/simplicio"),
+    ("mistral-vibe", "Mistral Vibe", "https://github.com/mistralai"),
+    ("qwen-code", "Qwen Code", "https://github.com/QwenLM/Qwen-Code"),
+    ("rovo-dev", "Rovo Dev", "https://www.atlassian.com/software/rovo"),
+)
+
+HOSTS = HOSTS + tuple(
+    _unverified(host_id, name, docs, "The public contract is not verified; automatic detection is disabled.")
+    for host_id, name, docs in REMAINING_HOSTS
+)
+
+
+def _home_path(value: str, home: Path) -> Path:
+    if value.startswith("~/"):
+        return home / value[2:]
+    return Path(value)
+
+
+def _is_truthy(value: Optional[str]) -> bool:
+    return str(value or "").strip().lower() in TRUTHY
+
+
+def _skip_hosts(env: Mapping[str, str]) -> frozenset:
+    raw = env.get("SIMPLICIO_SKIP_HOSTS", "")
+    return frozenset(item.strip().lower() for item in raw.split(",") if item.strip())
+
+
+def _is_skipped(spec: HostSpec, env: Mapping[str, str], skipped: frozenset) -> bool:
+    env_name = "SIMPLICIO_SKIP_" + spec.host_id.upper().replace("-", "_")
+    return spec.host_id.lower() in skipped or _is_truthy(env.get(env_name))
+
+
+def _exact_executables(spec: HostSpec, env: Mapping[str, str]) -> List[str]:
+    path = env.get("PATH")
+    found: List[str] = []
+    for name in spec.executable_names:
+        resolved = shutil.which(name, path=path)
+        if resolved and Path(resolved).name == name:
+            found.append(str(Path(resolved).resolve()))
+    return found
+
+
+def detect_hosts(
+    home: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+    specs: Iterable[HostSpec] = HOSTS,
+) -> List[Dict[str, object]]:
+    """Return an evidence-only snapshot without launching any host process."""
+
+    resolved_home = (home or Path.home()).expanduser().resolve()
+    environ = dict(os.environ if env is None else env)
+    skipped = _skip_hosts(environ)
+    result: List[Dict[str, object]] = []
+    for spec in specs:
+        executable_paths = _exact_executables(spec, environ)
+        app_paths = [
+            str(path)
+            for path in (_home_path(item, resolved_home) for item in spec.app_paths)
+            if path.exists()
+        ]
+        config_paths = [
+            str(path)
+            for path in (_home_path(item, resolved_home) for item in spec.config_paths)
+            if path.exists()
+        ]
+        present = bool(executable_paths or app_paths)
+        skipped_host = _is_skipped(spec, environ, skipped)
+        if skipped_host:
+            status = "skipped"
+        elif not present and spec.contract == "unverified":
+            status = "unsupported"
+        elif not present:
+            status = "absent"
+        elif spec.contract == "unverified":
+            status = "unsupported"
+        else:
+            status = "detected"
+        result.append(
+            {
+                "id": spec.host_id,
+                "name": spec.name,
+                "status": status,
+                "capability": spec.capability,
+                "contract": spec.contract,
+                "executable": executable_paths[0] if executable_paths else None,
+                "app": app_paths[0] if app_paths else None,
+                "config": config_paths[0] if config_paths else None,
+                "documentation": spec.documentation,
+                "reason": spec.reason,
+            }
+        )
+    return result
+
+
+def build_summary(
+    runtime_report: Optional[Mapping[str, object]] = None,
+    home: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Dict[str, object]:
+    hosts = detect_hosts(home=home, env=env)
+    report = dict(runtime_report or {})
+    runtime_status = report.get("status") if report else "not-run"
+    registered = report.get("registered")
+    failed = report.get("failed")
+    if isinstance(registered, list):
+        registered_ids = {str(item) for item in registered}
+        for host in hosts:
+            if host["status"] == "detected" and host["id"] in registered_ids:
+                host["status"] = "registered"
+    if isinstance(failed, list):
+        failed_ids = {str(item) for item in failed}
+        for host in hosts:
+            if host["id"] in failed_ids:
+                host["status"] = "failed"
+    counts: Dict[str, int] = {}
+    for host in hosts:
+        status = str(host["status"])
+        counts[status] = counts.get(status, 0) + 1
+    return {
+        "schema": SCHEMA,
+        "runtime": "single-binary",
+        "runtime_registration": {"status": runtime_status},
+        "hosts": hosts,
+        "counts": counts,
+    }
+
+
+def write_summary(path: Path, summary: Mapping[str, object]) -> None:
+    """Write a redacted, recoverable receipt with restrictive permissions."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw_path = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    temporary = Path(raw_path)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        temporary.chmod(0o600)
+        os.replace(str(temporary), str(path))
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Inspect Simplicio host integration detection.")
+    parser.add_argument("--home", type=Path, default=Path.home())
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    summary = build_summary(home=args.home)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        for host in summary["hosts"]:
+            print("{name}: {status}".format(**host))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).parents[1] / "pypi" / "simplicio"
+sys.path.insert(0, str(PACKAGE_ROOT))
+
+from simplicio.host_integrations import (
+    HOSTS,
+    build_summary,
+    detect_hosts,
+    write_summary,
+)
+
+
+def _command(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_matrix_has_unique_ids_and_all_parent_children() -> None:
+    ids = [spec.host_id for spec in HOSTS]
+    assert len(ids) == len(set(ids))
+    for expected in {
+        "claude-code",
+        "cursor",
+        "deepseek-harness",
+        "opencode",
+        "vscode",
+        "antigravity",
+        "kiro",
+        "pi",
+        "oh-my-pi",
+        "orca",
+        "command-code",
+    }:
+        assert expected in ids
+
+
+def test_detection_uses_exact_executable_and_app_evidence(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "claude")
+    home = tmp_path / "home"
+    (home / ".cursor").mkdir(parents=True)
+    (home / ".cursor" / "mcp.json").write_text("{}", encoding="utf-8")
+    snapshot = detect_hosts(home=home, env={"PATH": str(bin_dir)})
+    by_id = {item["id"]: item for item in snapshot}
+    assert by_id["claude-code"]["status"] == "detected"
+    assert by_id["claude-code"]["executable"].endswith("/claude")
+    assert by_id["cursor"]["status"] == "absent"
+    assert by_id["deepseek-harness"]["status"] == "unsupported"
+
+
+def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "cursor")
+    home = tmp_path / "home"
+    snapshot = detect_hosts(
+        home=home,
+        env={"PATH": str(bin_dir), "SIMPLICIO_SKIP_CURSOR": "1"},
+    )
+    cursor = next(item for item in snapshot if item["id"] == "cursor")
+    assert cursor["status"] == "skipped"
+    assert not home.exists()
+
+
+def test_summary_reconciles_runtime_receipt_without_claiming_unknown_hosts(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "claude")
+    summary = build_summary(
+        runtime_report={"status": "passed", "registered": ["claude-code"]},
+        home=tmp_path / "home",
+        env={"PATH": str(bin_dir)},
+    )
+    by_id = {item["id"]: item for item in summary["hosts"]}
+    assert by_id["claude-code"]["status"] == "registered"
+    assert by_id["deepseek-harness"]["status"] == "unsupported"
+    assert summary["runtime_registration"] == {"status": "passed"}
+
+
+def test_summary_is_atomic_and_restrictive(tmp_path: Path) -> None:
+    target = tmp_path / "state" / "host-integrations.json"
+    write_summary(target, {"schema": "test", "hosts": []})
+    assert json.loads(target.read_text(encoding="utf-8"))["schema"] == "test"
+    assert os.stat(target).st_mode & 0o777 == 0o600
+    assert not list(target.parent.glob("host-integrations.json.*"))


### PR DESCRIPTION
## Summary

- add one deterministic host matrix for the parent multi-host installer contract
- use exact non-invasive probes, explicit unsupported states, and global/per-host opt-outs
- keep Runtime as the single transactional MCP/native-hook writer
- persist an atomic redacted `simplicio-host-integrations.json` receipt
- add focused registry tests and documentation

Closes #146

## Validation

- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `sh -n install.sh`
- host-registry smoke: PASS (31 matrix entries, exact executable detection, unsupported-host guard, registered reconciliation, mode 0600 receipt)
- `node tests/node/installer-unit.test.cjs`: 12 passed

The container has no pytest executable, so the pytest suite remains a required external check rather than being misreported as run.