### PR TITLE
fix(plugins): fail closed for DeepSeek Harness (#149)

### DIFF
--- a/docs/hosts/deepseek-harness.md
+++ b/docs/hosts/deepseek-harness.md
@@ -1,0 +1,11 @@
+# DeepSeek Harness status
+
+DeepSeek Harness remains deliberately fail-closed. The repository does not
+have a verified canonical executable name, configuration location, or
+official MCP/plugin contract for this host, so the compatibility matrix does
+not probe guessed commands and the installer makes no changes.
+
+When an upstream contract is available, add its exact probe, scope, and
+verification command to `host_integrations.py`, then add a clean-profile
+fixture and live Runtime evidence before enabling automatic registration. A
+detected-looking binary must not be enough to opt into the integration.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -141,3 +141,32 @@ def test_cursor_contract_selects_requested_user_or_workspace_scope(tmp_path: Pat
     assert workspace_result["failed_hosts"] == []
     assert json.loads((home / ".cursor/mcp.json").read_text())["mcpServers"]["simplicio"]
     assert json.loads((workspace / ".cursor/mcp.json").read_text())["mcpServers"]["simplicio"]
+
+
+def test_unverified_deepseek_harness_fails_closed_without_mutation(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "deepseek-harness")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "deepseek")
+    home = tmp_path / "home"
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio",
+        home=home,
+        cwd=tmp_path,
+        env={"PATH": str(bin_dir)},
+        specs=(spec,),
+    )
+
+    assert result["failed_hosts"] == []
+    assert result["results"] == [{
+        "host_id": "deepseek-harness",
+        "status": "unsupported",
+        "scope": "user",
+        "config": None,
+        "capability": "unsupported",
+        "verification": "none",
+        "reason_code": "unsupported",
+        "changed": False,
+        "backup": None,
+    }]
+    assert not home.exists()


### PR DESCRIPTION
Closes #149

Adds explicit documentation and a fixture proving that an unverified DeepSeek Harness executable cannot trigger detection or mutate configuration.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 22 passed.