### PR TITLE
feat(installer): declare VS Code integration scopes

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -52,6 +52,11 @@ workspace configuration locations (`~/.config/opencode/opencode.json` and
 `opencode.json`). Registration and verification remain delegated to the
 Runtime; the installer does not parse or rewrite OpenCode configuration.
 
+Visual Studio Code is probed through the exact `code` or `code-insiders`
+executable. Its registry entry declares user (`~/.vscode/mcp.json`), workspace
+(`.vscode/mcp.json`), and remote scopes, with user scope as the default. The
+Runtime owns the JSON merge and returns the verification receipt.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -90,6 +90,15 @@ def test_opencode_has_runtime_registration_contract() -> None:
     assert opencode.default_scope == "user"
 
 
+def test_vscode_declares_all_supported_configuration_scopes() -> None:
+    vscode = next(spec for spec in HOSTS if spec.host_id == "vscode")
+    assert vscode.executable_names == ("code", "code-insiders")
+    assert vscode.scopes == ("user", "workspace", "remote")
+    assert vscode.default_scope == "user"
+    assert vscode.config_paths == ("~/.vscode/mcp.json", ".vscode/mcp.json")
+    assert vscode.verification_command[-1] == "--json"
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- document exact `code`/`code-insiders` probes
- declare user, workspace, and remote scopes with user as default
- cover the Runtime registration metadata with a regression test

Closes #151

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- VS Code scope contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment