### PR TITLE
feat(installer): fail closed for unverified Antigravity

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -57,6 +57,12 @@ executable. Its registry entry declares user (`~/.vscode/mcp.json`), workspace
 (`.vscode/mcp.json`), and remote scopes, with user scope as the default. The
 Runtime owns the JSON merge and returns the verification receipt.
 
+Google Antigravity remains fail-closed until its official executable and
+extension/MCP contract are publicly confirmed. The registry keeps its
+documentation pointer but intentionally supplies no executable probe or
+verification command, so an unrelated binary cannot be reported as a working
+integration.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -99,6 +99,14 @@ def test_vscode_declares_all_supported_configuration_scopes() -> None:
     assert vscode.verification_command[-1] == "--json"
 
 
+def test_antigravity_is_fail_closed_until_public_contract_is_verified() -> None:
+    antigravity = next(spec for spec in HOSTS if spec.host_id == "antigravity")
+    assert antigravity.executable_names == ()
+    assert antigravity.capability == "unsupported"
+    assert antigravity.contract == "unverified"
+    assert antigravity.verification_command == ()
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- preserve Antigravity documentation metadata
- disable executable detection and verification until the official public contract is confirmed
- add a regression test for the fail-closed behavior

Closes #152

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Antigravity fail-closed contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment