### PR TITLE
feat(installer): complete remaining host compatibility matrix

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -28,6 +28,14 @@ CLI path. DeepSeek Harness, Antigravity, Command Code, and the remaining
 compatibility-matrix entries remain explicit `unsupported`/`unverified` until
 their canonical upstream contract is confirmed.
 
+The compatibility matrix contains all 22 remaining names requested by the
+registry issue: Grok, GitHub Copilot, MiMo Code, Amp, OpenClaude, oh-my-pi,
+Hermes Agent, Devin, Goose, Auggie, Autohand Code, Charm/Crush, Cline,
+Codebuff, Command Code, Continue, Droid, Kilocode, Kimi, Mistral Vibe, Qwen
+Code, and Rovo Dev. The existing oh-my-pi adapter is the only row in this set
+with a verified Runtime contract; every other row is explicit
+`unsupported`/`unverified` and has no guessed executable probe.
+
 Claude Code is detected only through the exact `claude` executable. Its
 supported configuration locations are `~/.claude/settings.json` and
 `~/.claude/.mcp.json`; the public installer does not copy Codex-only hooks into

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -198,6 +198,36 @@ REMAINING_HOSTS: Tuple[Tuple[str, str, str], ...] = (
     ("rovo-dev", "Rovo Dev", "https://www.atlassian.com/software/rovo"),
 )
 
+# Names requested by the compatibility-matrix issue.  Entries that already
+# have a dedicated adapter (currently oh-my-pi) remain represented by that
+# adapter; every other row is explicit and fail-closed until verified.
+COMPATIBILITY_MATRIX_HOST_IDS = frozenset(
+    {
+        "grok",
+        "github-copilot",
+        "mimo-code",
+        "amp",
+        "openclaude",
+        "oh-my-pi",
+        "hermes-agent",
+        "devin",
+        "goose",
+        "auggie",
+        "autohand-code",
+        "charm-crush",
+        "cline",
+        "codebuff",
+        "command-code",
+        "continue",
+        "droid",
+        "kilocode",
+        "kimi",
+        "mistral-vibe",
+        "qwen-code",
+        "rovo-dev",
+    }
+)
+
 HOSTS = HOSTS + tuple(
     _unverified(host_id, name, docs, "The public contract is not verified; automatic detection is disabled.")
     for host_id, name, docs in REMAINING_HOSTS

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -9,6 +9,7 @@ PACKAGE_ROOT = Path(__file__).parents[1] / "pypi" / "simplicio"
 sys.path.insert(0, str(PACKAGE_ROOT))
 
 from simplicio.host_integrations import (
+    COMPATIBILITY_MATRIX_HOST_IDS,
     HOSTS,
     build_summary,
     detect_hosts,
@@ -132,6 +133,17 @@ def test_orca_uses_portable_cli_verification_without_worktree_mutation() -> None
     assert orca.contract == "documented-cli"
     assert orca.verification_command == ("orca", "status", "--json")
     assert "worktrees" in orca.reason
+
+
+def test_compatibility_matrix_covers_every_requested_remaining_host() -> None:
+    by_id = {spec.host_id: spec for spec in HOSTS}
+    assert COMPATIBILITY_MATRIX_HOST_IDS <= set(by_id)
+    assert len(COMPATIBILITY_MATRIX_HOST_IDS) == 22
+    for host_id in COMPATIBILITY_MATRIX_HOST_IDS - {"oh-my-pi"}:
+        spec = by_id[host_id]
+        assert spec.contract == "unverified"
+        assert spec.capability == "unsupported"
+        assert spec.executable_names == ()
 
 
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add one canonical set of the 22 names from the remaining compatibility-matrix scope
- assert every named row is represented
- keep unverified rows fail-closed with no guessed executable probes

Closes #156

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- compatibility matrix completeness smoke: PASS (22 rows)
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment