### PR TITLE
feat(installer): verify OpenCode registration metadata

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -47,6 +47,11 @@ contract is confirmed. It therefore appears as `unsupported`/`unverified`
 instead of treating a similarly named binary or arbitrary configuration file
 as proof of compatibility.
 
+OpenCode uses the exact `opencode` executable probe and its documented user or
+workspace configuration locations (`~/.config/opencode/opencode.json` and
+`opencode.json`). Registration and verification remain delegated to the
+Runtime; the installer does not parse or rewrite OpenCode configuration.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -81,6 +81,15 @@ def test_deepseek_harness_is_fail_closed_until_contract_is_verified() -> None:
     assert deepseek.verification_command == ()
 
 
+def test_opencode_has_runtime_registration_contract() -> None:
+    opencode = next(spec for spec in HOSTS if spec.host_id == "opencode")
+    assert opencode.executable_names == ("opencode",)
+    assert opencode.config_paths == ("~/.config/opencode/opencode.json", "opencode.json")
+    assert opencode.capability == "runtime-mcp"
+    assert opencode.verification_command[:3] == ("simplicio", "mcp", "register")
+    assert opencode.default_scope == "user"
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- add the exact OpenCode executable probe and documented config locations
- cover the Runtime registration contract with a regression test

Closes #150

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- OpenCode contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment