### PR TITLE
feat(plugins): add Kiro contract (#153)

### DIFF
--- a/docs/hosts/kiro.md
+++ b/docs/hosts/kiro.md
@@ -1,0 +1,13 @@
+# Kiro integration
+
+Kiro is detected by the exact `kiro-cli` executable. The default user-scoped
+configuration is `~/.kiro/settings/mcp.json`; the workspace equivalent is
+`.kiro/settings/mcp.json` when `--scope workspace` is selected.
+
+The adapter writes only the managed `simplicio` MCP entry, preserves unrelated
+settings, makes a backup before atomic replacement, and verifies the result.
+Repeated installation is idempotent. The Runtime, not the installer, owns
+the live MCP handshake.
+
+Use `--dry-run` for a no-write preview and
+`SIMPLICIO_SKIP_KIRO=1` to opt out.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -226,3 +226,27 @@ def test_unverified_antigravity_is_reported_without_guessing_a_binary(tmp_path: 
 
     assert result["results"][0]["status"] == "unsupported"
     assert result["results"][0]["reason_code"] == "unsupported"
+
+
+def test_kiro_contract_is_atomic_and_idempotent(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "kiro")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "kiro-cli")
+    home = tmp_path / "home"
+    config = home / ".kiro/settings/mcp.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(json.dumps({"enabled": True}) + "\n", encoding="utf-8")
+
+    first = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(spec,)
+    )
+    second = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(spec,)
+    )
+
+    assert first["failed_hosts"] == []
+    assert second["results"][0]["reason_code"] == "already_registered"
+    assert json.loads(config.read_text())["enabled"] is True


### PR DESCRIPTION
Closes #153

Adds the exact Kiro CLI contract, user/workspace scope documentation, and idempotent atomic registration coverage.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 26 passed.