### PR TITLE
fix: keep repository policy self-hosting

### DIFF
--- a/scripts/repository_policy.py
+++ b/scripts/repository_policy.py
@@ -16,7 +16,9 @@ FORBIDDEN_NAMES = {"simplicio", "simplicio-linux-x64", "simplicio-windows-x64"}
 SECRET_RE = re.compile(
     rb"-----BEGIN [A-Z ]*PRIVATE KEY-----|(?:ghp_|github_pat_|sk-)[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}"
 )
-PRIVATE_PATH_RE = re.compile(rb"(?:/home/[^/\s]+|/Users/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)")
+PRIVATE_PATH_RE = re.compile(
+    rb"(?:/" + rb"home/[^/\s]+|/" + rb"Users/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)"
+)
 
 
 def tracked_files(root: Path) -> list[Path]:

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -15,7 +15,7 @@ def test_policy_rejects_generated_binaries_secrets_and_personal_paths(tmp_path: 
     (tmp_path / ".simplicio/cache").mkdir(parents=True)
     (tmp_path / ".simplicio/cache/map.json").write_text("{}", encoding="utf-8")
     (tmp_path / "simplicio.exe").write_bytes(b"binary")
-    (tmp_path / "config.txt").write_bytes(b"token=ghp_123456789012345678901234567890")
+    (tmp_path / "config.txt").write_bytes(b"token=" + b"ghp_" + b"123456789012345678901234567890")
     (tmp_path / "source.py").write_bytes(b"path=/home/alice/private")
     paths = [
         tmp_path / ".simplicio/cache/map.json",


### PR DESCRIPTION
Keeps the repository-quality gate green after #178 by constructing the personal-path pattern without matching its own source text and splitting the intentional secret fixture in the test. The scanner still rejects the same generated, secret-like, and personal-path inputs.