### PR TITLE
feat(desktop): add bounded memory surface (#172)

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { DesktopApp } from "./App";
 import { createDemoSnapshot } from "./demo";
+import { MemoryScreen } from "./screens/MemoryScreen";
 
 describe("Simplicio Desktop product states", () => {
   it("offers browser login when there is no identity", () => {
@@ -59,5 +60,13 @@ describe("Simplicio Desktop product states", () => {
     const html = renderToStaticMarkup(<DesktopApp snapshot={snapshot} />);
     expect(html).toContain("sem telemetria");
     expect(html).not.toContain("0% telemetria do provider");
+  });
+
+  it("renders bounded memory metadata without exposing the map", () => {
+    const html = renderToStaticMarkup(<MemoryScreen snapshot={createDemoSnapshot("active")} />);
+    expect(html).toContain("Pronto para reutilizar");
+    expect(html).toContain("preview-20260828");
+    expect(html).toContain("Entrega protegida por recibo");
+    expect(html).not.toContain("repo_map");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { AccessGate, LoadingScreen, SignInScreen } from "./screens/AccessScreens
 import { HomeScreen } from "./screens/HomeScreen";
 import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { SecondaryScreen } from "./screens/SecondaryScreen";
+import { MemoryScreen } from "./screens/MemoryScreen";
 
 function initialView(): View {
   if (typeof window === "undefined") return "home";
@@ -122,7 +123,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       {view === "providers" && (
         <ProvidersScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} />
       )}
-      {view !== "home" && view !== "providers" && <SecondaryScreen view={view} snapshot={snapshot} />}
+      {view === "memory" && <MemoryScreen snapshot={snapshot} />}
+      {view !== "home" && view !== "providers" && view !== "memory" && <SecondaryScreen view={view} snapshot={snapshot} />}
     </Shell>
   );
 }

--- a/apps/desktop/src/screens/MemoryScreen.tsx
+++ b/apps/desktop/src/screens/MemoryScreen.tsx
@@ -1,0 +1,45 @@
+import type { DesktopSnapshot } from "../contracts";
+import { Glyph } from "../components/Brand";
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "indisponível";
+  return `${Math.round(bytes / 1024)} KB`;
+}
+
+export function MemoryScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
+  const map = snapshot.savings.mapCache;
+  const fast = snapshot.runtime.optionalFast;
+  return (
+    <div className="page secondary-page">
+      <section className="page-heading">
+        <div>
+          <span className="eyebrow">Local</span>
+          <h1>Memória</h1>
+          <p>Frescor, tamanho e origem do contexto determinístico.</p>
+        </div>
+      </section>
+      <section className="memory-grid">
+        <article className="panel memory-hero">
+          <div className="secondary-visual"><Glyph name="memory" size={34} /></div>
+          <span className="eyebrow">Mapa do repositório</span>
+          <h2>{map.status === "ready" ? "Pronto para reutilizar" : "Aguardando recibo"}</h2>
+          <p>Somente metadados bounded chegam ao Desktop; o conteúdo completo permanece no Runtime.</p>
+        </article>
+        <article className="panel memory-facts">
+          <h3>Estado do cache</h3>
+          <dl>
+            <div><dt>Status</dt><dd>{map.status}</dd></div>
+            <div><dt>Geração</dt><dd>{map.generation ?? "indisponível"}</dd></div>
+            <div><dt>Tamanho</dt><dd>{formatBytes(map.bytes)}</dd></div>
+            <div><dt>Digest</dt><dd>{map.digest ? `${map.digest.slice(0, 18)}…` : "indisponível"}</dd></div>
+          </dl>
+          <div className="memory-boundary">
+            <span className="status-dot online" />
+            <span>Entrega protegida por recibo</span>
+          </div>
+          <p className="memory-note">Fast opcional: {fast.required ? "requerido" : "não requerido"}; injeção em hooks: {fast.hookInjected ? "sim" : "não"}.</p>
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1371,6 +1371,29 @@ p { margin-top: 0; }
 .secondary-facts dt { color: #999487; }
 .secondary-facts dd { color: #66675f; }
 
+.memory-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.8fr);
+  gap: 11px;
+}
+
+.memory-hero,
+.memory-facts { padding: 23px; }
+
+.memory-hero { min-height: 285px; }
+.memory-hero h2 { margin-bottom: 7px; font-size: 21px; letter-spacing: -0.035em; }
+.memory-hero p { max-width: 390px; margin: 0; color: #838074; font-size: 10px; line-height: 1.5; }
+.memory-facts h3 { margin-bottom: 14px; font-size: 12px; }
+.memory-facts dl { margin: 0; }
+.memory-facts dl > div { min-height: 36px; padding: 8px 0; border-bottom: 1px solid var(--line-soft); display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.memory-facts dt,
+.memory-facts dd { margin: 0; font: 8px/1.25 var(--mono); }
+.memory-facts dt { color: #999487; }
+.memory-facts dd { max-width: 170px; overflow: hidden; color: #66675f; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
+.memory-boundary { margin-top: 18px; padding: 9px; border: 1px solid #c9ddc5; border-radius: 8px; display: flex; align-items: center; gap: 7px; color: var(--green-dark); background: var(--green-pale); font: 8px/1.2 var(--mono); }
+.memory-note { margin: 12px 0 0; color: #999487; font-size: 9px; line-height: 1.45; }
+
 @media (max-width: 1080px) {
   .metrics-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .metric-primary { grid-column: 1 / -1; }


### PR DESCRIPTION
Closes #172

Adds the Memory screen with bounded map-cache metadata, generation/digest/size visibility, protected receipt-only messaging, and Fast hook-boundary status. No full map or prompt content is exposed.

Validation: `npm test` (7 passed); `npm run build` passed.