### PR TITLE
feat(installer): declare Cursor integration scopes

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -35,6 +35,12 @@ those files. Verification is the Runtime registration receipt produced by
 `simplicio mcp register --binary <absolute-path> --json`, and the Runtime is
 responsible for the atomic merge and rollback of the host configuration.
 
+Cursor is detected only through the exact `cursor` executable. The registry
+declares both user (`~/.cursor/mcp.json`) and workspace (`.cursor/mcp.json`)
+scopes, with user scope as the default. The Runtime receives the selected
+scope and must preserve every unrelated provider, rule, extension, and MCP
+entry when reconciling the managed server.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -35,6 +35,8 @@ class HostSpec:
     contract: str = "unknown"
     minimum_version: str = "unknown"
     verification_command: Tuple[str, ...] = ()
+    scopes: Tuple[str, ...] = ("user",)
+    default_scope: str = "user"
     documentation: str = ""
     reason: str = ""
 
@@ -46,6 +48,8 @@ def _runtime_mcp(
     config_paths: Sequence[str],
     documentation: str,
     minimum_version: str = "not-pinned",
+    scopes: Sequence[str] = ("user",),
+    default_scope: str = "user",
 ) -> HostSpec:
     return HostSpec(
         host_id=host_id,
@@ -63,6 +67,8 @@ def _runtime_mcp(
             "<absolute-path>",
             "--json",
         ),
+        scopes=tuple(scopes),
+        default_scope=default_scope,
         documentation=documentation,
         reason="The Runtime owns the atomic MCP/native-hook registration.",
     )
@@ -97,6 +103,8 @@ HOSTS: Tuple[HostSpec, ...] = (
         ("cursor",),
         ("~/.cursor/mcp.json", ".cursor/mcp.json"),
         "https://cursor.com/cli",
+        scopes=("user", "workspace"),
+        default_scope="user",
     ),
     _unverified(
         "deepseek-harness",
@@ -117,6 +125,8 @@ HOSTS: Tuple[HostSpec, ...] = (
         ("code", "code-insiders"),
         ("~/.vscode/mcp.json", ".vscode/mcp.json"),
         "https://code.visualstudio.com/docs/copilot/chat/mcp-servers",
+        scopes=("user", "workspace", "remote"),
+        default_scope="user",
     ),
     _unverified(
         "antigravity",
@@ -268,6 +278,8 @@ def detect_hosts(
                 "contract": spec.contract,
                 "minimum_version": spec.minimum_version,
                 "verification": list(spec.verification_command),
+                "scopes": list(spec.scopes),
+                "default_scope": spec.default_scope,
                 "executable": executable_paths[0] if executable_paths else None,
                 "app": app_paths[0] if app_paths else None,
                 "config": config_paths[0] if config_paths else None,

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -65,6 +65,14 @@ def test_claude_code_has_runtime_verification_contract() -> None:
     assert "<absolute-path>" in claude.verification_command
 
 
+def test_cursor_declares_user_and_workspace_scopes() -> None:
+    cursor = next(spec for spec in HOSTS if spec.host_id == "cursor")
+    assert cursor.executable_names == ("cursor",)
+    assert cursor.scopes == ("user", "workspace")
+    assert cursor.default_scope == "user"
+    assert cursor.config_paths == ("~/.cursor/mcp.json", ".cursor/mcp.json")
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- declare Cursor's exact executable probe and config paths
- expose user/workspace scopes with user as the default
- keep registration Runtime-owned and idempotent

Closes #148

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Cursor scope contract smoke test: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment