### PR TITLE
feat(plugins): separate Pi and oh-my-pi contracts (#154)

### DIFF
--- a/docs/hosts/pi.md
+++ b/docs/hosts/pi.md
@@ -1,0 +1,14 @@
+# Pi and oh-my-pi integrations
+
+Pi and oh-my-pi are separate hosts with separate exact probes:
+
+- Pi: `pi`, user MCP file `~/.pi/agent/mcp.json`
+- oh-my-pi: `omp`, user MCP file `~/.omp/mcp.json`
+
+Neither name is treated as an alias for the other. The installer preserves
+unrelated entries, writes each managed entry atomically, verifies the JSON
+round trip, and is idempotent. Runtime owns live handshakes and any host-side
+plugin semantics.
+
+Use `--dry-run` or the corresponding `SIMPLICIO_SKIP_PI=1` and
+`SIMPLICIO_SKIP_OH_MY_PI=1` opt-outs before changing either host.

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -145,14 +145,14 @@ HOSTS: Tuple[HostSpec, ...] = (
         "pi",
         "Pi",
         ("pi",),
-        ("~/.pi/agent",),
+        ("~/.pi/agent/mcp.json",),
         "https://pi.dev/",
     ),
     _runtime_mcp(
         "oh-my-pi",
         "oh-my-pi",
         ("omp",),
-        ("~/.omp",),
+        ("~/.omp/mcp.json",),
         "https://omp.sh/",
     ),
     HostSpec(

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -250,3 +250,29 @@ def test_kiro_contract_is_atomic_and_idempotent(tmp_path: Path) -> None:
     assert first["failed_hosts"] == []
     assert second["results"][0]["reason_code"] == "already_registered"
     assert json.loads(config.read_text())["enabled"] is True
+
+
+def test_pi_and_oh_my_pi_use_separate_exact_executables_and_configs(tmp_path: Path) -> None:
+    pi = next(item for item in HOSTS if item.host_id == "pi")
+    omp = next(item for item in HOSTS if item.host_id == "oh-my-pi")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "pi")
+    _command(bin_dir / "omp")
+    home = tmp_path / "home"
+
+    pi_result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(pi,)
+    )
+    omp_result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(omp,)
+    )
+
+    assert pi_result["failed_hosts"] == []
+    assert omp_result["failed_hosts"] == []
+    assert (home / ".pi/agent/mcp.json").is_file()
+    assert (home / ".omp/mcp.json").is_file()
+    assert json.loads((home / ".pi/agent/mcp.json").read_text())["mcpServers"]["simplicio"]
+    assert json.loads((home / ".omp/mcp.json").read_text())["mcpServers"]["simplicio"]


### PR DESCRIPTION
Closes #154

Separates exact `pi` and `omp` detection and user MCP configuration paths, with independent idempotence coverage and documentation.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 27 passed.