### PR TITLE
fix(plugins): keep Antigravity fail closed (#152)

### DIFF
--- a/docs/hosts/antigravity.md
+++ b/docs/hosts/antigravity.md
@@ -1,0 +1,12 @@
+# Google Antigravity status
+
+Antigravity is represented in the compatibility matrix but remains
+unsupported until its canonical executable and official extension/MCP
+contract are verified. The installer intentionally does not guess a binary
+name or configuration file and therefore cannot mutate a user's setup based
+on a coincidental executable.
+
+Enabling this row requires upstream documentation, an exact probe, an
+atomic/idempotent fixture, and live Runtime handshake evidence. Until then,
+the UI should surface the reason as unsupported rather than as an install
+failure.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -212,3 +212,17 @@ def test_vscode_contract_supports_user_workspace_and_remote_scopes(tmp_path: Pat
 
     assert json.loads((home / ".vscode/mcp.json").read_text())["mcpServers"]["simplicio"]
     assert json.loads((workspace / ".vscode/mcp.json").read_text())["mcpServers"]["simplicio"]
+
+
+def test_unverified_antigravity_is_reported_without_guessing_a_binary(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "antigravity")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "antigravity")
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=tmp_path / "home", cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(spec,)
+    )
+
+    assert result["results"][0]["status"] == "unsupported"
+    assert result["results"][0]["reason_code"] == "unsupported"


### PR DESCRIPTION
Closes #152

Adds explicit unsupported-status documentation and a regression fixture proving Antigravity cannot be enabled through a guessed executable.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 25 passed.