### PR TITLE
feat(plugins): publish complete compatibility matrix (#156)

### DIFF
--- a/docs/hosts/compatibility-matrix.md
+++ b/docs/hosts/compatibility-matrix.md
@@ -1,0 +1,42 @@
+# Compatibility matrix
+
+The installer exposes this matrix through `compatibility_matrix()` and keeps
+every row explicit. Detection is exact and non-invasive; `unsupported` rows
+have no guessed executable and no automatic configuration writer.
+
+| Host | Capability | Contract | Probe |
+| --- | --- | --- | --- |
+| Claude Code | runtime-mcp | delegated-to-runtime | `claude` |
+| Cursor | runtime-mcp | delegated-to-runtime | `cursor` |
+| DeepSeek Harness | unsupported | unverified | — |
+| OpenCode | runtime-mcp | delegated-to-runtime | `opencode` |
+| Visual Studio Code | runtime-mcp | delegated-to-runtime | `code`, `code-insiders` |
+| Google Antigravity | unsupported | unverified | — |
+| Kiro | runtime-mcp | delegated-to-runtime | `kiro-cli` |
+| Pi | runtime-mcp | delegated-to-runtime | `pi` |
+| oh-my-pi | runtime-mcp | delegated-to-runtime | `omp` |
+| OrcaDev / Orca ADE | portable-cli | documented-cli | `orca status --json` |
+| Command Code | unsupported | unverified | — |
+| Grok | unsupported | unverified | — |
+| GitHub Copilot | unsupported | unverified | — |
+| MiMo Code | unsupported | unverified | — |
+| Amp | unsupported | unverified | — |
+| OpenClaude | unsupported | unverified | — |
+| Hermes Agent | unsupported | unverified | — |
+| Devin | unsupported | unverified | — |
+| Goose | unsupported | unverified | — |
+| Auggie | unsupported | unverified | — |
+| Autohand Code | unsupported | unverified | — |
+| Charm/Crush | unsupported | unverified | — |
+| Cline | unsupported | unverified | — |
+| Codebuff | unsupported | unverified | — |
+| Continue | unsupported | unverified | — |
+| Droid | unsupported | unverified | — |
+| Kilocode | unsupported | unverified | — |
+| Kimi | unsupported | unverified | — |
+| Mistral Vibe | unsupported | unverified | — |
+| Qwen Code | unsupported | unverified | — |
+| Rovo Dev | unsupported | unverified | — |
+
+The returned matrix contains only public contract metadata. It never includes
+credentials, prompt bodies, configuration bodies, or host process output.

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -234,6 +234,24 @@ HOSTS = HOSTS + tuple(
 )
 
 
+def compatibility_matrix() -> Tuple[Dict[str, object], ...]:
+    """Expose the complete, redacted host contract table for UIs and CI."""
+
+    return tuple(
+        {
+            "id": spec.host_id,
+            "name": spec.name,
+            "capability": spec.capability,
+            "contract": spec.contract,
+            "executable_names": list(spec.executable_names),
+            "scopes": list(spec.scopes),
+            "verification": list(spec.verification_command),
+            "documentation": spec.documentation,
+        }
+        for spec in HOSTS
+    )
+
+
 def _home_path(value: str, home: Path) -> Path:
     if value.startswith("~/"):
         return home / value[2:]

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -12,6 +12,7 @@ from simplicio.host_integrations import (
     COMPATIBILITY_MATRIX_HOST_IDS,
     HOSTS,
     build_summary,
+    compatibility_matrix,
     detect_hosts,
     write_summary,
 )
@@ -144,6 +145,21 @@ def test_compatibility_matrix_covers_every_requested_remaining_host() -> None:
         assert spec.contract == "unverified"
         assert spec.capability == "unsupported"
         assert spec.executable_names == ()
+
+
+def test_compatibility_matrix_is_complete_and_redacted() -> None:
+    matrix = compatibility_matrix()
+    assert len(matrix) == len(HOSTS)
+    assert {row["id"] for row in matrix} == {spec.host_id for spec in HOSTS}
+    for row in matrix:
+        assert set(row) == {
+            "id", "name", "capability", "contract", "executable_names",
+            "scopes", "verification", "documentation",
+        }
+        assert "token" not in json.dumps(row).lower()
+        if row["contract"] == "unverified":
+            assert row["capability"] == "unsupported"
+            assert row["executable_names"] == []
 
 
 def test_command_code_is_fail_closed_until_official_contract_is_confirmed() -> None:


### PR DESCRIPTION
Closes #156

Adds a machine-readable redacted compatibility matrix, complete host coverage, and explicit fail-closed tests/docs for every remaining provider.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 29 passed.