### PR TITLE
feat(plugins): add OpenCode contract (#150)

### DIFF
--- a/docs/hosts/opencode.md
+++ b/docs/hosts/opencode.md
@@ -1,0 +1,12 @@
+# OpenCode integration
+
+OpenCode is detected only by the exact `opencode` executable. Its user-scoped
+MCP document is `~/.config/opencode/opencode.json`; workspace registration is
+not inferred because it is not part of the verified contract in this matrix.
+
+The installer preserves unrelated JSON, writes the managed `simplicio` entry
+atomically, verifies the round trip, and keeps a recovery backup. Runtime
+handshake evidence is reported separately from this config-level proof.
+
+Use `--dry-run` to preview the change or `SIMPLICIO_SKIP_OPENCODE=1` to opt
+out. No provider credentials or prompt content are written by the adapter.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -170,3 +170,24 @@ def test_unverified_deepseek_harness_fails_closed_without_mutation(tmp_path: Pat
         "backup": None,
     }]
     assert not home.exists()
+
+
+def test_opencode_contract_registers_documented_user_config(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "opencode")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "opencode")
+    home = tmp_path / "home"
+    config = home / ".config/opencode/opencode.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(json.dumps({"provider": "local"}) + "\n", encoding="utf-8")
+
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(spec,)
+    )
+
+    assert result["failed_hosts"] == []
+    document = json.loads(config.read_text(encoding="utf-8"))
+    assert document["provider"] == "local"
+    assert document["mcpServers"]["simplicio"]["args"] == ["serve", "--mcp", "--stdio"]


### PR DESCRIPTION
Closes #150

Documents and verifies exact OpenCode detection and registration into its documented user config while preserving existing settings.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 23 passed.