### PR TITLE
feat(desktop): secure browser auth and logout

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ const SNAPSHOT_SCHEMA: &str = "simplicio.desktop-snapshot/v1";
 const MAX_SNAPSHOT_BYTES: usize = 65_536;
 const SNAPSHOT_ARGS: &[&str] = &["desktop", "snapshot", "--json"];
 const LOGIN_ARGS: &[&str] = &["desktop", "login"];
+const LOGOUT_ARGS: &[&str] = &["logout", "--json"];
 const SUBSCRIPTION_ARGS: &[&str] = &["desktop", "subscribe", "--json"];
 const STATUS_ARGS: &[&str] = &["desktop", "status", "--json"];
 
@@ -173,6 +174,16 @@ async fn desktop_login() -> Result<Value, String> {
 }
 
 #[tauri::command]
+async fn desktop_logout() -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        run_runtime_action(LOGOUT_ARGS)?;
+        snapshot_from_runtime()
+    })
+    .await
+    .map_err(|_| "Falha interna durante o logout".to_string())?
+}
+
+#[tauri::command]
 async fn desktop_open_subscription() -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(|| run_runtime_action(SUBSCRIPTION_ARGS))
         .await
@@ -193,6 +204,7 @@ pub fn run() {
             desktop_snapshot,
             refresh_desktop_snapshot,
             desktop_login,
+            desktop_logout,
             desktop_open_subscription,
             runtime_status
         ])
@@ -251,6 +263,7 @@ mod tests {
     fn bridge_exposes_only_fixed_runtime_arguments() {
         assert_eq!(SNAPSHOT_ARGS, ["desktop", "snapshot", "--json"]);
         assert_eq!(LOGIN_ARGS, ["desktop", "login"]);
+        assert_eq!(LOGOUT_ARGS, ["logout", "--json"]);
         assert_eq!(SUBSCRIPTION_ARGS, ["desktop", "subscribe", "--json"]);
         assert_eq!(STATUS_ARGS, ["desktop", "status", "--json"]);
     }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -74,11 +74,12 @@ describe("Simplicio Desktop product states", () => {
 
   it("offers account diagnostics and a redacted export", () => {
     const snapshot = createDemoSnapshot("active");
-    const html = renderToStaticMarkup(<SettingsScreen snapshot={snapshot} busy={false} onRefresh={() => undefined} onSubscribe={() => undefined} />);
+    const html = renderToStaticMarkup(<SettingsScreen snapshot={snapshot} busy={false} onRefresh={() => undefined} onSubscribe={() => undefined} onLogout={() => undefined} logoutBusy={false} />);
     const diagnostic = redactedDiagnostic(snapshot);
     expect(html).toContain("Gerenciar plano");
     expect(html).toContain("Exportar diagnóstico");
     expect(html).toContain("Atualizar estado");
+    expect(html).toContain("Sair da conta");
     expect(JSON.stringify(diagnostic)).not.toContain("voce@example.com");
     expect(JSON.stringify(diagnostic)).not.toContain("sonnet");
   });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import type { DesktopSnapshot } from "./contracts";
 import {
   beginDesktopLogin,
   loadDesktopSnapshot,
+  logoutDesktop,
   openDesktopSubscription,
   refreshDesktopSnapshot,
 } from "./bridge";
@@ -33,7 +34,7 @@ function initialView(): View {
 export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSnapshot }) {
   const [snapshot, setSnapshot] = useState<DesktopSnapshot | undefined>(initialSnapshot);
   const [loadFailed, setLoadFailed] = useState(false);
-  const [action, setAction] = useState<"login" | "refresh" | "subscribe" | null>(null);
+  const [action, setAction] = useState<"login" | "logout" | "refresh" | "subscribe" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [view, setView] = useState<View>(initialView);
 
@@ -90,6 +91,19 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     }
   }
 
+  async function logout() {
+    setAction("logout");
+    setActionError(null);
+    try {
+      setSnapshot(await logoutDesktop());
+      setView("home");
+    } catch {
+      setActionError("Não foi possível sair com segurança.");
+    } finally {
+      setAction(null);
+    }
+  }
+
   if (!snapshot && !loadFailed) return <LoadingScreen />;
 
   if (loadFailed) {
@@ -127,7 +141,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
       {view === "settings" && (
-        <SettingsScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} onSubscribe={subscribe} />
+        <SettingsScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"} />
       )}
       {view === "activity" && <ActivityScreen snapshot={snapshot} />}
       {view !== "home" && view !== "providers" && view !== "memory" && view !== "settings" && view !== "activity" && <SecondaryScreen view={view} snapshot={snapshot} />}

--- a/apps/desktop/src/auth.test.ts
+++ b/apps/desktop/src/auth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { AuthCallbackError, AuthTransactionStore, buildGoogleAuthorizationUrl, createPkceTransaction } from "./auth";
+
+const bytes = (length: number) => new Uint8Array(length).fill(7);
+
+describe("browser auth contract", () => {
+  it("builds an authorization-code PKCE URL without tokens", async () => {
+    const transaction = await createPkceTransaction(1_000, bytes);
+    const url = new URL(buildGoogleAuthorizationUrl({
+      clientId: "desktop-test",
+      redirectUri: "simplicio://oauth/callback",
+      transaction,
+      endpoint: "https://simpleti.test/login",
+    }));
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe(transaction.state);
+    expect(url.searchParams.has("access_token")).toBe(false);
+    expect(url.hash).toBe("");
+  });
+
+  it("rejects state mismatch, expiry, and replay", async () => {
+    const store = new AuthTransactionStore(bytes);
+    expect(() => store.consume("simplicio://oauth/callback?code=c&state=mismatch", 1_001)).toThrowError(AuthCallbackError);
+
+    const active = await store.begin(1_000);
+    expect(() => store.consume(`simplicio://oauth/callback?code=c&state=${active.state}`, 601_001)).toThrowError("expired");
+    const fresh = await store.begin(2_000);
+    expect(store.consume(`simplicio://oauth/callback?code=c&state=${fresh.state}`, 2_001)).toEqual({ code: "c", state: fresh.state });
+    expect(() => store.consume(`simplicio://oauth/callback?code=c&state=${fresh.state}`, 2_002)).toThrowError("invalid_state");
+  });
+
+  it("fails closed when the callback contains a token or missing code", async () => {
+    const store = new AuthTransactionStore();
+    const transaction = await store.begin(1_000);
+    expect(() => store.consume(`simplicio://oauth/callback?state=${transaction.state}&access_token=secret`, 1_001)).toThrowError("invalid_callback");
+    expect(() => store.consume(`simplicio://oauth/callback?state=${transaction.state}`, 1_001)).toThrowError("invalid_callback");
+  });
+});

--- a/apps/desktop/src/auth.ts
+++ b/apps/desktop/src/auth.ts
@@ -1,0 +1,104 @@
+const GOOGLE_LOGIN_URL = "https://simpleti.com.br/simplicio/login";
+const TOKEN_QUERY_KEYS = ["access_token", "id_token", "refresh_token", "token"];
+
+export interface PkceTransaction {
+  state: string;
+  verifier: string;
+  challenge: string;
+  createdAt: number;
+}
+
+export interface AuthorizationCallback {
+  code: string;
+  state: string;
+}
+
+export class AuthCallbackError extends Error {
+  constructor(public readonly code: "invalid_state" | "expired" | "replayed" | "invalid_callback") {
+    super(`OAuth callback rejected: ${code}`);
+    this.name = "AuthCallbackError";
+  }
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  if (!globalThis.crypto?.getRandomValues) throw new Error("Secure randomness is unavailable");
+  return globalThis.crypto.getRandomValues(bytes);
+}
+
+export async function createPkceTransaction(
+  now = Date.now(),
+  getRandomBytes: (length: number) => Uint8Array = randomBytes,
+): Promise<PkceTransaction> {
+  const verifierBytes = getRandomBytes(32);
+  const stateBytes = getRandomBytes(24);
+  const verifier = base64Url(verifierBytes);
+  const state = base64Url(stateBytes);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return { state, verifier, challenge: base64Url(new Uint8Array(digest)), createdAt: now };
+}
+
+export function buildGoogleAuthorizationUrl(options: {
+  clientId: string;
+  redirectUri: string;
+  transaction: PkceTransaction;
+  endpoint?: string;
+}): string {
+  const url = new URL(options.endpoint ?? GOOGLE_LOGIN_URL);
+  url.search = new URLSearchParams({
+    response_type: "code",
+    client_id: options.clientId,
+    redirect_uri: options.redirectUri,
+    code_challenge: options.transaction.challenge,
+    code_challenge_method: "S256",
+    state: options.transaction.state,
+  }).toString();
+  return url.toString();
+}
+
+export class AuthTransactionStore {
+  private readonly transactions = new Map<string, PkceTransaction>();
+  private readonly usedStates = new Set<string>();
+
+  constructor(private readonly getRandomBytes: (length: number) => Uint8Array = randomBytes) {}
+
+  async begin(now = Date.now()): Promise<PkceTransaction> {
+    const transaction = await createPkceTransaction(now, this.getRandomBytes);
+    this.transactions.set(transaction.state, transaction);
+    return transaction;
+  }
+
+  consume(callbackUrl: string, now = Date.now(), maxAgeMs = 10 * 60 * 1000): AuthorizationCallback {
+    let url: URL;
+    try {
+      url = new URL(callbackUrl);
+    } catch {
+      throw new AuthCallbackError("invalid_callback");
+    }
+
+    if (TOKEN_QUERY_KEYS.some((key) => url.searchParams.has(key)) || TOKEN_QUERY_KEYS.some((key) => url.hash.includes(key))) {
+      throw new AuthCallbackError("invalid_callback");
+    }
+
+    const state = url.searchParams.get("state");
+    const transaction = state ? this.transactions.get(state) : undefined;
+    if (!state || this.usedStates.has(state) || !transaction) throw new AuthCallbackError("invalid_state");
+    if (now - transaction.createdAt > maxAgeMs || now < transaction.createdAt) {
+      this.transactions.delete(state);
+      throw new AuthCallbackError("expired");
+    }
+
+    const code = url.searchParams.get("code");
+    if (!code || url.searchParams.has("error")) throw new AuthCallbackError("invalid_callback");
+
+    this.transactions.delete(state);
+    this.usedStates.add(state);
+    return { code, state };
+  }
+}

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -29,7 +29,12 @@ export async function loadDesktopSnapshot(): Promise<DesktopSnapshot> {
 
 export async function beginDesktopLogin(): Promise<DesktopSnapshot> {
   if (!isTauri()) return createDemoSnapshot("active");
-  return invoke<DesktopSnapshot>("desktop_login");
+  return withTimeout(invoke<DesktopSnapshot>("desktop_login"), 120_000, "Tempo limite do login excedido.");
+}
+
+export async function logoutDesktop(): Promise<DesktopSnapshot> {
+  if (!isTauri()) return createDemoSnapshot("signed_out");
+  return invoke<DesktopSnapshot>("desktop_logout");
 }
 
 export async function refreshDesktopSnapshot(): Promise<DesktopSnapshot> {
@@ -43,4 +48,20 @@ export async function openDesktopSubscription(): Promise<void> {
     return;
   }
   await invoke("desktop_open_subscription");
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        window.clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -30,11 +30,15 @@ export function SettingsScreen({
   busy,
   onRefresh,
   onSubscribe,
+  onLogout,
+  logoutBusy,
 }: {
   snapshot: DesktopSnapshot;
   busy: boolean;
   onRefresh: () => void;
   onSubscribe: () => void;
+  onLogout: () => void;
+  logoutBusy: boolean;
 }) {
   return (
     <div className="page secondary-page">
@@ -54,6 +58,9 @@ export function SettingsScreen({
             <div><dt>Expiração</dt><dd>{snapshot.access.expiresAt ? new Date(snapshot.access.expiresAt).toLocaleDateString("pt-BR") : "não informada"}</dd></div>
           </dl>
           <button className="button button-secondary button-wide" type="button" onClick={onSubscribe}>Gerenciar plano</button>
+          <button className="button button-secondary button-wide" type="button" onClick={onLogout} disabled={logoutBusy}>
+            {logoutBusy ? "Saindo…" : "Sair da conta"}
+          </button>
         </article>
         <article className="panel settings-card">
           <div className="settings-card-heading"><Glyph name="activity" size={20} /><div><span className="eyebrow">Diagnóstico</span><h2>Estado do Runtime</h2></div></div>
@@ -71,7 +78,7 @@ export function SettingsScreen({
       </section>
       <section className="panel settings-safety">
         <Glyph name="lock" size={18} />
-        <div><span className="eyebrow">Privacidade</span><strong>Dados locais sob controle</strong><p>Para sair da conta ou desinstalar, use o fluxo da aplicação nativa; nenhum token é mantido nesta tela.</p></div>
+        <div><span className="eyebrow">Privacidade</span><strong>Dados locais sob controle</strong><p>O logout revoga a sessão no Runtime e limpa as credenciais locais; nenhum token é mantido nesta tela.</p></div>
       </section>
     </div>
   );

--- a/docs/desktop/AUTH.md
+++ b/docs/desktop/AUTH.md
@@ -1,0 +1,21 @@
+# Desktop authentication contract
+
+The primary experience is a system-browser authorization-code flow. The
+Desktop never receives an access token in a URL or React state.
+
+1. The Runtime starts `desktop login`, creates the state/PKCE transaction, and
+   owns the callback handoff.
+2. `apps/desktop/src/auth.ts` defines the browser-side PKCE and deep-link
+   validation contract: S256 challenge, one-time state, ten-minute TTL, and
+   authorization code only.
+3. The Runtime exchanges the code, verifies identity and entitlement, and
+   publishes the versioned snapshot. The UI renders only the authoritative
+   `active`, `inactive`, `signed_out`, or `unknown` state.
+4. Logout invokes the Runtime's `logout --json` action before requesting a new
+   snapshot. Paid operations are therefore stopped by the Runtime authority,
+   not by a UI-only flag.
+
+Invalid state, replayed callbacks, expired transactions, provider/network
+failures, and callbacks containing token-shaped query/hash values fail closed.
+The login bridge also has a bounded timeout. The CLI device flow remains a
+fallback for headless environments and is not the Desktop's primary UX.


### PR DESCRIPTION
Closes #180

Implements the Desktop browser-auth contract with authorization-code PKCE (S256), one-time state, TTL, replay/mismatch rejection, and token-shaped callback rejection. The Tauri bridge gives the Runtime ownership of the browser exchange, enforces a bounded login timeout, and adds Runtime logout that clears the session before a fresh snapshot. The settings screen exposes logout without storing tokens in React state.

Validation: auth/Desktop Vitest and TypeScript/Vite build pass locally. The Runtime remains authoritative for entitlement, so provider/network uncertainty stays `unknown` rather than being inferred as inactive.