### PR TITLE
feat(desktop): centralize native design and accessibility

### DIFF
--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -1,15 +1,16 @@
 import type { ReactNode } from "react";
 import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
+import { t } from "../i18n";
 
 export type View = "home" | "providers" | "activity" | "memory" | "settings";
 
 const navigation: Array<{ id: View; label: string; icon: GlyphName }> = [
-  { id: "home", label: "Início", icon: "home" },
-  { id: "providers", label: "Providers", icon: "providers" },
-  { id: "activity", label: "Atividade", icon: "activity" },
-  { id: "memory", label: "Memória", icon: "memory" },
-  { id: "settings", label: "Configurações", icon: "settings" },
+  { id: "home", label: t("nav.home"), icon: "home" },
+  { id: "providers", label: t("nav.providers"), icon: "providers" },
+  { id: "activity", label: t("nav.activity"), icon: "activity" },
+  { id: "memory", label: t("nav.memory"), icon: "memory" },
+  { id: "settings", label: t("nav.settings"), icon: "settings" },
 ];
 
 interface ShellProps {
@@ -35,6 +36,7 @@ export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
               onClick={() => onViewChange(item.id)}
               type="button"
               aria-label={item.label}
+              aria-current={view === item.id ? "page" : undefined}
             >
               <Glyph name={item.icon} />
               <span>{item.label}</span>
@@ -53,6 +55,7 @@ export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
               onClick={() => onViewChange(item.id)}
               type="button"
               aria-label={item.label}
+              aria-current={view === item.id ? "page" : undefined}
             >
               <Glyph name={item.icon} />
               <span>{item.label}</span>

--- a/apps/desktop/src/design_system.test.ts
+++ b/apps/desktop/src/design_system.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { copy, locale, t } from "./i18n";
+import { designTokens } from "./design_tokens";
+
+describe("desktop design system", () => {
+  it("keeps the initial locale and UI copy separate from Runtime data", () => {
+    expect(locale).toBe("pt-BR");
+    expect(t("nav.settings")).toBe("Configurações");
+    expect(Object.keys(copy).every((key) => key.startsWith("nav.") || key.startsWith("provider."))).toBe(true);
+  });
+
+  it("centralizes interaction tokens and keeps touch targets usable", () => {
+    expect(designTokens.targetMinimum).toBe("44px");
+    expect(designTokens.focus).toContain("2px");
+    expect(designTokens.radius.md).toBe("9px");
+  });
+});

--- a/apps/desktop/src/design_tokens.ts
+++ b/apps/desktop/src/design_tokens.ts
@@ -1,0 +1,16 @@
+export const designTokens = {
+  color: {
+    ink: "#25261f",
+    muted: "#777567",
+    canvas: "#f3edda",
+    surface: "#faf7ea",
+    green: "#54a879",
+    greenDark: "#2f704e",
+    warning: "#bb7b34",
+  },
+  space: { xs: "4px", sm: "8px", md: "12px", lg: "16px", xl: "24px" },
+  radius: { sm: "7px", md: "9px", lg: "13px", pill: "999px" },
+  motion: { fast: "140ms", calm: "220ms" },
+  focus: "2px solid #2f704e",
+  targetMinimum: "44px",
+} as const;

--- a/apps/desktop/src/i18n.ts
+++ b/apps/desktop/src/i18n.ts
@@ -1,0 +1,20 @@
+export const locale = "pt-BR" as const;
+
+export const copy = {
+  "nav.home": "Início",
+  "nav.providers": "Providers",
+  "nav.activity": "Atividade",
+  "nav.memory": "Memória",
+  "nav.settings": "Configurações",
+  "provider.connected": "Conectado",
+  "provider.registered": "Registrado",
+  "provider.detected": "Detectado",
+  "provider.needs_attention": "Requer atenção",
+  "provider.not_installed": "Não instalado",
+} as const;
+
+export type CopyKey = keyof typeof copy;
+
+export function t(key: CopyKey): string {
+  return copy[key];
+}

--- a/apps/desktop/src/screens/ProvidersScreen.tsx
+++ b/apps/desktop/src/screens/ProvidersScreen.tsx
@@ -2,13 +2,14 @@ import { useMemo, useState } from "react";
 import type { DesktopSnapshot, ProviderConnection, ProviderState } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { providerRegistry } from "../provider_registry";
+import { t } from "../i18n";
 
 const stateCopy: Record<ProviderState, string> = {
-  connected: "Conectado",
-  registered: "Registrado",
-  detected: "Detectado",
-  needs_attention: "Requer atenção",
-  not_installed: "Não instalado",
+  connected: t("provider.connected"),
+  registered: t("provider.registered"),
+  detected: t("provider.detected"),
+  needs_attention: t("provider.needs_attention"),
+  not_installed: t("provider.not_installed"),
 };
 
 const actionCopy: Record<ProviderState, string> = {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -23,6 +23,19 @@
   --warning: #bb7b34;
   --danger: #bd665d;
   --mono: "SFMono-Regular", "IBM Plex Mono", Consolas, monospace;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --radius-sm: 7px;
+  --radius-md: 9px;
+  --radius-lg: 13px;
+  --radius-pill: 999px;
+  --motion-fast: 140ms;
+  --motion-calm: 220ms;
+  --focus-ring: 2px solid var(--green-dark);
+  --target-min: 44px;
   color-scheme: light;
 }
 
@@ -50,7 +63,7 @@ textarea { font: inherit; }
 button { color: inherit; }
 
 button:focus-visible {
-  outline: 2px solid rgba(47, 112, 78, 0.58);
+  outline: var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -128,10 +141,10 @@ p { margin-top: 0; }
 .status-dot.offline { background: #aaa492; }
 
 .button {
-  min-height: 36px;
+  min-height: var(--target-min);
   padding: 0 13px;
   border: 1px solid transparent;
-  border-radius: 9px;
+  border-radius: var(--radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -139,7 +152,7 @@ p { margin-top: 0; }
   font-size: 12px;
   font-weight: 650;
   cursor: pointer;
-  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+  transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
 .button-primary {
@@ -168,6 +181,7 @@ p { margin-top: 0; }
 .button-wide { width: 100%; }
 
 .text-button {
+  min-height: 36px;
   padding: 4px 0;
   border: 0;
   display: inline-flex;
@@ -178,6 +192,12 @@ p { margin-top: 0; }
   font-size: 11px;
   font-weight: 650;
   cursor: pointer;
+}
+
+@media (forced-colors: active) {
+  button:focus-visible { outline: 2px solid CanvasText; }
+  .status-dot { forced-color-adjust: none; background: CanvasText; }
+  .nav-item.active, .button-primary { border: 2px solid ButtonText; }
 }
 
 .text-button:hover { color: var(--green-dark); }

--- a/docs/desktop/DESIGN.md
+++ b/docs/desktop/DESIGN.md
@@ -1,0 +1,17 @@
+# Desktop design system and accessibility baseline
+
+The Desktop uses a small, light-native visual system: butter canvas, ivory
+surfaces, near-black text, soft green for healthy/action states, and amber only
+for attention. CSS custom properties in `src/styles.css` are the source of
+truth for color, spacing, radius, focus, motion, and target-size tokens.
+
+The initial locale is `pt-BR`. `src/i18n.ts` contains UI copy keys only;
+Runtime strings and provider IDs remain data and are never used as translation
+keys.
+
+The baseline includes visible keyboard focus, `aria-current` navigation,
+pressed filter controls, labeled regions, 44px primary controls, responsive
+sidebar-to-bottom navigation, a reduced-motion media query, and a forced-colors
+fallback. Screens keep loading, empty, offline, recoverable-error, and
+updating states short and actionable. Review screenshots at narrow and wide
+window sizes before shipping a visual change.


### PR DESCRIPTION
Closes #182

Adds centralized visual tokens for color, spacing, radius, motion, focus, and target size; an isolated PT-BR UI copy registry; accessible navigation/filter semantics; responsive/reduced-motion/forced-colors safeguards; and design-system guidance for regression review at wide and narrow window sizes.

Validation: desktop Vitest and TypeScript/Vite build pass locally.