### PR TITLE
feat(plugins): add Orca verification-only plan (#155)

### DIFF
--- a/docs/hosts/orca.md
+++ b/docs/hosts/orca.md
@@ -1,0 +1,10 @@
+# OrcaDev / Orca ADE integration
+
+Orca uses the exact `orca` executable and a portable CLI verification plan:
+`orca status --json`. Simplicio does not rewrite Orca configuration, install
+skills, mutate worktrees, or read credentials for this host.
+
+The plan is evidence-only and can be surfaced to the Runtime/UI for an
+explicit verification step. A detected Orca binary is therefore reported as
+detected with `manual_host_verification`, while live host semantics remain
+outside the installer.

--- a/pypi/simplicio/simplicio/host_adapters.py
+++ b/pypi/simplicio/simplicio/host_adapters.py
@@ -56,6 +56,26 @@ def _entry(binary: str) -> dict[str, Any]:
     }
 
 
+def portable_cli_plan(spec: HostSpec, executable: str) -> dict[str, Any]:
+    """Return a verification-only plan for hosts without an MCP writer.
+
+    Portable hosts are intentionally never configured by this module.  The
+    plan is safe to show in a receipt or UI and leaves worktrees, credentials,
+    and host state untouched.
+    """
+
+    if spec.capability != "portable-cli" or not spec.verification_command:
+        raise ValueError("host does not expose a portable CLI contract")
+    command = tuple(spec.verification_command)
+    return {
+        "host_id": spec.host_id,
+        "argv": [executable, *command[1:]],
+        "verification_only": True,
+        "mutates_worktree": False,
+        "reads_credentials": False,
+    }
+
+
 def _digest(value: bytes) -> str:
     return "sha256:" + hashlib.sha256(value).hexdigest()
 

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from simplicio.host_adapters import install_detected_hosts
+from simplicio.host_adapters import install_detected_hosts, portable_cli_plan
 from simplicio.host_integrations import HOSTS, HostSpec
 
 
@@ -276,3 +276,15 @@ def test_pi_and_oh_my_pi_use_separate_exact_executables_and_configs(tmp_path: Pa
     assert (home / ".omp/mcp.json").is_file()
     assert json.loads((home / ".pi/agent/mcp.json").read_text())["mcpServers"]["simplicio"]
     assert json.loads((home / ".omp/mcp.json").read_text())["mcpServers"]["simplicio"]
+
+
+def test_orca_portable_contract_is_verification_only() -> None:
+    spec = next(item for item in HOSTS if item.host_id == "orca")
+    plan = portable_cli_plan(spec, "/usr/local/bin/orca")
+    assert plan == {
+        "host_id": "orca",
+        "argv": ["/usr/local/bin/orca", "status", "--json"],
+        "verification_only": True,
+        "mutates_worktree": False,
+        "reads_credentials": False,
+    }


### PR DESCRIPTION
Closes #155

Adds a portable Orca status plan with explicit no-worktree-mutation and no-credential-read invariants, plus documentation and regression coverage.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 28 passed.