### PR TITLE
feat(desktop): add bounded sidecar supervision (#177)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+mod supervisor;
+
 const SNAPSHOT_SCHEMA: &str = "simplicio.desktop-snapshot/v1";
 const MAX_SNAPSHOT_BYTES: usize = 65_536;
 const SNAPSHOT_ARGS: &[&str] = &["desktop", "snapshot", "--json"];

--- a/apps/desktop/src-tauri/src/supervisor.rs
+++ b/apps/desktop/src-tauri/src/supervisor.rs
@@ -1,0 +1,115 @@
+use std::time::Duration;
+
+const DEFAULT_MAX_RESTARTS: u8 = 3;
+const MAX_BACKOFF_SECONDS: u64 = 30;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SidecarState {
+    Stopped,
+    Starting { attempt: u8 },
+    Healthy,
+    Degraded { attempt: u8 },
+    Offline,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SidecarSupervisor {
+    state: SidecarState,
+    failures: u8,
+    max_restarts: u8,
+    backoff: Duration,
+}
+
+impl Default for SidecarSupervisor {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_RESTARTS)
+    }
+}
+
+impl SidecarSupervisor {
+    pub fn new(max_restarts: u8) -> Self {
+        Self {
+            state: SidecarState::Stopped,
+            failures: 0,
+            max_restarts,
+            backoff: Duration::ZERO,
+        }
+    }
+
+    pub fn state(&self) -> &SidecarState {
+        &self.state
+    }
+
+    pub fn begin_start(&mut self) -> bool {
+        if self.failures >= self.max_restarts {
+            self.state = SidecarState::Offline;
+            return false;
+        }
+        let attempt = self.failures.saturating_add(1);
+        self.state = SidecarState::Starting { attempt };
+        true
+    }
+
+    pub fn mark_healthy(&mut self) {
+        self.failures = 0;
+        self.backoff = Duration::ZERO;
+        self.state = SidecarState::Healthy;
+    }
+
+    pub fn mark_failed(&mut self) -> Duration {
+        self.failures = self.failures.saturating_add(1);
+        let seconds = 2u64.saturating_pow(self.failures.saturating_sub(1) as u32).min(MAX_BACKOFF_SECONDS);
+        self.backoff = Duration::from_secs(seconds);
+        self.state = if self.failures >= self.max_restarts {
+            SidecarState::Offline
+        } else {
+            SidecarState::Degraded { attempt: self.failures }
+        };
+        self.backoff
+    }
+
+    pub fn restart_allowed(&self) -> bool {
+        self.failures < self.max_restarts
+    }
+
+    pub fn backoff(&self) -> Duration {
+        self.backoff
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_healthy_and_resets_after_recovery() {
+        let mut supervisor = SidecarSupervisor::default();
+        assert!(supervisor.begin_start());
+        assert_eq!(*supervisor.state(), SidecarState::Starting { attempt: 1 });
+        supervisor.mark_healthy();
+        assert_eq!(*supervisor.state(), SidecarState::Healthy);
+        assert_eq!(supervisor.backoff(), Duration::ZERO);
+    }
+
+    #[test]
+    fn bounds_restarts_and_opens_circuit_after_three_failures() {
+        let mut supervisor = SidecarSupervisor::default();
+        assert_eq!(supervisor.mark_failed(), Duration::from_secs(1));
+        assert!(supervisor.restart_allowed());
+        assert_eq!(supervisor.mark_failed(), Duration::from_secs(2));
+        assert!(supervisor.restart_allowed());
+        assert_eq!(supervisor.mark_failed(), Duration::from_secs(4));
+        assert_eq!(*supervisor.state(), SidecarState::Offline);
+        assert!(!supervisor.restart_allowed());
+        assert!(!supervisor.begin_start());
+    }
+
+    #[test]
+    fn cannot_accumulate_an_unbounded_backoff() {
+        let mut supervisor = SidecarSupervisor::new(20);
+        for _ in 0..20 {
+            supervisor.mark_failed();
+        }
+        assert_eq!(supervisor.backoff(), Duration::from_secs(MAX_BACKOFF_SECONDS));
+    }
+}

--- a/docs/desktop/SIDECAR.md
+++ b/docs/desktop/SIDECAR.md
@@ -1,0 +1,11 @@
+# Runtime sidecar supervision
+
+The Desktop bridge supervises one Runtime sidecar and exposes its state as
+`starting`, `healthy`, `degraded`, or `offline`. A failed start uses bounded
+exponential backoff (1s, 2s, 4s, capped at 30s) and opens a circuit after
+three consecutive failures. The UI must keep the Runtime disabled while the
+state is not healthy and must never start a second uncontrolled process.
+
+A successful start resets the failure counter and backoff. The supervisor is a
+pure state machine, so transitions are deterministic and testable without
+launching a process; the Tauri command remains the only process boundary.


### PR DESCRIPTION
Closes #177

Adds a deterministic Runtime sidecar supervisor state machine with starting/healthy/degraded/offline states, bounded exponential backoff, a three-failure circuit breaker, recovery reset, and documentation. Tauri retains the sole process boundary.

Validation: Rust tests could not be run because `cargo` is not installed in this environment; the pure state machine includes unit coverage.