### PR TITLE
feat(installer): fail closed for unverified Command Code

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -86,6 +86,11 @@ OrcaDev / Orca ADE is represented as a `portable-cli` entry. The exact probe is
 Installer work stays outside project worktrees; host-specific skills and MCP
 behavior remain owned by Orca's documented CLI contract.
 
+Command Code follows the same fail-closed rule as the other unverified rows.
+Until its official executable and plugin/MCP contract are confirmed, the
+registry records the product name and documentation pointer only. It does not
+launch a guessed command or claim that a configuration file proves support.
+
 ## Opt-out and scope
 
 Skip every host with a comma-separated list or one host with an environment

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -146,6 +146,14 @@ def test_compatibility_matrix_covers_every_requested_remaining_host() -> None:
         assert spec.executable_names == ()
 
 
+def test_command_code_is_fail_closed_until_official_contract_is_confirmed() -> None:
+    command_code = next(spec for spec in HOSTS if spec.host_id == "command-code")
+    assert command_code.executable_names == ()
+    assert command_code.capability == "unsupported"
+    assert command_code.contract == "unverified"
+    assert command_code.verification_command == ()
+
+
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- keep Command Code explicit in the host registry
- disable guessed executable detection and verification until the official contract is confirmed
- add a regression test and operator documentation

Closes #157

## Validation
- `python3 -m compileall -q pypi/simplicio/simplicio tests/test_host_integrations.py`
- `git diff --check`
- Command Code fail-closed contract smoke: PASS
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment