### PR TITLE
feat(plugin): publish native Hermes Runtime middleware

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,12 @@
       "source": "./plugins/simplicio-sprint",
       "category": "development",
       "description": "SendSprint intake and delivery skill for Jira, Azure DevOps, and GitHub sprint-to-draft-PR workflows."
+    },
+    {
+      "name": "simplicio-hermes",
+      "source": "./plugins/simplicio-hermes",
+      "category": "development",
+      "description": "Native Hermes middleware adapter for deterministic Runtime preparation and provider receipts."
     }
   ]
 }

--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -1,0 +1,34 @@
+# Simplicio Hermes native adapter
+
+`simplicio-hermes` is a thin native middleware adapter. It calls the
+deterministic Runtime bridges `prepare_model_call` and
+`record_model_result`; it does not call an LLM, select a model, activate fan
+out, or duplicate Mapper/Runtime logic.
+
+The adapter registers `on_session_start`, `llm_request`, `llm_execution`,
+`post_api_request`, and `api_request_error`. `llm_request` must complete before
+Hermes sends the provider request. The exact provider, model, tools, streaming
+flags, cache directives, and provider-specific options are copied unchanged.
+Only the bounded `ContextPacket` returned by Runtime is added to `messages` or
+Responses `input`.
+
+```js
+import { createHermesPlugin } from "simplicio-hermes";
+
+const plugin = createHermesPlugin({ runtime, mode: "enforce" });
+// Hermes registers plugin.hooks using its native middleware registry.
+```
+
+Use `enforce` when a request must not proceed without a preparation receipt;
+use `best_effort` only when Hermes' fail-open behavior is explicitly desired.
+Every status has a stable reason code, and `protected` is false until context,
+provider-path, and usage receipt stages are all observed.
+
+## Installation boundary
+
+The package and manifest are shipped here, but the repository does not contain
+a Hermes executable or a verified Hermes 0.20.x plugin-install API. Therefore
+the generic host registry remains fail-closed for `hermes-agent` until a clean
+profile proves installation, repair, plugin enablement, MCP availability, and
+multi-step provider coverage. `hermes mcp test simplicio` alone must not turn
+the protected status green.

--- a/plugins/simplicio-hermes/index.mjs
+++ b/plugins/simplicio-hermes/index.mjs
@@ -1,0 +1,261 @@
+const HOOK_NAMES = [
+  "on_session_start",
+  "llm_request",
+  "llm_execution",
+  "post_api_request",
+  "api_request_error",
+];
+
+const DEFAULT_MAX_CONTEXT_BYTES = 32 * 1024;
+
+export const HERMES_HOOKS = Object.freeze([...HOOK_NAMES]);
+
+export class HermesProtectionError extends Error {
+  constructor(reasonCode, cause) {
+    super(`Hermes protection blocked the provider request: ${reasonCode}`);
+    this.name = "HermesProtectionError";
+    this.reasonCode = reasonCode;
+    this.cause = cause;
+  }
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function firstValue(...values) {
+  return values.map(stringValue).find(Boolean);
+}
+
+function byteLength(value) {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function boundedPacket(packet, maxBytes) {
+  const serialized = typeof packet === "string" ? packet : JSON.stringify(packet);
+  if (!serialized || byteLength(serialized) > maxBytes) {
+    throw new HermesProtectionError("context_packet_too_large");
+  }
+  return serialized;
+}
+
+function summarizeError(error) {
+  return {
+    name: error instanceof Error ? error.name : "Error",
+    message: error instanceof Error ? error.message.slice(0, 160) : "Runtime error",
+  };
+}
+
+function requestIdentity(request, session) {
+  return {
+    host: "hermes",
+    session_id: firstValue(request.session_id, session.session_id),
+    turn_id: firstValue(request.turn_id, session.turn_id),
+    api_request_id: firstValue(request.api_request_id, request.request_id),
+    provider_request_id: firstValue(request.provider_request_id),
+    provider: request.provider,
+    model: request.model,
+  };
+}
+
+function selectedRequest(request) {
+  // These fields are passed through unchanged to the Runtime and are never
+  // replaced by the adapter. Messages/input are deliberately excluded here.
+  return {
+    provider: request.provider,
+    model: request.model,
+    tools: request.tools,
+    stream: request.stream,
+    streaming: request.streaming,
+    options: request.options,
+    cache: request.cache,
+    cache_control: request.cache_control,
+    provider_options: request.provider_options,
+  };
+}
+
+function injectContext(request, contextPacket) {
+  if (Array.isArray(request.messages)) {
+    return {
+      ...request,
+      messages: [{ role: "system", content: contextPacket }, ...request.messages],
+    };
+  }
+  if (Array.isArray(request.input)) {
+    return {
+      ...request,
+      input: [{ role: "system", content: contextPacket }, ...request.input],
+    };
+  }
+  if (typeof request.input === "string") {
+    return { ...request, input: `${contextPacket}\n\n${request.input}` };
+  }
+  return { ...request, context_packet: contextPacket };
+}
+
+function eventUsage(event) {
+  return event.usage ?? event.response?.usage ?? event.result?.usage;
+}
+
+function eventCache(event) {
+  return event.cache ?? event.response?.cache ?? event.result?.cache;
+}
+
+function eventCost(event) {
+  return event.cost ?? event.response?.cost ?? event.result?.cost;
+}
+
+/**
+ * Hermes native middleware adapter. The injected runtime is the only source
+ * of ContextPacket and ledger receipts; this package never invokes a model.
+ */
+export function createHermesPlugin({
+  runtime,
+  mode = "best_effort",
+  maxContextBytes = DEFAULT_MAX_CONTEXT_BYTES,
+} = {}) {
+  if (mode !== "best_effort" && mode !== "enforce") {
+    throw new TypeError("Hermes mode must be best_effort or enforce");
+  }
+
+  const runtimeBridge = runtime ?? {};
+  const session = { session_id: undefined, turn_id: undefined };
+  const state = {
+    context_path_active: false,
+    provider_path_active: false,
+    usage_collector_active: false,
+    last_reason_code: "session_not_started",
+    generation: undefined,
+  };
+
+  function status() {
+    const mcpAvailable = runtimeBridge.mcp_available === true || runtimeBridge.capabilities?.mcp_available === true;
+    const protectedRequest = state.context_path_active && state.provider_path_active && state.usage_collector_active;
+    return {
+      host: "hermes",
+      plugin_installed: true,
+      plugin_enabled: true,
+      mcp_available: mcpAvailable,
+      context_path_active: state.context_path_active,
+      provider_path_active: state.provider_path_active,
+      usage_collector_active: state.usage_collector_active,
+      protected: protectedRequest,
+      mode,
+      generation: state.generation,
+      reason_code: protectedRequest ? "protected" : state.last_reason_code,
+    };
+  }
+
+  function fail(reasonCode, cause) {
+    state.last_reason_code = reasonCode;
+    if (mode === "enforce") throw new HermesProtectionError(reasonCode, cause);
+  }
+
+  async function prepare_model_call(request = {}) {
+    if (typeof runtimeBridge.prepare_model_call !== "function") {
+      fail("runtime_prepare_unavailable");
+      return { ...request, simplicio: { protected: false, reason_code: "runtime_prepare_unavailable" } };
+    }
+
+    const identity = requestIdentity(request, session);
+    try {
+      const prepared = await runtimeBridge.prepare_model_call({
+        ...selectedRequest(request),
+        ...identity,
+        host_session_id: identity.session_id,
+        host_turn_id: identity.turn_id,
+      });
+      const packet = boundedPacket(prepared?.contextPacket ?? prepared?.context_packet, maxContextBytes);
+      state.context_path_active = true;
+      state.provider_path_active = true;
+      state.generation = firstValue(prepared.generation, prepared.map_generation);
+      state.last_reason_code = "context_prepared";
+      return {
+        ...injectContext(request, packet),
+        simplicio: {
+          protected: true,
+          reason_code: "context_prepared",
+          generation: state.generation,
+          session_id: identity.session_id,
+          turn_id: identity.turn_id,
+        },
+      };
+    } catch (error) {
+      const reasonCode = error instanceof HermesProtectionError ? error.reasonCode : "runtime_prepare_failed";
+      fail(reasonCode, error);
+      return {
+        ...request,
+        simplicio: { protected: false, reason_code: reasonCode },
+      };
+    }
+  }
+
+  async function record_model_result(event = {}) {
+    if (typeof runtimeBridge.record_model_result !== "function") {
+      fail("runtime_record_unavailable");
+      return { ...event, simplicio: { protected: false, reason_code: "runtime_record_unavailable" } };
+    }
+
+    const identity = requestIdentity(event, session);
+    try {
+      await runtimeBridge.record_model_result({
+        ...identity,
+        usage: eventUsage(event),
+        cache: eventCache(event),
+        cost: eventCost(event),
+        provider_request_id: firstValue(event.provider_request_id, event.response?.id, event.result?.id),
+        api_request_id: firstValue(event.api_request_id, event.request_id),
+        usage_source: event.usage_source ?? "hermes_post_api_request",
+        error: event.error ? summarizeError(event.error) : undefined,
+      });
+      state.usage_collector_active = true;
+      state.last_reason_code = "receipt_recorded";
+      return {
+        ...event,
+        simplicio: { protected: state.context_path_active && state.provider_path_active, reason_code: "receipt_recorded" },
+      };
+    } catch (error) {
+      const reasonCode = "runtime_record_failed";
+      fail(reasonCode, error);
+      return { ...event, simplicio: { protected: false, reason_code: reasonCode } };
+    }
+  }
+
+  const hooks = {
+    on_session_start(context = {}) {
+      session.session_id = firstValue(context.session_id, context.sessionId);
+      session.turn_id = firstValue(context.turn_id, context.turnId);
+      state.last_reason_code = "session_started";
+      return { ...context, simplicio: status() };
+    },
+    llm_request: prepare_model_call,
+    llm_execution(event = {}) {
+      const identity = requestIdentity(event, session);
+      return {
+        ...event,
+        simplicio: {
+          ...event.simplicio,
+          session_id: identity.session_id,
+          turn_id: identity.turn_id,
+          api_request_id: identity.api_request_id,
+          provider_request_id: identity.provider_request_id,
+          protected: state.context_path_active && state.provider_path_active,
+        },
+      };
+    },
+    post_api_request: record_model_result,
+    api_request_error: (event = {}) => record_model_result({ ...event, error: event.error ?? event }),
+  };
+
+  return Object.freeze({
+    name: "simplicio-hermes",
+    version: "0.1.0",
+    mode,
+    hooks,
+    status,
+    prepare_model_call,
+    record_model_result,
+  });
+}
+
+export default createHermesPlugin;

--- a/plugins/simplicio-hermes/manifest.json
+++ b/plugins/simplicio-hermes/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "simplicio-hermes",
+  "version": "0.1.0",
+  "host": "hermes",
+  "entry": "./index.mjs",
+  "hooks": [
+    "on_session_start",
+    "llm_request",
+    "llm_execution",
+    "post_api_request",
+    "api_request_error"
+  ],
+  "modes": ["best_effort", "enforce"],
+  "runtime": {
+    "prepare": "prepare_model_call",
+    "record": "record_model_result"
+  }
+}

--- a/plugins/simplicio-hermes/package.json
+++ b/plugins/simplicio-hermes/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "simplicio-hermes",
+  "version": "0.1.0",
+  "description": "Native Hermes middleware adapter for deterministic Simplicio Runtime preparation and receipts.",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": "./index.mjs",
+  "engines": { "node": ">=18" },
+  "scripts": { "test": "node --test ./test.mjs" },
+  "license": "MIT"
+}

--- a/plugins/simplicio-hermes/test.mjs
+++ b/plugins/simplicio-hermes/test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createHermesPlugin, HermesProtectionError, HERMES_HOOKS } from "./index.mjs";
+
+function runtimeFixture() {
+  const calls = { prepare: [], record: [] };
+  return {
+    calls,
+    mcp_available: true,
+    async prepare_model_call(input) {
+      calls.prepare.push(input);
+      return { contextPacket: { generation: "g1", facts: ["bounded"] }, generation: "g1" };
+    },
+    async record_model_result(input) {
+      calls.record.push(input);
+    },
+  };
+}
+
+test("registers every native request/receipt surface", () => {
+  assert.deepEqual(HERMES_HOOKS, ["on_session_start", "llm_request", "llm_execution", "post_api_request", "api_request_error"]);
+});
+
+test("prepares every provider request and preserves provider identity/options", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime, mode: "enforce" });
+  plugin.hooks.on_session_start({ session_id: "s1", turn_id: "t1" });
+  const request = {
+    provider: "openrouter",
+    model: "anthropic/claude-sonnet",
+    tools: [{ type: "function", name: "search" }],
+    stream: true,
+    options: { temperature: 0.2, max_tokens: 300 },
+    cache: { read: true, write: true },
+    messages: [{ role: "user", content: "hello" }],
+  };
+  const prepared = await plugin.hooks.llm_request(request);
+  assert.equal(prepared.provider, request.provider);
+  assert.equal(prepared.model, request.model);
+  assert.deepEqual(prepared.tools, request.tools);
+  assert.deepEqual(prepared.options, request.options);
+  assert.deepEqual(prepared.cache, request.cache);
+  assert.equal(prepared.messages[1].content, "hello");
+  assert.match(prepared.messages[0].content, /bounded/);
+  assert.deepEqual(runtime.calls.prepare[0], {
+    provider: request.provider,
+    model: request.model,
+    tools: request.tools,
+    stream: true,
+    streaming: undefined,
+    options: request.options,
+    cache: request.cache,
+    cache_control: undefined,
+    provider_options: undefined,
+    host: "hermes",
+    session_id: "s1",
+    turn_id: "t1",
+    api_request_id: undefined,
+    provider_request_id: undefined,
+    host_session_id: "s1",
+    host_turn_id: "t1",
+  });
+  assert.equal(plugin.status().protected, false);
+});
+
+test("records usage/cache/cost and correlates all request identifiers", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime, mode: "best_effort" });
+  plugin.hooks.on_session_start({ session_id: "s1" });
+  await plugin.hooks.llm_request({ provider: "openai", model: "gpt-5", messages: [] });
+  const execution = plugin.hooks.llm_execution({ turn_id: "t2", api_request_id: "a2", provider_request_id: "p2" });
+  assert.equal(execution.simplicio.api_request_id, "a2");
+  await plugin.hooks.post_api_request({
+    session_id: "s1",
+    turn_id: "t2",
+    api_request_id: "a2",
+    provider_request_id: "p2",
+    usage: { input_tokens: 10, output_tokens: 4 },
+    cache: { read_tokens: 8, write_tokens: 2 },
+    cost: { usd: 0.01 },
+  });
+  assert.deepEqual(runtime.calls.record[0].usage, { input_tokens: 10, output_tokens: 4 });
+  assert.deepEqual(runtime.calls.record[0].cache, { read_tokens: 8, write_tokens: 2 });
+  assert.equal(runtime.calls.record[0].provider_request_id, "p2");
+  assert.equal(runtime.calls.record[0].api_request_id, "a2");
+  assert.equal(plugin.status().usage_collector_active, true);
+});
+
+test("enforce blocks a provider request when preparation fails", async () => {
+  const plugin = createHermesPlugin({
+    runtime: { async prepare_model_call() { throw new Error("offline"); } },
+    mode: "enforce",
+  });
+  await assert.rejects(
+    plugin.hooks.llm_request({ provider: "x", model: "y", messages: [] }),
+    (error) => error instanceof HermesProtectionError && error.reasonCode === "runtime_prepare_failed",
+  );
+  assert.equal(plugin.status().protected, false);
+});
+
+test("best_effort remains fail-open but exposes typed protection status", async () => {
+  let llmCalls = 0;
+  const plugin = createHermesPlugin({
+    runtime: { async prepare_model_call() { throw new Error("offline"); } },
+    mode: "best_effort",
+  });
+  const request = { provider: "x", model: "y", tools: [{ name: "keep" }], messages: [] };
+  const result = await plugin.hooks.llm_request(request);
+  llmCalls += 1;
+  assert.equal(llmCalls, 1);
+  assert.equal(result.provider, request.provider);
+  assert.equal(result.model, request.model);
+  assert.deepEqual(result.tools, request.tools);
+  assert.equal(result.simplicio.protected, false);
+  assert.equal(plugin.status().reason_code, "runtime_prepare_failed");
+  assert.doesNotMatch(JSON.stringify(plugin.status()), /offline|secret|hello/);
+});


### PR DESCRIPTION
Closes #184

Publishes `plugins/simplicio-hermes` as a thin native middleware package with manifest, package metadata, documentation, and deterministic Node tests. It registers session/request/execution/receipt/error hooks, calls only `prepare_model_call` and `record_model_result`, injects a bounded Runtime ContextPacket, preserves provider/model/tools/stream/cache/options, forwards usage/cache/cost and correlation IDs, and supports fail-closed `enforce` plus visible `best_effort` status.

The adapter makes no generative calls and never selects or substitutes a model. The public host registry intentionally remains fail-closed for `hermes-agent`: this environment has no Hermes executable or verified official installer API, so a clean-profile install/multi-step provider E2E cannot be honestly claimed by this PR. That installation boundary and the required follow-up evidence are documented.