### PR TITLE
feat(bootstrap): publish desktop and cli profile contract

### DIFF
--- a/distribution/bootstrap-profiles.json
+++ b/distribution/bootstrap-profiles.json
@@ -1,0 +1,59 @@
+{
+  "schema": "simplicio.bootstrap-profiles/v1",
+  "download_options": [
+    {
+      "id": "recommended-desktop",
+      "label": "Desktop",
+      "recommended": true,
+      "channel": "desktop",
+      "entrypoint": "https://github.com/wesleysimplicio/simplicio-agent/releases/latest",
+      "bootstrap_command": "simplicio bootstrap apply --profile recommended-desktop --auto",
+      "shared_state_profile": "recommended",
+      "component_lock": "shared",
+      "includes": [
+        "runtime",
+        "cli",
+        "daemon-or-sidecar",
+        "neural-database",
+        "skills-index",
+        "managed-integrations",
+        "updater",
+        "rollback-metadata",
+        "uninstall-ledger",
+        "savings-validation-receipts"
+      ],
+      "excludes": []
+    },
+    {
+      "id": "recommended-cli",
+      "label": "CLI only",
+      "recommended": false,
+      "channel": "cli",
+      "entrypoint": "https://pypi.org/project/simplicio/",
+      "bootstrap_command": "simplicio bootstrap apply --profile recommended-cli --auto",
+      "shared_state_profile": "recommended",
+      "component_lock": "shared",
+      "includes": [
+        "runtime",
+        "cli",
+        "neural-database",
+        "skills-index",
+        "managed-integrations",
+        "updater",
+        "rollback-metadata",
+        "uninstall-ledger",
+        "savings-validation-receipts"
+      ],
+      "excludes": ["desktop-shell"]
+    }
+  ],
+  "invariants": {
+    "exactly_two_download_options": true,
+    "desktop_includes_cli": true,
+    "shared_transaction_contract": "simplicio.bootstrap/v1",
+    "shared_component_lock": true,
+    "login_is_the_only_happy_path_consent": true,
+    "no_unverified_download_execution": true,
+    "per_user_by_default": true
+  }
+}

--- a/docs/BOOTSTRAP_PROFILES.md
+++ b/docs/BOOTSTRAP_PROFILES.md
@@ -1,0 +1,31 @@
+# Bootstrap profiles
+
+The public download surface offers exactly two channels:
+
+1. `recommended-desktop` — the recommended signed Desktop shell. Desktop
+   includes the CLI and bootstraps the Runtime, state, skills, managed
+   integrations, updater, rollback metadata, uninstall ledger, and savings
+   receipts after login.
+2. `recommended-cli` — a per-user CLI bootstrap for terminals and headless
+   environments. It uses the same Runtime transaction, component lock, state
+   profile, and receipts, but excludes the Desktop shell.
+
+The machine-readable contract is
+[`distribution/bootstrap-profiles.json`](../distribution/bootstrap-profiles.json).
+The Runtime and Desktop repositories own the implementation of the transaction;
+this repository owns the stable public profile IDs and download choices.
+
+## Happy path
+
+```text
+Desktop download → open → login → bootstrap apply → ready
+CLI bootstrap    → login → bootstrap apply → ready
+```
+
+The application must not add a mode wizard, technical preflight, embedded
+terminal, or second consent step to this path. Every channel derives from the
+same signed release/component lock and must verify before execution.
+
+Installers prefer per-user locations, stage before switching, preserve healthy
+state on failure, and keep managed integration edits reversible. They never
+copy provider credentials or bypass operating-system security prompts.

--- a/landing.html
+++ b/landing.html
@@ -89,13 +89,13 @@ footer a{color:#0066cc;text-decoration:none}
 </section>
 
 <section id="download" class="dark">
-<h2>Baixe e experimente.</h2>
-<p>7 dias grátis · R$ 99/mês · Cancele quando quiser</p>
+<h2>Get Simplicio.</h2>
+<p>Escolha seu canal antes de instalar. Depois do login, ele configura tudo.</p>
 <div style="margin:20px 0">
-<a href="download/Simplicio-Agent-1.8.0-arm64.dmg" class="btn-pill blue">⬇ Apple Silicon</a>
-<a href="download/Simplicio-Agent-1.8.0-x64.dmg" class="btn-pill outline">⬇ Intel</a>
+<a href="https://github.com/wesleysimplicio/simplicio-agent/releases/latest" class="btn-pill blue" data-bootstrap-profile="recommended-desktop">⬇ Desktop · recomendado</a>
+<a href="https://pypi.org/project/simplicio/" class="btn-pill outline" data-bootstrap-profile="recommended-cli">⬇ CLI only</a>
 </div>
-<div style="font-size:12px;color:rgba(255,255,255,0.3)">v3.0.0 · macOS 13+ · DeepSeek incluso</div>
+<div style="font-size:12px;color:rgba(255,255,255,0.3)">Um perfil, um Runtime, um estado compartilhado</div>
 </section>
 
 <footer>

--- a/tests/test_bootstrap_profiles.py
+++ b/tests/test_bootstrap_profiles.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_public_bootstrap_contract_has_exactly_two_shared_profiles() -> None:
+    contract = json.loads(
+        (ROOT / "distribution" / "bootstrap-profiles.json").read_text(encoding="utf-8")
+    )
+    profiles = contract["download_options"]
+    assert contract["schema"] == "simplicio.bootstrap-profiles/v1"
+    assert [profile["id"] for profile in profiles] == [
+        "recommended-desktop",
+        "recommended-cli",
+    ]
+    assert len(profiles) == 2
+    assert profiles[0]["recommended"] is True
+    assert profiles[0]["component_lock"] == profiles[1]["component_lock"] == "shared"
+    assert profiles[0]["shared_state_profile"] == profiles[1]["shared_state_profile"] == "recommended"
+    assert "cli" in profiles[0]["includes"]
+    assert "desktop-shell" in profiles[1]["excludes"]
+    assert contract["invariants"]["exactly_two_download_options"] is True
+
+
+def test_landing_surface_exposes_desktop_and_cli_only_once() -> None:
+    landing = (ROOT / "landing.html").read_text(encoding="utf-8")
+    assert landing.count('data-bootstrap-profile="recommended-desktop"') == 1
+    assert landing.count('data-bootstrap-profile="recommended-cli"') == 1
+    assert "Desktop · recomendado" in landing
+    assert "CLI only" in landing


### PR DESCRIPTION
## Summary
- publish a machine-readable `recommended-desktop`/`recommended-cli` contract
- update the landing page to expose exactly those two download choices
- guarantee a shared component lock/state profile and desktop-includes-CLI invariant
- document the public boundary with Runtime/Desktop implementations

Closes #111

## Validation
- bootstrap profile contract smoke: PASS (2 options, shared lock)
- `python3 -m compileall -q tests/test_bootstrap_profiles.py`
- `git diff --check`
- `node tests/node/installer-unit.test.cjs`: 12 passed, 0 failed
- `pytest` unavailable in the execution environment