### PR TITLE
feat(installer): install plugins for detected hosts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,14 @@ the signed SHA256/Ed25519 Runtime release, and installs the platform binary.
 If the Python script directory is not already on `PATH`, add it before running
 `simplicio install`.
 
+After the Runtime registers MCP/hooks for every detected client, both direct
+installers also reconcile native packages for installed Codex, Claude Code and
+Gemini CLI hosts. Those are the host surfaces with documented non-interactive
+plugin or extension installers. Other detected IDEs and harnesses remain on the
+verified Runtime MCP integration instead of receiving guessed commands. Set
+`SIMPLICIO_INSTALL_HOST_PLUGINS=0` only in managed/bootstrap environments that
+already installed the package.
+
 Known installer incidents and regression sentinels are tracked in
 [docs/INSTALL_ERROR_REGISTRY.md](docs/INSTALL_ERROR_REGISTRY.md).
 

--- a/install.ps1
+++ b/install.ps1
@@ -16,6 +16,8 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - Runtime report directory (default: ~/.simplicio)
+#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected native host plugins
+#                                    (default: install Codex/Claude/Gemini packages)
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem) — target "windows-x64", asset
@@ -195,6 +197,91 @@ function Test-McpToolSurface([string]$BinaryPath) {
   } catch {
     return $false
   }
+}
+
+function Invoke-NativeHostCommand([string]$Command, [string[]]$Arguments) {
+  try {
+    & $Command @Arguments *> $null
+    return ($LASTEXITCODE -eq 0)
+  } catch {
+    return $false
+  }
+}
+
+function Install-GeminiExtension {
+  $installedManifest = Join-Path $env:USERPROFILE ".gemini\extensions\simplicio\gemini-extension.json"
+  if (Test-Path $installedManifest) {
+    Write-Host "  ✓ Gemini CLI native extension already installed"
+    return $true
+  }
+
+  $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("simplicio-plugin-" + [guid]::NewGuid().ToString("N"))
+  $archive = Join-Path $tempRoot "simplicio-master.zip"
+  $unpacked = Join-Path $tempRoot "unpacked"
+  try {
+    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+    Invoke-WebRequest -Uri "https://github.com/$Repo/archive/refs/heads/master.zip" -OutFile $archive -UseBasicParsing
+    Expand-Archive -Path $archive -DestinationPath $unpacked -Force
+    $manifest = Get-ChildItem -Path $unpacked -Recurse -File -Filter "gemini-extension.json" |
+      Where-Object { $_.FullName -match "[\\/]plugins[\\/]simplicio[\\/]gemini-extension\.json$" } |
+      Select-Object -First 1
+    if ($null -eq $manifest) { return $false }
+    if (Invoke-NativeHostCommand "gemini" @("extensions", "install", $manifest.DirectoryName, "--consent")) {
+      Write-Host "  ✓ Gemini CLI native extension installed"
+      return $true
+    }
+    return $false
+  } catch {
+    return $false
+  } finally {
+    if (Test-Path $tempRoot) {
+      Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+function Install-DetectedHostPlugins {
+  if ($env:SIMPLICIO_INSTALL_HOST_PLUGINS -eq "0") {
+    Write-Host "  - native host plugin installation skipped by SIMPLICIO_INSTALL_HOST_PLUGINS=0"
+    return $true
+  }
+
+  $detected = 0
+  $failures = 0
+  if (Get-Command codex -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    [void](Invoke-NativeHostCommand "codex" @("plugin", "marketplace", "add", $Repo, "--ref", "master"))
+    if (Invoke-NativeHostCommand "codex" @("plugin", "add", "simplicio@simplicio-codex")) {
+      Write-Host "  ✓ Codex native plugin installed"
+    } else {
+      Write-Warning "Codex detected, but simplicio@simplicio-codex could not be installed"
+      $failures += 1
+    }
+  }
+
+  if (Get-Command claude -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    [void](Invoke-NativeHostCommand "claude" @("plugin", "marketplace", "add", $Repo))
+    if (Invoke-NativeHostCommand "claude" @("plugin", "install", "simplicio@simplicio", "--scope", "user")) {
+      Write-Host "  ✓ Claude Code native plugin installed"
+    } else {
+      Write-Warning "Claude Code detected, but simplicio@simplicio could not be installed"
+      $failures += 1
+    }
+  }
+
+  if (Get-Command gemini -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    if (-not (Install-GeminiExtension)) {
+      Write-Warning "Gemini CLI detected, but the Simplicio native extension could not be installed"
+      $failures += 1
+    }
+  }
+
+  if ($detected -eq 0) {
+    Write-Host "  - no native-package host detected; Runtime MCP registration covers the other clients"
+  }
+  return ($failures -eq 0)
 }
 
 # ─── -Doctor: idempotent, read-only health check ───────────────────────────
@@ -461,6 +548,15 @@ if (Test-McpToolSurface $DestPath) {
 } else {
   Write-Error "Runtime installed, but automatic MCP/hooks registration failed: $DestPath mcp register --binary $DestPath --json"
   exit 1
+}
+
+# Native packages add skills, commands and host-specific lifecycle behavior on
+# top of Runtime MCP registration. Unsupported/undocumented host installers are
+# never guessed; those clients remain on the verified MCP/hooks path.
+if (Install-DetectedHostPlugins) {
+  Write-Host "  ✓ native plugins reconciled for detected hosts"
+} else {
+  Write-Warning "Runtime/MCP are ready, but one or more native plugins need manual action; see PLUGIN.md"
 }
 Report-LoginState
 Write-Host "  ✓ Direct MCP: $DestPath serve --mcp --stdio; SIMPLICIO_MCP_URL=$SimplicioMcpUrl"

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,8 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
+#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected native host plugins
+#                                    (default: install Codex/Claude/Gemini packages)
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem): id "macos-arm64" -> asset
@@ -222,6 +224,101 @@ verify_mcp_tools() {
   binary_path="$1"
   [ -x "$binary_path" ] || return 1
   SIMPLICIO_MCP_URL="$SIMPLICIO_MCP_URL" "$binary_path" mcp register --binary "$binary_path" --json >/dev/null 2>&1
+}
+
+
+install_gemini_extension() {
+  installed_manifest="$HOME/.gemini/extensions/simplicio/gemini-extension.json"
+  if [ -f "$installed_manifest" ]; then
+    ok "extensão nativa do Gemini CLI já instalada"
+    return 0
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    warn "Gemini CLI detectado, mas Python 3 é necessário para preparar a extensão"
+    return 1
+  fi
+
+  plugin_tmp="$(mktemp -d)"
+  plugin_zip="$plugin_tmp/simplicio-master.zip"
+  plugin_url="$GITHUB/archive/refs/heads/master.zip"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$plugin_url" -o "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$plugin_url" -O "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  else
+    rm -rf "$plugin_tmp"
+    return 1
+  fi
+
+  plugin_dir="$(python3 - "$plugin_zip" "$plugin_tmp/unpacked" <<'PY'
+import pathlib, sys, zipfile
+archive, destination = sys.argv[1:]
+root = pathlib.Path(destination).resolve()
+root.mkdir(parents=True, exist_ok=True)
+with zipfile.ZipFile(archive) as bundle:
+    for member in bundle.infolist():
+        target = (root / member.filename).resolve()
+        if target != root and root not in target.parents:
+            raise SystemExit("unsafe plugin archive path")
+    bundle.extractall(root)
+matches = list(root.glob("*/plugins/simplicio/gemini-extension.json"))
+if len(matches) != 1:
+    raise SystemExit("Gemini extension manifest not found exactly once")
+print(matches[0].parent)
+PY
+)" || { rm -rf "$plugin_tmp"; return 1; }
+
+  if gemini extensions install "$plugin_dir" --consent >/dev/null 2>&1; then
+    rm -rf "$plugin_tmp"
+    ok "extensão nativa do Gemini CLI instalada"
+    return 0
+  fi
+  rm -rf "$plugin_tmp"
+  return 1
+}
+
+install_detected_host_plugins() {
+  if [ "${SIMPLICIO_INSTALL_HOST_PLUGINS:-1}" = "0" ]; then
+    info "instalação de plugins nativos ignorada por SIMPLICIO_INSTALL_HOST_PLUGINS=0"
+    return 0
+  fi
+
+  detected=0
+  failures=0
+  if command -v codex >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    codex plugin marketplace add "$REPO" --ref master >/dev/null 2>&1 || true
+    if codex plugin add simplicio@simplicio-codex >/dev/null 2>&1; then
+      ok "plugin nativo do Codex instalado"
+    else
+      warn "Codex detectado, mas o plugin simplicio@simplicio-codex não pôde ser instalado"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if command -v claude >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    claude plugin marketplace add "$REPO" >/dev/null 2>&1 || true
+    if claude plugin install simplicio@simplicio --scope user >/dev/null 2>&1; then
+      ok "plugin nativo do Claude Code instalado"
+    else
+      warn "Claude Code detectado, mas o plugin simplicio@simplicio não pôde ser instalado"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if command -v gemini >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    if ! install_gemini_extension; then
+      warn "Gemini CLI detectado, mas a extensão nativa do Simplicio não pôde ser instalada"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if [ "$detected" -eq 0 ]; then
+    info "nenhum host com pacote nativo detectado; o registro MCP cobre os demais clientes"
+  fi
+  [ "$failures" -eq 0 ]
 }
 
 # ─── --doctor: idempotent, read-only health check ──────────────────────────
@@ -530,6 +627,15 @@ if verify_mcp_tools "$DEST_PATH"; then
   ok "MCP e hooks registrados automaticamente para os clientes detectados"
 else
   err "o Runtime foi instalado, mas o registro automático de MCP/hooks falhou: $DEST_PATH mcp register --binary $DEST_PATH --json"
+fi
+
+# Native packages add skills, commands and host-specific lifecycle behavior on
+# top of the Runtime MCP registration. Only hosts with a documented installer
+# contract are attempted; every other detected client stays on MCP/hooks.
+if install_detected_host_plugins; then
+  ok "plugins nativos reconciliados para os hosts detectados"
+else
+  warn "Runtime/MCP estão prontos, mas um ou mais plugins nativos exigem ação manual; consulte PLUGIN.md"
 fi
 report_login_state
 ok "MCP direto: $DEST_PATH serve --mcp --stdio; SIMPLICIO_MCP_URL=${SIMPLICIO_MCP_URL}"

--- a/plugins/simplicio/bin/simplicio-mcp-bootstrap.js
+++ b/plugins/simplicio/bin/simplicio-mcp-bootstrap.js
@@ -251,6 +251,7 @@ function runOfficialInstaller(installerPath, home, logPath) {
     SIMPLICIO_BIN_DIR: managedBinDir,
     SIMPLICIO_BUNDLE_DIR: path.join(isolatedHome, ".simplicio"),
     SIMPLICIO_INSTALL_CODEX: "0",
+    SIMPLICIO_INSTALL_HOST_PLUGINS: "0",
     SIMPLICIO_VERSION: POLICY.runtimeVersion
   };
   delete env.SIMPLICIO_ALLOW_UNVERIFIED;

--- a/tests/test_installer_host_plugins_contract.py
+++ b/tests/test_installer_host_plugins_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_shell_installs_documented_native_plugins_after_runtime_registration() -> None:
+    text = (ROOT / "install.sh").read_text(encoding="utf-8")
+    registration = 'verify_mcp_tools "$DEST_PATH"'
+    plugin_install = "install_detected_host_plugins"
+
+    assert 'command -v codex' in text
+    assert 'codex plugin marketplace add "$REPO" --ref master' in text
+    assert "codex plugin add simplicio@simplicio-codex" in text
+    assert 'command -v claude' in text
+    assert 'claude plugin marketplace add "$REPO"' in text
+    assert "claude plugin install simplicio@simplicio --scope user" in text
+    assert 'command -v gemini' in text
+    assert 'gemini extensions install "$plugin_dir" --consent' in text
+    assert text.index(registration) < text.index(plugin_install, text.index(registration))
+
+
+def test_powershell_installs_documented_native_plugins_after_runtime_registration() -> None:
+    text = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    registration = "Test-McpToolSurface $DestPath"
+    plugin_install = "Install-DetectedHostPlugins"
+
+    assert "Get-Command codex -CommandType Application" in text
+    assert '@("plugin", "marketplace", "add", $Repo, "--ref", "master")' in text
+    assert '@("plugin", "add", "simplicio@simplicio-codex")' in text
+    assert "Get-Command claude -CommandType Application" in text
+    assert '@("plugin", "marketplace", "add", $Repo)' in text
+    assert '@("plugin", "install", "simplicio@simplicio", "--scope", "user")' in text
+    assert "Get-Command gemini -CommandType Application" in text
+    assert '@("extensions", "install", $manifest.DirectoryName, "--consent")' in text
+    assert text.index(registration) < text.index(plugin_install, text.index(registration))
+
+
+def test_host_plugin_bootstrap_is_idempotent_and_does_not_guess_unsupported_clis() -> None:
+    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
+    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    bootstrap = (
+        ROOT / "plugins/simplicio/bin/simplicio-mcp-bootstrap.js"
+    ).read_text(encoding="utf-8")
+
+    for text in (shell, powershell):
+        assert "SIMPLICIO_INSTALL_HOST_PLUGINS" in text
+        for unsupported in (
+            "cursor plugin install",
+            "code plugin install",
+            "kiro plugin install",
+            "qwen plugin install",
+        ):
+            assert unsupported not in text.lower()
+
+    assert 'SIMPLICIO_INSTALL_HOST_PLUGINS: "0"' in bootstrap


### PR DESCRIPTION
## Summary

- Detects installed Codex, Claude Code, and Gemini CLI hosts from both install.sh and install.ps1.
- Installs the repository's native plugin or extension package after Runtime MCP registration and tool-surface verification.
- Keeps unsupported hosts on the existing Runtime MCP/hooks integration, warns without rolling back a verified Runtime install, and supports SIMPLICIO_INSTALL_HOST_PLUGINS=0.
- Prevents recursive plugin bootstrap installation.

## Tracking issue

Related: direct maintainer request (no issue).

## Quality evidence

- [x] Local deterministic quality gate is green: 251 tests and 30 subtests passed.
- [x] Installer contract regression coverage added.
- [x] Coverage policy remains enforced by the existing repository suite.
- [x] Shell syntax, PowerShell parser, bootstrap handshake, and installer contracts were exercised.
- [x] No test is skipped.
- [x] No benchmark behavior changed.

## Regression test

tests/test_installer_host_plugins_contract.py verifies exact host commands, ordering after MCP registration, opt-out behavior, recursion protection, and absence of guessed unsupported host commands.

## Exceptions

None.