### PR TITLE
feat(installer): add Claude Code verification metadata

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -28,6 +28,13 @@ CLI path. DeepSeek Harness, Antigravity, Command Code, and the remaining
 compatibility-matrix entries remain explicit `unsupported`/`unverified` until
 their canonical upstream contract is confirmed.
 
+Claude Code is detected only through the exact `claude` executable. Its
+supported configuration locations are `~/.claude/settings.json` and
+`~/.claude/.mcp.json`; the public installer does not copy Codex-only hooks into
+those files. Verification is the Runtime registration receipt produced by
+`simplicio mcp register --binary <absolute-path> --json`, and the Runtime is
+responsible for the atomic merge and rollback of the host configuration.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment
@@ -46,9 +53,10 @@ idempotent reconciliation to the Runtime.
 
 The receipt uses `simplicio.host-integration/v1` and contains the Runtime
 registration status, one row for every matrix entry, exact detected evidence,
-the capability (`runtime-mcp`, `portable-cli`, or `unsupported`), and the
-primary documentation URL. It contains no tokens or provider credentials and
-is written atomically with mode `0600`.
+the capability (`runtime-mcp`, `portable-cli`, or `unsupported`), a
+minimum-version field, a verification command (when known), and the primary
+documentation URL. It contains no tokens or provider credentials and is
+written atomically with mode `0600`.
 
 The receipt is evidence of what the installer observed; a host is marked
 `registered` only when the Runtime JSON result names it as registered. File

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -33,6 +33,8 @@ class HostSpec:
     config_paths: Tuple[str, ...] = ()
     capability: str = "unsupported"
     contract: str = "unknown"
+    minimum_version: str = "unknown"
+    verification_command: Tuple[str, ...] = ()
     documentation: str = ""
     reason: str = ""
 
@@ -43,6 +45,7 @@ def _runtime_mcp(
     executable_names: Sequence[str],
     config_paths: Sequence[str],
     documentation: str,
+    minimum_version: str = "not-pinned",
 ) -> HostSpec:
     return HostSpec(
         host_id=host_id,
@@ -51,6 +54,15 @@ def _runtime_mcp(
         config_paths=tuple(config_paths),
         capability="runtime-mcp",
         contract="delegated-to-runtime",
+        minimum_version=minimum_version,
+        verification_command=(
+            "simplicio",
+            "mcp",
+            "register",
+            "--binary",
+            "<absolute-path>",
+            "--json",
+        ),
         documentation=documentation,
         reason="The Runtime owns the atomic MCP/native-hook registration.",
     )
@@ -65,6 +77,7 @@ def _unverified(host_id: str, name: str, documentation: str, reason: str) -> Hos
         name=name,
         capability="unsupported",
         contract="unverified",
+        verification_command=(),
         documentation=documentation,
         reason=reason,
     )
@@ -138,6 +151,8 @@ HOSTS: Tuple[HostSpec, ...] = (
         executable_names=("orca",),
         capability="portable-cli",
         contract="documented-cli",
+        minimum_version="not-pinned",
+        verification_command=("orca", "status", "--json"),
         documentation="https://www.onorca.dev/docs/cli/overview",
         reason="Use the documented Orca skills/MCP path; do not alter worktrees.",
     ),
@@ -251,6 +266,8 @@ def detect_hosts(
                 "status": status,
                 "capability": spec.capability,
                 "contract": spec.contract,
+                "minimum_version": spec.minimum_version,
+                "verification": list(spec.verification_command),
                 "executable": executable_paths[0] if executable_paths else None,
                 "app": app_paths[0] if app_paths else None,
                 "config": config_paths[0] if config_paths else None,

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -24,6 +24,7 @@ def _command(path: Path) -> None:
 def test_matrix_has_unique_ids_and_all_parent_children() -> None:
     ids = [spec.host_id for spec in HOSTS]
     assert len(ids) == len(set(ids))
+    assert all(spec.minimum_version for spec in HOSTS)
     for expected in {
         "claude-code",
         "cursor",
@@ -53,6 +54,15 @@ def test_detection_uses_exact_executable_and_app_evidence(tmp_path: Path) -> Non
     assert by_id["claude-code"]["executable"].endswith("/claude")
     assert by_id["cursor"]["status"] == "absent"
     assert by_id["deepseek-harness"]["status"] == "unsupported"
+
+
+def test_claude_code_has_runtime_verification_contract() -> None:
+    claude = next(spec for spec in HOSTS if spec.host_id == "claude-code")
+    assert claude.executable_names == ("claude",)
+    assert claude.config_paths == ("~/.claude/settings.json", "~/.claude/.mcp.json")
+    assert claude.capability == "runtime-mcp"
+    assert claude.verification_command[-1] == "--json"
+    assert "<absolute-path>" in claude.verification_command
 
 
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- define Claude Code's exact executable/configuration contract in the shared host registry
- expose minimum-version and verification-command fields in the machine-readable receipt
- keep Claude integration Runtime-delegated and isolated from Codex-only hooks
- add focused contract coverage

Closes #147

## Validation

- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Claude contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed

The local container has no pytest executable; the PR records this rather than claiming the pytest suite was run.