### PR TITLE
feat(plugins): add VS Code scope contract (#151)

### DIFF
--- a/docs/hosts/vscode.md
+++ b/docs/hosts/vscode.md
@@ -1,0 +1,15 @@
+# Visual Studio Code integration
+
+Visual Studio Code is detected by the exact `code` or `code-insiders`
+executable. The adapter supports the three documented scopes:
+
+- user: `~/.vscode/mcp.json`
+- workspace: `.vscode/mcp.json` in the workspace
+- remote: `.vscode/mcp.json` in the selected remote workspace
+
+The requested scope is explicit and never silently falls back to another one.
+Registration preserves unrelated settings, uses an atomic replacement with a
+backup, and verifies the managed MCP entry after writing. Runtime owns the
+live handshake and remote-session evidence.
+
+Preview with `--dry-run`; opt out with `SIMPLICIO_SKIP_VSCODE=1`.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -191,3 +191,24 @@ def test_opencode_contract_registers_documented_user_config(tmp_path: Path) -> N
     document = json.loads(config.read_text(encoding="utf-8"))
     assert document["provider"] == "local"
     assert document["mcpServers"]["simplicio"]["args"] == ["serve", "--mcp", "--stdio"]
+
+
+def test_vscode_contract_supports_user_workspace_and_remote_scopes(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "vscode")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "code")
+    home = tmp_path / "home"
+    workspace = tmp_path / "remote-workspace"
+    (home / ".vscode").mkdir(parents=True)
+    (workspace / ".vscode").mkdir(parents=True)
+
+    for scope in ("user", "workspace", "remote"):
+        result = install_detected_hosts(
+            "/opt/simplicio/bin/simplicio", home=home, cwd=workspace,
+            env={"PATH": str(bin_dir)}, scope=scope, specs=(spec,)
+        )
+        assert result["failed_hosts"] == []
+
+    assert json.loads((home / ".vscode/mcp.json").read_text())["mcpServers"]["simplicio"]
+    assert json.loads((workspace / ".vscode/mcp.json").read_text())["mcpServers"]["simplicio"]


### PR DESCRIPTION
Closes #151

Documents and verifies exact VS Code/Insiders detection with explicit user, workspace, and remote scope registration.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 24 passed.