### PR TITLE
fix(plugins): keep Command Code fail closed (#157)

### DIFF
--- a/docs/hosts/command-code.md
+++ b/docs/hosts/command-code.md
@@ -1,0 +1,10 @@
+# Command Code status
+
+Command Code is listed for compatibility tracking, but automatic integration
+is disabled until its canonical executable, config scope, and official
+plugin/MCP contract are confirmed. No guessed command is probed and no
+configuration is changed when a similarly named executable is present.
+
+The enablement gate is intentionally evidence-based: upstream contract,
+clean-profile fixture, idempotent/atomic registration, and live Runtime
+verification must all exist before this row can leave `unsupported`.

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -288,3 +288,18 @@ def test_orca_portable_contract_is_verification_only() -> None:
         "mutates_worktree": False,
         "reads_credentials": False,
     }
+
+
+def test_command_code_contract_requires_an_official_contract(tmp_path: Path) -> None:
+    spec = next(item for item in HOSTS if item.host_id == "command-code")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _command(bin_dir / "command-code")
+    home = tmp_path / "home"
+    result = install_detected_hosts(
+        "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
+        env={"PATH": str(bin_dir)}, specs=(spec,)
+    )
+    assert result["results"][0]["status"] == "unsupported"
+    assert result["results"][0]["reason_code"] == "unsupported"
+    assert not home.exists()


### PR DESCRIPTION
Closes #157

Adds explicit contract-gating documentation and regression coverage proving that guessed Command Code binaries cannot enable an integration.

Validation: `pytest -q tests/test_host_adapters.py tests/test_host_integrations.py` — 30 passed.