### PR TITLE
feat(installer): verify Kiro registration metadata

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -63,6 +63,11 @@ documentation pointer but intentionally supplies no executable probe or
 verification command, so an unrelated binary cannot be reported as a working
 integration.
 
+Kiro uses the exact `kiro-cli` probe and the documented user/workspace MCP
+locations (`~/.kiro/settings/mcp.json` and `.kiro/settings/mcp.json`). The
+Runtime performs the idempotent registration and provides the JSON receipt;
+the public installer does not edit Kiro files directly.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -107,6 +107,14 @@ def test_antigravity_is_fail_closed_until_public_contract_is_verified() -> None:
     assert antigravity.verification_command == ()
 
 
+def test_kiro_has_runtime_registration_contract() -> None:
+    kiro = next(spec for spec in HOSTS if spec.host_id == "kiro")
+    assert kiro.executable_names == ("kiro-cli",)
+    assert kiro.config_paths == ("~/.kiro/settings/mcp.json", ".kiro/settings/mcp.json")
+    assert kiro.capability == "runtime-mcp"
+    assert kiro.verification_command[:3] == ("simplicio", "mcp", "register")
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- add the exact `kiro-cli` probe and documented MCP config locations
- cover Kiro's Runtime registration metadata with a regression test

Closes #153

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Kiro contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment