### PR TITLE
feat(installer): fail closed for unverified DeepSeek Harness

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -41,6 +41,12 @@ scopes, with user scope as the default. The Runtime receives the selected
 scope and must preserve every unrelated provider, rule, extension, and MCP
 entry when reconciling the managed server.
 
+DeepSeek Harness is intentionally fail-closed. No executable name or
+verification command is registered until the official harness plugin/MCP
+contract is confirmed. It therefore appears as `unsupported`/`unverified`
+instead of treating a similarly named binary or arbitrary configuration file
+as proof of compatibility.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -73,6 +73,14 @@ def test_cursor_declares_user_and_workspace_scopes() -> None:
     assert cursor.config_paths == ("~/.cursor/mcp.json", ".cursor/mcp.json")
 
 
+def test_deepseek_harness_is_fail_closed_until_contract_is_verified() -> None:
+    deepseek = next(spec for spec in HOSTS if spec.host_id == "deepseek-harness")
+    assert deepseek.executable_names == ()
+    assert deepseek.capability == "unsupported"
+    assert deepseek.contract == "unverified"
+    assert deepseek.verification_command == ()
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- keep DeepSeek Harness out of automatic executable detection until its official contract is verified
- add a regression contract test and document the fail-closed behavior

Closes #149

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- DeepSeek fail-closed contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment