### PR TITLE
feat(desktop): evidence-backed provider registry

### DIFF
--- a/apps/desktop/src/contracts.ts
+++ b/apps/desktop/src/contracts.ts
@@ -2,6 +2,7 @@ export type AccessState = "signed_out" | "inactive" | "active" | "unknown";
 
 export type ProviderState =
   | "connected"
+  | "registered"
   | "detected"
   | "needs_attention"
   | "not_installed";

--- a/apps/desktop/src/demo.ts
+++ b/apps/desktop/src/demo.ts
@@ -4,7 +4,7 @@ type DemoProvider = Pick<ProviderConnection, "id" | "name" | "kind" | "protocol"
 
 function demoProvider(provider: DemoProvider): ProviderConnection {
   const installed = provider.state !== "not_installed";
-  const registered = provider.state === "detected" || provider.state === "connected";
+  const registered = provider.state === "connected" || provider.state === "needs_attention";
   return {
     ...provider,
     installState: installed ? "installed" : "absent",
@@ -13,9 +13,11 @@ function demoProvider(provider: DemoProvider): ProviderConnection {
     freshness: "current",
     reasonCode: !installed
       ? "host_not_installed"
-      : registered
-        ? "handshake_not_observed"
-        : "registration_missing_or_drifted",
+      : provider.state === "needs_attention"
+        ? "handshake_failed"
+        : provider.state === "detected"
+          ? "host_detected"
+          : "handshake_not_observed",
     availableActions: !installed ? ["register"] : registered ? ["verify", "repair"] : ["register"],
   };
 }

--- a/apps/desktop/src/provider_registry.test.ts
+++ b/apps/desktop/src/provider_registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { canonicalProviderState, providerRegistry, redactedProviderScan } from "./provider_registry";
+
+describe("canonical provider registry", () => {
+  it("requires current handshake evidence before showing connected", () => {
+    const provider = createDemoSnapshot("active").providers[0];
+    expect(canonicalProviderState(provider)).toBe("detected");
+    expect(canonicalProviderState({ ...provider, registrationState: "registered" })).toBe("registered");
+    expect(canonicalProviderState({ ...provider, registrationState: "registered", handshakeState: "live" })).toBe("connected");
+  });
+
+  it("maps stale or drifted evidence to attention and preserves absent hosts", () => {
+    const [provider] = createDemoSnapshot("active").providers;
+    expect(canonicalProviderState({ ...provider, freshness: "stale" })).toBe("needs_attention");
+    expect(canonicalProviderState({ ...provider, reasonCode: "config_drift" })).toBe("needs_attention");
+    expect(canonicalProviderState({ ...provider, installState: "absent" })).toBe("not_installed");
+  });
+
+  it("sorts the five states and returns a bounded redacted scan", () => {
+    const snapshot = createDemoSnapshot("active");
+    const registry = providerRegistry(snapshot.providers);
+    expect(registry.map((provider) => provider.state)).toEqual([
+      "needs_attention", "needs_attention", "needs_attention", "detected", "detected", "detected", "not_installed", "not_installed", "not_installed", "not_installed", "not_installed", "not_installed", "not_installed", "not_installed",
+    ]);
+    const bounded = { ...snapshot, limits: { ...snapshot.limits, maxProviders: 3 } };
+    const scan = redactedProviderScan(bounded);
+    expect(scan).toHaveLength(3);
+    expect(scan[0]).not.toHaveProperty("detail");
+    expect(JSON.stringify(scan)).not.toContain("config");
+  });
+});

--- a/apps/desktop/src/provider_registry.ts
+++ b/apps/desktop/src/provider_registry.ts
@@ -1,0 +1,82 @@
+import type { DesktopSnapshot, ProviderConnection, ProviderState } from "./contracts";
+
+export const PROVIDER_STATES: readonly ProviderState[] = [
+  "connected",
+  "registered",
+  "detected",
+  "needs_attention",
+  "not_installed",
+];
+
+const stateRank: Record<ProviderState, number> = {
+  connected: 0,
+  needs_attention: 1,
+  registered: 2,
+  detected: 3,
+  not_installed: 4,
+};
+
+/** Derives the UI state from evidence, never from a host's display label. */
+export function canonicalProviderState(provider: ProviderConnection): ProviderState {
+  if (provider.installState === "absent") return "not_installed";
+
+  if (
+    provider.registrationState === "registered" &&
+    provider.handshakeState === "live" &&
+    provider.freshness === "current"
+  ) {
+    return "connected";
+  }
+
+  if (
+    provider.handshakeState === "stale" ||
+    provider.freshness === "stale" ||
+    /drift|incompat|failed/i.test(provider.reasonCode)
+  ) {
+    return "needs_attention";
+  }
+
+  if (provider.registrationState === "registered") return "registered";
+  return "detected";
+}
+
+export function normalizeProvider(provider: ProviderConnection): ProviderConnection {
+  return { ...provider, state: canonicalProviderState(provider) };
+}
+
+export function providerRegistry(providers: ProviderConnection[]): ProviderConnection[] {
+  return providers
+    .map(normalizeProvider)
+    .sort((left, right) => stateRank[left.state] - stateRank[right.state] || left.name.localeCompare(right.name));
+}
+
+export interface RedactedProviderScan {
+  id: string;
+  name: string;
+  state: ProviderState;
+  installState: ProviderConnection["installState"];
+  registrationState: ProviderConnection["registrationState"];
+  handshakeState: ProviderConnection["handshakeState"];
+  freshness: ProviderConnection["freshness"];
+  reasonCode: string;
+  availableActions: ProviderConnection["availableActions"];
+}
+
+/** Bounded dry-run data for diagnostics/UI. It intentionally omits detail and config bodies. */
+export function redactedProviderScan(
+  snapshot: { providers: DesktopSnapshot["providers"]; limits: { maxProviders: number } },
+): RedactedProviderScan[] {
+  return providerRegistry(snapshot.providers)
+    .slice(0, snapshot.limits.maxProviders)
+    .map(({ id, name, state, installState, registrationState, handshakeState, freshness, reasonCode, availableActions }) => ({
+      id,
+      name,
+      state,
+      installState,
+      registrationState,
+      handshakeState,
+      freshness,
+      reasonCode,
+      availableActions,
+    }));
+}

--- a/apps/desktop/src/screens/ProvidersScreen.tsx
+++ b/apps/desktop/src/screens/ProvidersScreen.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import type { DesktopSnapshot, ProviderConnection, ProviderState } from "../contracts";
 import { Glyph } from "../components/Brand";
+import { providerRegistry } from "../provider_registry";
 
 const stateCopy: Record<ProviderState, string> = {
   connected: "Conectado",
+  registered: "Registrado",
   detected: "Detectado",
   needs_attention: "Requer atenção",
   not_installed: "Não instalado",
@@ -11,6 +13,7 @@ const stateCopy: Record<ProviderState, string> = {
 
 const actionCopy: Record<ProviderState, string> = {
   connected: "Ver detalhes",
+  registered: "Verificar",
   detected: "Conectar",
   needs_attention: "Corrigir conexão",
   not_installed: "Como instalar",
@@ -49,19 +52,18 @@ export function ProvidersScreen({
 }) {
   const [filter, setFilter] = useState<"all" | "ready" | "available">("all");
   const ordered = useMemo(() => {
-    const rank: Record<ProviderState, number> = { connected: 0, needs_attention: 1, detected: 2, not_installed: 3 };
-    return [...snapshot.providers]
+    return providerRegistry(snapshot.providers)
       .filter((provider) => {
         if (filter === "ready") return provider.state === "connected" || provider.state === "needs_attention";
-        if (filter === "available") return provider.state === "detected" || provider.state === "not_installed";
+        if (filter === "available") return provider.state === "registered" || provider.state === "detected" || provider.state === "not_installed";
         return true;
       })
-      .sort((a, b) => rank[a.state] - rank[b.state]);
   }, [filter, snapshot.providers]);
 
-  const connected = snapshot.providers.filter((provider) => provider.state === "connected").length;
-  const detected = snapshot.providers.filter((provider) => provider.state === "detected").length;
-  const attention = snapshot.providers.filter((provider) => provider.state === "needs_attention").length;
+  const canonical = providerRegistry(snapshot.providers);
+  const connected = canonical.filter((provider) => provider.state === "connected").length;
+  const detected = canonical.filter((provider) => provider.state === "detected" || provider.state === "registered").length;
+  const attention = canonical.filter((provider) => provider.state === "needs_attention").length;
 
   return (
     <div className="page providers-page">
@@ -85,14 +87,14 @@ export function ProvidersScreen({
 
       <div className="provider-toolbar">
         <div className="segmented-control" role="group" aria-label="Filtrar providers">
-          <button className={filter === "all" ? "active" : ""} onClick={() => setFilter("all")} type="button">Todos</button>
-          <button className={filter === "ready" ? "active" : ""} onClick={() => setFilter("ready")} type="button">Em uso</button>
-          <button className={filter === "available" ? "active" : ""} onClick={() => setFilter("available")} type="button">Disponíveis</button>
+          <button aria-pressed={filter === "all"} className={filter === "all" ? "active" : ""} onClick={() => setFilter("all")} type="button">Todos</button>
+          <button aria-pressed={filter === "ready"} className={filter === "ready" ? "active" : ""} onClick={() => setFilter("ready")} type="button">Em uso</button>
+          <button aria-pressed={filter === "available"} className={filter === "available" ? "active" : ""} onClick={() => setFilter("available")} type="button">Disponíveis</button>
         </div>
         <span className="provider-count">{ordered.length} providers</span>
       </div>
 
-      <section className="provider-grid">
+      <section className="provider-grid" aria-label="Lista de providers">
         {ordered.map((provider) => <ProviderCard provider={provider} key={provider.id} />)}
       </section>
 

--- a/docs/desktop/PROVIDERS.md
+++ b/docs/desktop/PROVIDERS.md
@@ -1,0 +1,25 @@
+# Desktop provider registry
+
+The Desktop separates host evidence from model-provider credentials. A provider
+card is derived from the registry, not from a host name or a successful config
+file write.
+
+## Canonical states
+
+| State | Required evidence | Meaning |
+| --- | --- | --- |
+| `connected` | installed + registered + current live handshake | The Simplicio server identity and protocol were observed within the TTL. |
+| `registered` | installed + registration read back | The config is present, but no current handshake was proven. |
+| `detected` | installed host only | The host/CLI exists, but registration is not proven. |
+| `needs_attention` | stale handshake/freshness or drift/incompatibility | Repair or verification is required. |
+| `not_installed` | host/CLI absent | Installation instructions are the only safe action. |
+
+`redactedProviderScan` is the dry-run/diagnostic surface. It is bounded by the
+Runtime snapshot limit and contains evidence fields and action IDs only; it
+never includes config files, credentials, prompts, or provider payloads.
+
+Registration writes must remain atomic, create a recoverable backup, and read
+back the resulting document before reporting `registered`. Connect, verify,
+repair, and instruction actions must be idempotent. The registry intentionally
+does not mark `hermes-agent` as supported until its clean-profile installer and
+provider-path E2E contract is available.


### PR DESCRIPTION
Closes #179

Adds a canonical provider registry with the five evidence-backed states: connected, registered, detected, needs_attention, and not_installed. The UI now orders and filters normalized states, while dry-run diagnostics are bounded and redact configuration details. Existing host registration remains atomic/read-back validated; the provider contract documents idempotent repair and keeps unverified Hermes support fail-closed.

Validation: desktop Vitest and TypeScript/Vite build pass locally.