### PR TITLE
feat(desktop): add account settings and safe diagnostics (#173)

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DesktopApp } from "./App";
 import { createDemoSnapshot } from "./demo";
 import { MemoryScreen } from "./screens/MemoryScreen";
+import { SettingsScreen, redactedDiagnostic } from "./screens/SettingsScreen";
 
 describe("Simplicio Desktop product states", () => {
   it("offers browser login when there is no identity", () => {
@@ -68,5 +69,16 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("preview-20260828");
     expect(html).toContain("Entrega protegida por recibo");
     expect(html).not.toContain("repo_map");
+  });
+
+  it("offers account diagnostics and a redacted export", () => {
+    const snapshot = createDemoSnapshot("active");
+    const html = renderToStaticMarkup(<SettingsScreen snapshot={snapshot} busy={false} onRefresh={() => undefined} onSubscribe={() => undefined} />);
+    const diagnostic = redactedDiagnostic(snapshot);
+    expect(html).toContain("Gerenciar plano");
+    expect(html).toContain("Exportar diagnóstico");
+    expect(html).toContain("Atualizar estado");
+    expect(JSON.stringify(diagnostic)).not.toContain("voce@example.com");
+    expect(JSON.stringify(diagnostic)).not.toContain("sonnet");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,6 +12,7 @@ import { HomeScreen } from "./screens/HomeScreen";
 import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { SecondaryScreen } from "./screens/SecondaryScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
+import { SettingsScreen } from "./screens/SettingsScreen";
 
 function initialView(): View {
   if (typeof window === "undefined") return "home";
@@ -124,7 +125,10 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         <ProvidersScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} />
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
-      {view !== "home" && view !== "providers" && view !== "memory" && <SecondaryScreen view={view} snapshot={snapshot} />}
+      {view === "settings" && (
+        <SettingsScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} onSubscribe={subscribe} />
+      )}
+      {view !== "home" && view !== "providers" && view !== "memory" && view !== "settings" && <SecondaryScreen view={view} snapshot={snapshot} />}
     </Shell>
   );
 }

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -1,0 +1,78 @@
+import type { DesktopSnapshot } from "../contracts";
+import { Glyph } from "../components/Brand";
+
+export function redactedDiagnostic(snapshot: DesktopSnapshot) {
+  return {
+    schema: "simplicio.desktop-diagnostic/v1",
+    generatedAt: snapshot.generatedAt,
+    source: snapshot.source,
+    access: { state: snapshot.access.state, plan: snapshot.access.plan, reasonCode: snapshot.access.reasonCode },
+    runtime: { state: snapshot.runtime.state, version: snapshot.runtime.version, transport: snapshot.runtime.transport },
+    savings: { proofKind: snapshot.savings.proofKind, ledgerStatus: snapshot.savings.ledgerStatus, eventCount: snapshot.savings.eventCount },
+    providers: snapshot.providers.map(({ id, state, reasonCode }) => ({ id, state, reasonCode })),
+    redaction: snapshot.redaction,
+  };
+}
+
+function downloadDiagnostic(snapshot: DesktopSnapshot) {
+  if (typeof document === "undefined") return;
+  const payload = JSON.stringify(redactedDiagnostic(snapshot), null, 2);
+  const url = URL.createObjectURL(new Blob([payload], { type: "application/json" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "simplicio-diagnostic.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function SettingsScreen({
+  snapshot,
+  busy,
+  onRefresh,
+  onSubscribe,
+}: {
+  snapshot: DesktopSnapshot;
+  busy: boolean;
+  onRefresh: () => void;
+  onSubscribe: () => void;
+}) {
+  return (
+    <div className="page secondary-page">
+      <section className="page-heading">
+        <div>
+          <span className="eyebrow">Preferências</span>
+          <h1>Configurações</h1>
+          <p>Conta, atualização e diagnóstico sem expor dados sensíveis.</p>
+        </div>
+      </section>
+      <section className="settings-grid">
+        <article className="panel settings-card">
+          <div className="settings-card-heading"><Glyph name="settings" size={20} /><div><span className="eyebrow">Conta</span><h2>{snapshot.access.plan ?? "Simplicio"}</h2></div></div>
+          <dl>
+            <div><dt>Acesso</dt><dd>{snapshot.access.state}</dd></div>
+            <div><dt>Identidade</dt><dd>{snapshot.access.identityKnown ? "confirmada" : "não disponível"}</dd></div>
+            <div><dt>Expiração</dt><dd>{snapshot.access.expiresAt ? new Date(snapshot.access.expiresAt).toLocaleDateString("pt-BR") : "não informada"}</dd></div>
+          </dl>
+          <button className="button button-secondary button-wide" type="button" onClick={onSubscribe}>Gerenciar plano</button>
+        </article>
+        <article className="panel settings-card">
+          <div className="settings-card-heading"><Glyph name="activity" size={20} /><div><span className="eyebrow">Diagnóstico</span><h2>Estado do Runtime</h2></div></div>
+          <dl>
+            <div><dt>Versão</dt><dd>{snapshot.runtime.version || "indisponível"}</dd></div>
+            <div><dt>Transporte</dt><dd>{snapshot.runtime.transport}</dd></div>
+            <div><dt>Última leitura</dt><dd>{snapshot.runtime.lastReceiptAt ? new Date(snapshot.runtime.lastReceiptAt).toLocaleString("pt-BR") : "sem recibo"}</dd></div>
+          </dl>
+          <div className="settings-actions">
+            <button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}>{busy ? "Atualizando…" : "Atualizar estado"}</button>
+            <button className="button button-secondary" type="button" onClick={() => downloadDiagnostic(snapshot)}>Exportar diagnóstico</button>
+          </div>
+          <p className="settings-note">O export omite email, caminhos, prompts, configurações, credenciais, skills e ledger bruto.</p>
+        </article>
+      </section>
+      <section className="panel settings-safety">
+        <Glyph name="lock" size={18} />
+        <div><span className="eyebrow">Privacidade</span><strong>Dados locais sob controle</strong><p>Para sair da conta ou desinstalar, use o fluxo da aplicação nativa; nenhum token é mantido nesta tela.</p></div>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1394,6 +1394,27 @@ p { margin-top: 0; }
 .memory-boundary { margin-top: 18px; padding: 9px; border: 1px solid #c9ddc5; border-radius: 8px; display: flex; align-items: center; gap: 7px; color: var(--green-dark); background: var(--green-pale); font: 8px/1.2 var(--mono); }
 .memory-note { margin: 12px 0 0; color: #999487; font-size: 9px; line-height: 1.45; }
 
+.settings-grid { min-width: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 11px; }
+.settings-card { min-height: 285px; padding: 21px; display: flex; flex-direction: column; }
+.settings-card-heading { display: flex; align-items: center; gap: 10px; }
+.settings-card-heading > .glyph { width: 36px; height: 36px; padding: 8px; border: 1px solid #bfd2b9; border-radius: 9px; color: var(--green-dark); background: var(--green-soft); }
+.settings-card-heading .eyebrow { margin-bottom: 3px; font-size: 8px; }
+.settings-card h2 { margin: 0; font-size: 15px; letter-spacing: -0.02em; }
+.settings-card dl { margin: 18px 0; }
+.settings-card dl > div { padding: 9px 0; border-bottom: 1px solid var(--line-soft); display: flex; justify-content: space-between; gap: 12px; }
+.settings-card dt, .settings-card dd { margin: 0; font: 8px/1.2 var(--mono); }
+.settings-card dt { color: #999487; }
+.settings-card dd { max-width: 180px; overflow: hidden; color: #66675f; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
+.settings-card > .button { margin-top: auto; }
+.settings-actions { margin-top: auto; display: flex; flex-wrap: wrap; gap: 7px; }
+.settings-actions .button { flex: 1 1 140px; }
+.settings-note { margin: 11px 0 0; color: #999487; font-size: 9px; line-height: 1.4; }
+.settings-safety { margin-top: 11px; padding: 15px 18px; display: flex; align-items: flex-start; gap: 11px; color: var(--green-dark); background: var(--green-pale); }
+.settings-safety > .glyph { flex: 0 0 auto; margin-top: 2px; }
+.settings-safety .eyebrow { margin-bottom: 3px; font-size: 8px; }
+.settings-safety strong { display: block; color: #465447; font-size: 11px; }
+.settings-safety p { margin: 4px 0 0; color: #7f897b; font-size: 9px; line-height: 1.4; }
+
 @media (max-width: 1080px) {
   .metrics-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .metric-primary { grid-column: 1 / -1; }


### PR DESCRIPTION
Closes #173

Adds the account/settings surface with Runtime refresh, subscription management, and a redacted diagnostic export. The export omits identity email, paths, prompts, configuration bodies, credentials, skills, and raw ledgers.

Validation: `npm test` (8 passed); `npm run build` passed.