### PR TITLE
feat(plugins): add transactional host integration orchestrator

### DIFF
--- a/pypi/simplicio/simplicio/host_adapters.py
+++ b/pypi/simplicio/simplicio/host_adapters.py
@@ -1,0 +1,243 @@
+"""Bounded, transactional host integration orchestration.
+
+The Runtime remains the authority for live MCP handshakes.  This module owns
+the installer-side mechanics that are safe to exercise without starting a
+host: selecting a documented scope, merging the portable MCP entry, keeping
+unrelated configuration byte-for-byte equivalent, and emitting evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .host_integrations import HOSTS, HostSpec, detect_hosts
+
+
+SCHEMA = "simplicio.host-adapters/v1"
+MANAGED_SERVER = "simplicio"
+TRUTHY = frozenset(("1", "true", "yes", "on"))
+
+
+@dataclass(frozen=True)
+class IntegrationResult:
+    host_id: str
+    status: str
+    scope: str
+    config: str | None
+    capability: str
+    verification: str
+    reason_code: str
+    changed: bool = False
+    backup: str | None = None
+
+
+def _is_truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in TRUTHY
+
+
+def _safe_binary(binary: str | os.PathLike[str]) -> str:
+    path = Path(binary).expanduser()
+    if not path.is_absolute() or not path.name:
+        raise ValueError("binary must be an absolute executable path")
+    return str(path)
+
+
+def _entry(binary: str) -> dict[str, Any]:
+    return {
+        "command": binary,
+        "args": ["serve", "--mcp", "--stdio"],
+    }
+
+
+def _digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _scope_path(spec: HostSpec, *, scope: str, home: Path, cwd: Path) -> Path | None:
+    if scope not in spec.scopes:
+        return None
+    candidates = spec.config_paths
+    if scope == "user":
+        candidates = tuple(item for item in candidates if item.startswith("~/"))
+    elif scope == "workspace":
+        candidates = tuple(item for item in candidates if not item.startswith("~/"))
+    elif scope == "remote":
+        candidates = tuple(item for item in candidates if not item.startswith("~/"))
+    for raw in candidates:
+        if raw.startswith("~/"):
+            return home / raw[2:]
+        return cwd / raw
+    return None
+
+
+def _load_json(path: Path) -> tuple[dict[str, Any], bytes, str | None]:
+    if not path.exists():
+        return {}, b"", None
+    raw = path.read_bytes()
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {}, raw, "malformed_config"
+    if not isinstance(value, dict):
+        return {}, raw, "malformed_config"
+    return value, raw, None
+
+
+def _merge_mcp(document: dict[str, Any], binary: str) -> tuple[dict[str, Any], str]:
+    result = json.loads(json.dumps(document, ensure_ascii=False))
+    key = "mcpServers" if isinstance(result.get("mcpServers"), dict) else "servers"
+    servers = result.setdefault(key, {})
+    if not isinstance(servers, dict):
+        raise ValueError("MCP server collection must be an object")
+    servers[MANAGED_SERVER] = _entry(binary)
+    return result, key
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    temporary = Path(raw)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_one(spec: HostSpec, path: Path, binary: str, *, dry_run: bool) -> IntegrationResult:
+    document, before, error = _load_json(path)
+    if error:
+        return IntegrationResult(spec.host_id, "failed", "", str(path), spec.capability, "none", error)
+    try:
+        merged, _ = _merge_mcp(document, binary)
+        encoded = (json.dumps(merged, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    except (TypeError, ValueError):
+        return IntegrationResult(spec.host_id, "failed", "", str(path), spec.capability, "none", "invalid_mcp_document")
+    changed = encoded != before
+    backup: str | None = None
+    if changed and not dry_run:
+        try:
+            if path.exists():
+                backup_path = path.with_name(path.name + ".simplicio.bak")
+                shutil.copy2(path, backup_path)
+                backup = str(backup_path)
+            _atomic_write(path, encoded)
+            round_trip, _, round_trip_error = _load_json(path)
+            servers = round_trip.get("mcpServers", round_trip.get("servers", {}))
+            if round_trip_error or not isinstance(servers, dict) or servers.get(MANAGED_SERVER) != _entry(binary):
+                raise OSError("managed entry did not survive the atomic write")
+        except (OSError, ValueError):
+            if backup and Path(backup).exists():
+                shutil.copy2(backup, path)
+            return IntegrationResult(spec.host_id, "failed", "", str(path), spec.capability, "none", "write_or_verify_failed")
+    return IntegrationResult(
+        spec.host_id,
+        "planned" if dry_run else "registered",
+        "",
+        str(path),
+        spec.capability,
+        "config_roundtrip" if not dry_run else "dry_run",
+        "already_registered" if not changed else "registered",
+        changed=changed,
+        backup=backup,
+    )
+
+
+def install_detected_hosts(
+    binary: str | os.PathLike[str],
+    *,
+    home: Path | None = None,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    scope: str | None = None,
+    dry_run: bool = False,
+    specs: Iterable[HostSpec] = HOSTS,
+) -> dict[str, Any]:
+    """Install every detected supported integration and isolate failures."""
+
+    binary_path = _safe_binary(binary)
+    environment = dict(os.environ if env is None else env)
+    resolved_home = (home or Path.home()).expanduser().resolve()
+    resolved_cwd = (cwd or Path.cwd()).resolve()
+    chosen_scope = scope or environment.get("SIMPLICIO_HOST_SCOPE", "user")
+    if chosen_scope not in {"user", "workspace", "remote"}:
+        raise ValueError("scope must be user, workspace, or remote")
+    detections = {str(item["id"]): item for item in detect_hosts(resolved_home, environment, specs)}
+    results: list[IntegrationResult] = []
+    for spec in specs:
+        observed = detections[spec.host_id]
+        status = str(observed["status"])
+        if status in {"absent", "skipped", "unsupported"}:
+            results.append(IntegrationResult(spec.host_id, status, chosen_scope, None, spec.capability, "none", status))
+            continue
+        if spec.contract == "unverified":
+            results.append(IntegrationResult(spec.host_id, "unsupported", chosen_scope, None, spec.capability, "none", "contract_unverified"))
+            continue
+        if spec.capability == "portable-cli":
+            results.append(IntegrationResult(spec.host_id, "detected", chosen_scope, None, spec.capability, "portable_cli", "manual_host_verification"))
+            continue
+        path = _scope_path(spec, scope=chosen_scope, home=resolved_home, cwd=resolved_cwd)
+        if path is None:
+            results.append(IntegrationResult(spec.host_id, "failed", chosen_scope, None, spec.capability, "none", "scope_unsupported"))
+            continue
+        item = _write_one(spec, path, binary_path, dry_run=dry_run)
+        results.append(
+            IntegrationResult(
+                item.host_id,
+                item.status,
+                chosen_scope,
+                item.config,
+                item.capability,
+                item.verification,
+                item.reason_code,
+                item.changed,
+                item.backup,
+            )
+        )
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    return {
+        "schema": SCHEMA,
+        "binary": binary_path,
+        "scope": chosen_scope,
+        "dry_run": dry_run,
+        "runtime_installation": "one_binary",
+        "results": [asdict(result) for result in results],
+        "counts": counts,
+        "failed_hosts": [result.host_id for result in results if result.status == "failed"],
+        "verification": "config_roundtrip_only; live_handshake_remains_runtime_owned",
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Install detected Simplicio host integrations transactionally.")
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--home", type=Path, default=Path.home())
+    parser.add_argument("--cwd", type=Path, default=Path.cwd())
+    parser.add_argument("--scope", choices=("user", "workspace", "remote"))
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    result = install_detected_hosts(args.binary, home=args.home, cwd=args.cwd, scope=args.scope, dry_run=args.dry_run)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) if args.json else "\n".join(
+        f"{item['host_id']}: {item['status']} ({item['reason_code']})" for item in result["results"]
+    ))
+    return int(bool(result["failed_hosts"]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from simplicio.host_adapters import install_detected_hosts
+from simplicio.host_integrations import HostSpec
+
+
+def _command(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _spec(host_id: str = "fixture") -> HostSpec:
+    return HostSpec(
+        host_id=host_id,
+        name="Fixture Host",
+        executable_names=(host_id,),
+        config_paths=("~/.fixture/config.json",),
+        capability="runtime-mcp",
+        contract="delegated-to-runtime",
+        scopes=("user",),
+    )
+
+
+def test_multi_host_install_preserves_unrelated_json_and_is_idempotent(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "fixture")
+    home = tmp_path / "home"
+    config = home / ".fixture" / "config.json"
+    config.parent.mkdir(parents=True)
+    original = {"theme": "dark", "servers": {"other": {"command": "other"}}}
+    config.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+    first = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio",
+        home=home,
+        cwd=tmp_path,
+        env={"PATH": str(bin_dir)},
+        specs=(_spec(),),
+    )
+    assert first["failed_hosts"] == []
+    assert first["counts"]["registered"] == 1
+    assert json.loads(config.read_text(encoding="utf-8"))["theme"] == "dark"
+    assert config.with_name("config.json.simplicio.bak").is_file()
+
+    second = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio",
+        home=home,
+        cwd=tmp_path,
+        env={"PATH": str(bin_dir)},
+        specs=(_spec(),),
+    )
+    assert second["failed_hosts"] == []
+    assert second["results"][0]["reason_code"] == "already_registered"
+
+
+def test_dry_run_and_skip_do_not_mutate_files(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "fixture")
+    home = tmp_path / "home"
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio",
+        home=home,
+        cwd=tmp_path,
+        env={"PATH": str(bin_dir), "SIMPLICIO_SKIP_FIXTURE": "1"},
+        dry_run=True,
+        specs=(_spec(),),
+    )
+    assert result["counts"] == {"skipped": 1}
+    assert not home.exists()
+
+
+def test_malformed_config_isolated_as_failure(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "fixture")
+    home = tmp_path / "home"
+    config = home / ".fixture" / "config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("not json", encoding="utf-8")
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio",
+        home=home,
+        cwd=tmp_path,
+        env={"PATH": str(bin_dir)},
+        specs=(_spec(),),
+    )
+    assert result["failed_hosts"] == ["fixture"]
+    assert config.read_text(encoding="utf-8") == "not json"


### PR DESCRIPTION
Closes #146

Adds a bounded host integration orchestrator with exact executable detection, per-host isolation, user/workspace scope selection, atomic JSON MCP registration, backups, rollback, idempotence, dry-run, opt-out support, and redacted structured evidence.

Validation: `PYTHONPATH=pypi/simplicio python -m pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` (19 passed).