### PR TITLE
feat(desktop): add bounded activity timeline (#174)

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -4,6 +4,7 @@ import { DesktopApp } from "./App";
 import { createDemoSnapshot } from "./demo";
 import { MemoryScreen } from "./screens/MemoryScreen";
 import { SettingsScreen, redactedDiagnostic } from "./screens/SettingsScreen";
+import { ActivityScreen, redactedActivity } from "./screens/ActivityScreen";
 
 describe("Simplicio Desktop product states", () => {
   it("offers browser login when there is no identity", () => {
@@ -80,5 +81,14 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("Atualizar estado");
     expect(JSON.stringify(diagnostic)).not.toContain("voce@example.com");
     expect(JSON.stringify(diagnostic)).not.toContain("sonnet");
+  });
+
+  it("renders bounded activity receipts and redacts details on export", () => {
+    const snapshot = createDemoSnapshot("active");
+    const html = renderToStaticMarkup(<ActivityScreen snapshot={snapshot} />);
+    expect(html).toContain("Exportar recibos");
+    expect(html).toContain("Todos");
+    expect(html).toContain("máximo 5");
+    expect(redactedActivity(snapshot.activity)[0]).not.toHaveProperty("detail");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,6 +13,7 @@ import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { SecondaryScreen } from "./screens/SecondaryScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
+import { ActivityScreen } from "./screens/ActivityScreen";
 
 function initialView(): View {
   if (typeof window === "undefined") return "home";
@@ -128,7 +129,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       {view === "settings" && (
         <SettingsScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} onSubscribe={subscribe} />
       )}
-      {view !== "home" && view !== "providers" && view !== "memory" && view !== "settings" && <SecondaryScreen view={view} snapshot={snapshot} />}
+      {view === "activity" && <ActivityScreen snapshot={snapshot} />}
+      {view !== "home" && view !== "providers" && view !== "memory" && view !== "settings" && view !== "activity" && <SecondaryScreen view={view} snapshot={snapshot} />}
     </Shell>
   );
 }

--- a/apps/desktop/src/screens/ActivityScreen.tsx
+++ b/apps/desktop/src/screens/ActivityScreen.tsx
@@ -1,0 +1,82 @@
+import { useMemo, useState } from "react";
+import type { ActivityItem, DesktopSnapshot } from "../contracts";
+import { Glyph } from "../components/Brand";
+
+type StatusFilter = "all" | ActivityItem["status"];
+
+export function redactedActivity(items: ActivityItem[]) {
+  return items.map(({ id, title, provider, savedTokens, occurredAt, status }) => ({
+    id, title, provider, savedTokens, occurredAt, status,
+  }));
+}
+
+function downloadActivity(items: ActivityItem[]) {
+  if (typeof document === "undefined") return;
+  const payload = JSON.stringify({ schema: "simplicio.activity-export/v1", items: redactedActivity(items) }, null, 2);
+  const url = URL.createObjectURL(new Blob([payload], { type: "application/json" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "simplicio-activity.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function statusLabel(status: ActivityItem["status"]): string {
+  return status === "verified" ? "verificado" : status === "running" ? "em execução" : "atenção";
+}
+
+export function ActivityScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [provider, setProvider] = useState("all");
+  const [page, setPage] = useState(0);
+  const pageSize = Math.max(1, Math.min(snapshot.limits.maxActivity, 5));
+  const providers = useMemo(() => Array.from(new Set(snapshot.activity.map((item) => item.provider))).sort(), [snapshot.activity]);
+  const filtered = snapshot.activity.filter((item) => (status === "all" || item.status === status) && (provider === "all" || item.provider === provider));
+  const visible = filtered.slice(page * pageSize, (page + 1) * pageSize);
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+  const shown = safePage === page ? visible : filtered.slice(safePage * pageSize, (safePage + 1) * pageSize);
+
+  return (
+    <div className="page secondary-page">
+      <section className="page-heading">
+        <div>
+          <span className="eyebrow">Recibos</span>
+          <h1>Atividade</h1>
+          <p>Execuções, cache e economia com evidência limitada ao snapshot.</p>
+        </div>
+        <button className="button button-secondary" type="button" onClick={() => downloadActivity(filtered)}>Exportar recibos</button>
+      </section>
+      <section className="panel activity-page-panel">
+        <div className="activity-toolbar">
+          <div className="segmented-control" aria-label="Filtrar por estado">
+            {(["all", "verified", "running", "attention"] as const).map((item) => (
+              <button key={item} className={status === item ? "active" : ""} type="button" onClick={() => { setStatus(item); setPage(0); }}>
+                {item === "all" ? "Todos" : statusLabel(item)}
+              </button>
+            ))}
+          </div>
+          <label className="activity-provider-filter">Provider
+            <select value={provider} onChange={(event) => { setProvider(event.target.value); setPage(0); }}>
+              <option value="all">Todos</option>
+              {providers.map((item) => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+        </div>
+        <div className="activity-page-list">
+          {shown.length === 0 ? <p className="empty-state">Nenhum recibo neste filtro.</p> : shown.map((item) => (
+            <article className="activity-page-row" key={item.id}>
+              <div className={`activity-status ${item.status === "attention" ? "attention" : ""}`}><Glyph name="activity" size={15} /></div>
+              <div className="activity-copy"><strong>{item.title}</strong><p>{item.detail}</p><span>{item.provider} · {new Date(item.occurredAt).toLocaleString("pt-BR")}</span></div>
+              <div className="activity-saving"><strong>−{item.savedTokens.toLocaleString("pt-BR")}</strong><span>tokens</span></div>
+            </article>
+          ))}
+        </div>
+        <footer className="activity-pagination">
+          <span>{filtered.length} recibo(s) · máximo {snapshot.limits.maxActivity}</span>
+          <div><button className="text-button" type="button" disabled={safePage === 0} onClick={() => setPage((current) => Math.max(0, current - 1))}>Anterior</button><span>Página {safePage + 1} de {pageCount}</span><button className="text-button" type="button" disabled={safePage >= pageCount - 1} onClick={() => setPage((current) => Math.min(pageCount - 1, current + 1))}>Próxima</button></div>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1415,6 +1415,19 @@ p { margin-top: 0; }
 .settings-safety strong { display: block; color: #465447; font-size: 11px; }
 .settings-safety p { margin: 4px 0 0; color: #7f897b; font-size: 9px; line-height: 1.4; }
 
+.activity-page-panel { padding: 18px; }
+.activity-toolbar { min-width: 0; margin-bottom: 13px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.activity-provider-filter { display: inline-flex; align-items: center; gap: 7px; color: #969184; font: 8px/1 var(--mono); }
+.activity-provider-filter select { min-height: 28px; padding: 0 25px 0 8px; border: 1px solid var(--line); border-radius: 7px; color: #66675f; background: var(--surface-strong); font: 9px/1 var(--mono); }
+.activity-page-list { border-top: 1px solid var(--line-soft); }
+.activity-page-row { min-width: 0; padding: 13px 0; border-bottom: 1px solid var(--line-soft); display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 11px; }
+.activity-page-row:last-child { border-bottom: 0; }
+.activity-page-row .activity-copy p { display: block; margin: 3px 0 0; color: #858276; font-size: 9px; }
+.activity-pagination { padding-top: 13px; display: flex; align-items: center; justify-content: space-between; gap: 12px; color: #969184; font: 8px/1.3 var(--mono); }
+.activity-pagination > div { display: flex; align-items: center; gap: 10px; }
+.activity-pagination .text-button { padding: 0; color: var(--green-dark); font: 8px/1 var(--mono); }
+.activity-pagination .text-button:disabled { color: #b2ad9f; cursor: default; }
+
 @media (max-width: 1080px) {
   .metrics-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .metric-primary { grid-column: 1 / -1; }


### PR DESCRIPTION
Closes #174

Replaces the Activity placeholder with a bounded receipt timeline, status/provider filters, pagination capped by the snapshot limit, and a redacted export that omits receipt details.

Validation: `npm test` (9 passed); `npm run build` passed.