### PR TITLE
feat(desktop): document and test Desktop v1 shell (#171)

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -39,6 +39,18 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("Demonstração");
   });
 
+  it("exposes the complete v1 shell only after active access", () => {
+    const html = renderToStaticMarkup(
+      <DesktopApp snapshot={createDemoSnapshot("active")} />,
+    );
+    expect(html).toContain("Início");
+    expect(html).toContain("Providers");
+    expect(html).toContain("Atividade");
+    expect(html).toContain("Memória");
+    expect(html).toContain("Configurações");
+    expect(html).toContain("v3.8.36");
+  });
+
   it("does not invent cost or cache metrics without evidence", () => {
     const snapshot = createDemoSnapshot("active");
     snapshot.savings.estimatedUsd = null;

--- a/docs/desktop/IMPLEMENTATION.md
+++ b/docs/desktop/IMPLEMENTATION.md
@@ -1,0 +1,33 @@
+# Desktop v1 implementation contract
+
+`apps/desktop` is the Tauri 2 + React/TypeScript shell. It has one authority
+boundary: the Tauri process invokes the signed Simplicio Runtime sidecar and
+the UI renders only the versioned `simplicio.desktop-snapshot/v1` response.
+
+The application has four access states:
+
+| State | Runtime behavior | UI behavior |
+| --- | --- | --- |
+| `signed_out` | not started | Google login entry point |
+| `inactive` | disabled | subscription and refresh actions |
+| `unknown` | disabled | diagnostic refresh, never treated as unpaid |
+| `active` | snapshot-backed | Home, Providers, Activity, Memory, Settings |
+
+The snapshot is bounded to 65,536 bytes, five activity rows, and 32 providers.
+It is redacted at the boundary: paths, configuration bodies, credentials,
+prompts, skill bodies, and raw ledgers never reach the UI contract. Optional
+Fast is not required and never injects into hooks.
+
+All mutations are represented as governed, non-executed actions in the
+snapshot and are dispatched through the bridge. The frontend never starts a
+shell command, stores a token, or claims a provider handshake without a
+Runtime receipt. Browser preview uses labelled demo data only; the packaged
+Tauri path fails closed on an invalid or missing snapshot.
+
+Local acceptance:
+
+```bash
+npm test
+npm run build
+cargo test --manifest-path src-tauri/Cargo.toml
+```


### PR DESCRIPTION
Closes #171

Consolidates the Desktop v1 ownership boundary, access-state behavior, snapshot limits/redaction, and governed-action contract, with shell coverage for all v1 routes.

Validation: `npm test` (6 passed); `npm run build` passed.