### PR TITLE
feat(installer): verify Orca portable CLI metadata

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -73,6 +73,11 @@ commands, `pi` and `omp`, respectively. Their Runtime registration metadata is
 kept distinct so installing one cannot be used as evidence that the other is
 present; both use the Runtime receipt for verification.
 
+OrcaDev / Orca ADE is represented as a `portable-cli` entry. The exact probe is
+`orca`, and verification is the non-mutating `orca status --json` command.
+Installer work stays outside project worktrees; host-specific skills and MCP
+behavior remain owned by Orca's documented CLI contract.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -125,6 +125,15 @@ def test_pi_and_oh_my_pi_use_separate_exact_host_entries() -> None:
     assert pi.verification_command == omp.verification_command
 
 
+def test_orca_uses_portable_cli_verification_without_worktree_mutation() -> None:
+    orca = next(spec for spec in HOSTS if spec.host_id == "orca")
+    assert orca.executable_names == ("orca",)
+    assert orca.capability == "portable-cli"
+    assert orca.contract == "documented-cli"
+    assert orca.verification_command == ("orca", "status", "--json")
+    assert "worktrees" in orca.reason
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- declare Orca as a portable CLI integration
- verify with the non-mutating `orca status --json` command
- document that installer work stays outside worktrees

Closes #155

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Orca portable-cli contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment