### PR TITLE
feat(release): add signed Desktop release contract (#176)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      artifact_base_url:
+        description: Immutable staging URL containing the version segment
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: windows-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: setup_python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - id: install
+        run: python -m pip install -r requirements-quality.txt
+      - id: state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/verify_release_provenance.py state
+      - id: provenance
+        env:
+          ARTIFACT_BASE_URL: ${{ inputs.artifact_base_url }}
+          TAG_EXISTS: ${{ steps.state.outputs.tag_exists }}
+        run: python scripts/verify_release_provenance.py plan
+      - id: download
+        if: steps.provenance.outputs.mode == 'publish'
+        env:
+          ARTIFACT_BASE_URL: ${{ inputs.artifact_base_url }}
+        run: python scripts/verify_release_provenance.py download
+      - id: verify_staged
+        if: steps.provenance.outputs.mode == 'publish'
+        run: python scripts/verify_release_provenance.py verify-staged
+      - id: metadata
+        if: steps.provenance.outputs.mode == 'publish'
+        run: python scripts/verify_release_provenance.py metadata
+      - id: publish
+        if: steps.provenance.outputs.mode == 'publish'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.state.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: v${{ steps.state.outputs.version }} — Public Beta
+          body: |
+            Free public beta. All features remain unlocked during the public-beta phase.
+
+            Windows: `irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex`
+            macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.sh | sh`
+
+            Checksum-verified update manifest included (`simplicio update check`).
+          prerelease: false
+          make_latest: "true"
+          fail_on_unmatched_files: true
+          overwrite_files: false
+          files: dist/*

--- a/distribution/desktop-release.json
+++ b/distribution/desktop-release.json
@@ -1,0 +1,21 @@
+{
+  "schema": "simplicio.desktop-release/v1",
+  "artifact_policy": {
+    "signed": true,
+    "checksum": "SHA256",
+    "provenance": "required",
+    "sbom": "required"
+  },
+  "update_policy": {
+    "verify_before_install": true,
+    "stage_before_swap": true,
+    "rollback_on_start_failure": true,
+    "retain_previous": 1
+  },
+  "e2e_requirements": [
+    "manifest signature verifies",
+    "component lock matches staged files",
+    "fresh sidecar starts",
+    "failed start restores previous sidecar"
+  ]
+}

--- a/docs/desktop/RELEASE.md
+++ b/docs/desktop/RELEASE.md
@@ -1,0 +1,19 @@
+# Desktop release and updater contract
+
+Desktop artifacts are published only through the closed-world release
+workflow. A release is eligible when the signed manifest, SHA256 digests,
+SBOM, provenance records, and component lock all match the immutable staged
+bytes. The workflow refuses a remote release whose tag or asset digests have
+drifted.
+
+The updater follows a stage-before-swap transaction:
+
+1. download into an isolated staging directory;
+2. verify signature, checksum, provenance, and component membership;
+3. retain the current sidecar as the single rollback candidate;
+4. atomically switch the active sidecar;
+5. start the sidecar and restore the previous candidate if startup fails.
+
+The release acceptance suite must exercise both a successful fresh start and
+a failed-start rollback. The Desktop UI never presents an update as complete
+until the Runtime returns a healthy receipt.


### PR DESCRIPTION
Closes #176

Adds the closed-world release workflow contract, signed/checksummed/provenance-gated Desktop artifact policy, stage-before-swap updater requirements, rollback policy, and E2E acceptance requirements.

Validation: `pytest -q tests/test_verify_distribution_consistency.py tests/test_bench_verify_distribution_consistency.py tests/test_release_local_contract.py -k 'not powershell_parser'` — 26 passed, 1 environment-dependent test deselected.