### PR TITLE
feat(installer): install every detected host plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ simplicio-*
 !plugins/simplicio/plugin.json
 !plugins/simplicio/mcp.json
 !plugins/simplicio/.claude-plugin/
+!plugins/simplicio-hermes/
+!plugins/simplicio-hermes/plugin.yaml
+!plugins/simplicio-hermes/__init__.py
+!plugins/simplicio-hermes/hermes_plugin.py
 !plugins/simplicio/.claude-plugin/plugin.json
 !plugins/simplicio/gemini-extension.json
 !plugins/simplicio/host-surfaces.json

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,12 +41,14 @@ If the Python script directory is not already on `PATH`, add it before running
 `simplicio install`.
 
 After the Runtime registers MCP/hooks for every detected client, both direct
-installers also reconcile native packages for installed Codex, Claude Code and
-Gemini CLI hosts. Those are the host surfaces with documented non-interactive
-plugin or extension installers. Other detected IDEs and harnesses remain on the
-verified Runtime MCP integration instead of receiving guessed commands. Set
+installers reconcile every compatible host package. Claude Code, GitHub Copilot
+CLI, and Qwen Code receive all published marketplace plugins (`simplicio`, Loop,
+Prompt, Sprint, and Hermes). Codex and Gemini receive their native package,
+Cursor and Kiro receive the portable Agent Plugin, and Hermes receives the
+enabled native Python plugin with `pre_llm_call` and `post_llm_call` hooks.
+Hosts without a package API remain on the verified Runtime MCP integration. Set
 `SIMPLICIO_INSTALL_HOST_PLUGINS=0` only in managed/bootstrap environments that
-already installed the package.
+already installed the packages.
 
 Known installer incidents and regression sentinels are tracked in
 [docs/INSTALL_ERROR_REGISTRY.md](docs/INSTALL_ERROR_REGISTRY.md).

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -5,6 +5,12 @@ Code marketplaces, the portable Agent Plugins v1 contract, and a Gemini CLI
 extension. Hosts without a verified plugin API use the Runtime-owned MCP/config
 integration instead of an invented plugin format.
 
+The official `install.sh` and `install.ps1` detect installed hosts and install
+every compatible published package automatically. Claude Code, GitHub Copilot
+CLI, and Qwen Code receive all five marketplace plugins; Codex and Gemini
+receive their native package; Cursor and Kiro receive the portable Agent Plugin;
+and Hermes receives and enables the native `simplicio-hermes` plugin.
+
 ## Install in Codex
 
 ```bash
@@ -56,6 +62,7 @@ In Claude Code:
 /plugin install simplicio-loop@simplicio
 /plugin install simplicio-prompt@simplicio
 /plugin install simplicio-sprint@simplicio
+/plugin install simplicio-hermes@simplicio
 ```
 
 The main `simplicio` package bootstraps the verified Runtime automatically.
@@ -70,6 +77,7 @@ packages remain available for their specialized workflows.
 | `simplicio-loop` | Loop, tasks alias, orient, review, compress, learn, autoresearch, Prism, Mapper, Fast, Dev CLI, Runtime skills and safety hooks | [`simplicio-loop`](https://github.com/wesleysimplicio/simplicio-loop) |
 | `simplicio-prompt` | Tuple-Space/Yool prompt contract, fan-out commands, and opt-in prompt adapter | [`simplicio-prompt`](https://github.com/wesleysimplicio/simplicio-prompt) |
 | `simplicio-sprint` | Sprint intake, mapping, evidence collection, and draft-PR delivery | [`simplicio-sprint`](https://github.com/wesleysimplicio/simplicio-sprint) |
+| `simplicio-hermes` | Native `pre_llm_call` context preparation and post-call Runtime receipts for Hermes Agent | This repository |
 
 The Loop plugin is the default integration. Prompt and Sprint remain separate
 installable plugins so their hooks and commands do not create duplicate runtime

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ This public repository also publishes the Simplicio Claude Code marketplace:
 /plugin install simplicio-loop@simplicio
 /plugin install simplicio-prompt@simplicio
 /plugin install simplicio-sprint@simplicio
+/plugin install simplicio-hermes@simplicio
 ```
 
 The plugin bundle is documented in [`PLUGIN.md`](PLUGIN.md). These are optional

--- a/install.ps1
+++ b/install.ps1
@@ -16,8 +16,8 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - Runtime report directory (default: ~/.simplicio)
-#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected native host plugins
-#                                    (default: install Codex/Claude/Gemini packages)
+#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected host plugins
+#                                    (default: install every compatible package)
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem) — target "windows-x64", asset
@@ -37,6 +37,7 @@ $ErrorActionPreference = "Stop"
 
 $Repo = "wesleysimplicio/simplicio"
 $BinName = "simplicio.exe"
+$MarketplacePlugins = @("simplicio", "simplicio-loop", "simplicio-prompt", "simplicio-sprint", "simplicio-hermes")
 $Target = "windows-x64"
 $Asset = "simplicio-windows-x64.exe"
 $Ed25519PublicKey = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
@@ -208,6 +209,39 @@ function Invoke-NativeHostCommand([string]$Command, [string[]]$Arguments) {
   }
 }
 
+function Test-AnyPath([string[]]$Paths) {
+  foreach ($path in $Paths) {
+    if (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path $path)) { return $true }
+  }
+  return $false
+}
+
+function Install-PortableAgentPlugin([string]$TargetDir, [string]$HostName) {
+  $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("simplicio-agent-plugin-" + [guid]::NewGuid().ToString("N"))
+  $archive = Join-Path $tempRoot "simplicio-master.zip"
+  $unpacked = Join-Path $tempRoot "unpacked"
+  try {
+    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+    Invoke-WebRequest -Uri "https://github.com/$Repo/archive/refs/heads/master.zip" -OutFile $archive -UseBasicParsing
+    Expand-Archive -Path $archive -DestinationPath $unpacked -Force
+    $manifest = Get-ChildItem -Path $unpacked -Recurse -File -Filter "plugin.json" |
+      Where-Object { $_.FullName -match "[\\/]plugins[\\/]simplicio[\\/]plugin\.json$" } |
+      Select-Object -First 1
+    if ($null -eq $manifest) { return $false }
+    New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
+    Get-ChildItem -Force -Path $manifest.DirectoryName | Copy-Item -Destination $TargetDir -Recurse -Force
+    if (-not (Test-Path (Join-Path $TargetDir "plugin.json"))) { return $false }
+    Write-Host "  ✓ Simplicio Agent Plugin installed for $HostName"
+    return $true
+  } catch {
+    return $false
+  } finally {
+    if (Test-Path $tempRoot) {
+      Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
+    }
+  }
+}
+
 function Install-GeminiExtension {
   $installedManifest = Join-Path $env:USERPROFILE ".gemini\extensions\simplicio\gemini-extension.json"
   if (Test-Path $installedManifest) {
@@ -262,11 +296,13 @@ function Install-DetectedHostPlugins {
   if (Get-Command claude -CommandType Application -ErrorAction SilentlyContinue) {
     $detected += 1
     [void](Invoke-NativeHostCommand "claude" @("plugin", "marketplace", "add", $Repo))
-    if (Invoke-NativeHostCommand "claude" @("plugin", "install", "simplicio@simplicio", "--scope", "user")) {
-      Write-Host "  ✓ Claude Code native plugin installed"
-    } else {
-      Write-Warning "Claude Code detected, but simplicio@simplicio could not be installed"
-      $failures += 1
+    foreach ($pluginName in $MarketplacePlugins) {
+      if (Invoke-NativeHostCommand "claude" @("plugin", "install", "$pluginName@simplicio", "--scope", "user")) {
+        Write-Host "  ✓ plugin $pluginName installed in Claude Code"
+      } else {
+        Write-Warning "Claude Code detected, but $pluginName@simplicio could not be installed"
+        $failures += 1
+      }
     }
   }
 
@@ -278,8 +314,76 @@ function Install-DetectedHostPlugins {
     }
   }
 
+  if (Get-Command copilot -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    [void](Invoke-NativeHostCommand "copilot" @("plugin", "marketplace", "add", $Repo))
+    foreach ($pluginName in $MarketplacePlugins) {
+      if (Invoke-NativeHostCommand "copilot" @("plugin", "install", "$pluginName@simplicio")) {
+        Write-Host "  ✓ plugin $pluginName installed in GitHub Copilot CLI"
+      } else {
+        Write-Warning "GitHub Copilot CLI detected, but $pluginName@simplicio could not be installed"
+        $failures += 1
+      }
+    }
+  }
+
+  if (Get-Command qwen -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    foreach ($pluginName in $MarketplacePlugins) {
+      if (Invoke-NativeHostCommand "qwen" @("extensions", "install", "${Repo}:$pluginName")) {
+        Write-Host "  ✓ extension $pluginName installed in Qwen Code"
+      } else {
+        Write-Warning "Qwen Code detected, but $pluginName could not be installed"
+        $failures += 1
+      }
+    }
+  }
+
+  if (Get-Command hermes -CommandType Application -ErrorAction SilentlyContinue) {
+    $detected += 1
+    $installed = Invoke-NativeHostCommand "hermes" @("plugins", "install", "$Repo/plugins/simplicio-hermes", "--force", "--enable")
+    $valid = $installed -and (Invoke-NativeHostCommand "hermes" @("plugins", "doctor", "simplicio-hermes", "--ci"))
+    if ($valid) {
+      Write-Host "  ✓ simplicio-hermes plugin installed, enabled, and validated"
+    } else {
+      Write-Warning "Hermes detected, but simplicio-hermes could not be installed and enabled"
+      $failures += 1
+    }
+  }
+
+  $cursorPaths = @(
+    (Join-Path $env:USERPROFILE ".cursor"),
+    $(if ($env:APPDATA) { Join-Path $env:APPDATA "Cursor" } else { "" }),
+    $(if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "Programs\cursor" } else { "" })
+  )
+  $cursorDetected = [bool](
+    (Get-Command cursor -ErrorAction SilentlyContinue) -or
+    (Get-Command cursor-agent -ErrorAction SilentlyContinue) -or
+    (Test-AnyPath $cursorPaths)
+  )
+  if ($cursorDetected) {
+    $detected += 1
+    $target = Join-Path $env:USERPROFILE ".cursor\plugins\local\simplicio"
+    if (-not (Install-PortableAgentPlugin $target "Cursor")) { $failures += 1 }
+  }
+
+  $kiroPaths = @(
+    (Join-Path $env:USERPROFILE ".kiro"),
+    $(if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "Programs\Kiro" } else { "" })
+  )
+  $kiroDetected = [bool](
+    (Get-Command kiro -ErrorAction SilentlyContinue) -or
+    (Get-Command kiro-cli -ErrorAction SilentlyContinue) -or
+    (Test-AnyPath $kiroPaths)
+  )
+  if ($kiroDetected) {
+    $detected += 1
+    $target = Join-Path $env:USERPROFILE ".kiro\powers\simplicio"
+    if (-not (Install-PortableAgentPlugin $target "Kiro")) { $failures += 1 }
+  }
+
   if ($detected -eq 0) {
-    Write-Host "  - no native-package host detected; Runtime MCP registration covers the other clients"
+    Write-Host "  - no compatible plugin-package host detected; Runtime MCP registration covers the other clients"
   }
   return ($failures -eq 0)
 }
@@ -550,13 +654,15 @@ if (Test-McpToolSurface $DestPath) {
   exit 1
 }
 
-# Native packages add skills, commands and host-specific lifecycle behavior on
-# top of Runtime MCP registration. Unsupported/undocumented host installers are
-# never guessed; those clients remain on the verified MCP/hooks path.
+# Host packages add skills, commands and host-specific lifecycle behavior on
+# top of Runtime MCP registration. Every detected host with a documented
+# package surface is installed automatically; MCP remains the compatibility
+# path for clients without a package API.
 if (Install-DetectedHostPlugins) {
   Write-Host "  ✓ native plugins reconciled for detected hosts"
 } else {
-  Write-Warning "Runtime/MCP are ready, but one or more native plugins need manual action; see PLUGIN.md"
+  Write-Error "Runtime/MCP are ready, but automatic installation of one or more detected plugins failed; see PLUGIN.md"
+  exit 1
 }
 Report-LoginState
 Write-Host "  ✓ Direct MCP: $DestPath serve --mcp --stdio; SIMPLICIO_MCP_URL=$SimplicioMcpUrl"

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,8 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
-#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected native host plugins
-#                                    (default: install Codex/Claude/Gemini packages)
+#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected host plugins
+#                                    (default: install every compatible package)
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem): id "macos-arm64" -> asset
@@ -37,6 +37,7 @@ ED25519_PUBLIC_KEY="2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 ED25519_HELPER_URL="https://raw.githubusercontent.com/$REPO/master/scripts/verify_ed25519.py"
 ED25519_HELPER_SHA256="f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
 BIN_NAME="simplicio"
+MARKETPLACE_PLUGINS="simplicio simplicio-loop simplicio-prompt simplicio-sprint simplicio-hermes"
 
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
@@ -277,6 +278,54 @@ PY
   return 1
 }
 
+install_portable_agent_plugin() {
+  target_dir="$1"
+  host_name="$2"
+  if ! command -v python3 >/dev/null 2>&1; then
+    warn "$host_name detectado, mas Python 3 é necessário para preparar o Agent Plugin"
+    return 1
+  fi
+
+  plugin_tmp="$(mktemp -d)"
+  plugin_zip="$plugin_tmp/simplicio-master.zip"
+  plugin_url="$GITHUB/archive/refs/heads/master.zip"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$plugin_url" -o "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$plugin_url" -O "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  else
+    rm -rf "$plugin_tmp"
+    return 1
+  fi
+
+  plugin_dir="$(python3 - "$plugin_zip" "$plugin_tmp/unpacked" <<'PY'
+import pathlib, sys, zipfile
+archive, destination = sys.argv[1:]
+root = pathlib.Path(destination).resolve()
+root.mkdir(parents=True, exist_ok=True)
+with zipfile.ZipFile(archive) as bundle:
+    for member in bundle.infolist():
+        target = (root / member.filename).resolve()
+        if target != root and root not in target.parents:
+            raise SystemExit("unsafe plugin archive path")
+    bundle.extractall(root)
+matches = list(root.glob("*/plugins/simplicio/plugin.json"))
+if len(matches) != 1:
+    raise SystemExit("Agent Plugin manifest not found exactly once")
+print(matches[0].parent)
+PY
+)" || { rm -rf "$plugin_tmp"; return 1; }
+
+  mkdir -p "$target_dir" || { rm -rf "$plugin_tmp"; return 1; }
+  if cp -R "$plugin_dir/." "$target_dir/"; then
+    rm -rf "$plugin_tmp"
+    ok "Agent Plugin do Simplicio instalado para $host_name"
+    return 0
+  fi
+  rm -rf "$plugin_tmp"
+  return 1
+}
+
 install_detected_host_plugins() {
   if [ "${SIMPLICIO_INSTALL_HOST_PLUGINS:-1}" = "0" ]; then
     info "instalação de plugins nativos ignorada por SIMPLICIO_INSTALL_HOST_PLUGINS=0"
@@ -299,12 +348,14 @@ install_detected_host_plugins() {
   if command -v claude >/dev/null 2>&1; then
     detected=$((detected + 1))
     claude plugin marketplace add "$REPO" >/dev/null 2>&1 || true
-    if claude plugin install simplicio@simplicio --scope user >/dev/null 2>&1; then
-      ok "plugin nativo do Claude Code instalado"
-    else
-      warn "Claude Code detectado, mas o plugin simplicio@simplicio não pôde ser instalado"
-      failures=$((failures + 1))
-    fi
+    for plugin_name in $MARKETPLACE_PLUGINS; do
+      if claude plugin install "$plugin_name@simplicio" --scope user >/dev/null 2>&1; then
+        ok "plugin $plugin_name instalado no Claude Code"
+      else
+        warn "Claude Code detectado, mas $plugin_name@simplicio não pôde ser instalado"
+        failures=$((failures + 1))
+      fi
+    done
   fi
 
   if command -v gemini >/dev/null 2>&1; then
@@ -315,8 +366,68 @@ install_detected_host_plugins() {
     fi
   fi
 
+  if command -v copilot >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    copilot plugin marketplace add "$REPO" >/dev/null 2>&1 || true
+    for plugin_name in $MARKETPLACE_PLUGINS; do
+      if copilot plugin install "$plugin_name@simplicio" >/dev/null 2>&1; then
+        ok "plugin $plugin_name instalado no GitHub Copilot CLI"
+      else
+        warn "GitHub Copilot CLI detectado, mas $plugin_name@simplicio não pôde ser instalado"
+        failures=$((failures + 1))
+      fi
+    done
+  fi
+
+  if command -v qwen >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    for plugin_name in $MARKETPLACE_PLUGINS; do
+      if qwen extensions install "$REPO:$plugin_name" >/dev/null 2>&1; then
+        ok "extensão $plugin_name instalada no Qwen Code"
+      else
+        warn "Qwen Code detectado, mas $plugin_name não pôde ser instalado"
+        failures=$((failures + 1))
+      fi
+    done
+  fi
+
+  if command -v hermes >/dev/null 2>&1; then
+    detected=$((detected + 1))
+    if hermes plugins install "$REPO/plugins/simplicio-hermes" --force --enable >/dev/null 2>&1 &&
+       hermes plugins doctor simplicio-hermes --ci >/dev/null 2>&1; then
+      ok "plugin simplicio-hermes instalado, habilitado e validado"
+    else
+      warn "Hermes detectado, mas o plugin simplicio-hermes não pôde ser instalado e habilitado"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  cursor_detected=0
+  if command -v cursor >/dev/null 2>&1 || command -v cursor-agent >/dev/null 2>&1 ||
+     [ -d "$HOME/.cursor" ] || [ -d "$HOME/Library/Application Support/Cursor" ]; then
+    cursor_detected=1
+  fi
+  if [ "$cursor_detected" -eq 1 ]; then
+    detected=$((detected + 1))
+    if ! install_portable_agent_plugin "$HOME/.cursor/plugins/local/simplicio" "Cursor"; then
+      failures=$((failures + 1))
+    fi
+  fi
+
+  kiro_detected=0
+  if command -v kiro >/dev/null 2>&1 || command -v kiro-cli >/dev/null 2>&1 ||
+     [ -d "$HOME/.kiro" ] || [ -d "/Applications/Kiro.app" ]; then
+    kiro_detected=1
+  fi
+  if [ "$kiro_detected" -eq 1 ]; then
+    detected=$((detected + 1))
+    if ! install_portable_agent_plugin "$HOME/.kiro/powers/simplicio" "Kiro"; then
+      failures=$((failures + 1))
+    fi
+  fi
+
   if [ "$detected" -eq 0 ]; then
-    info "nenhum host com pacote nativo detectado; o registro MCP cobre os demais clientes"
+    info "nenhum host com pacote de plugin compatível detectado; o registro MCP cobre os demais clientes"
   fi
   [ "$failures" -eq 0 ]
 }
@@ -629,13 +740,14 @@ else
   err "o Runtime foi instalado, mas o registro automático de MCP/hooks falhou: $DEST_PATH mcp register --binary $DEST_PATH --json"
 fi
 
-# Native packages add skills, commands and host-specific lifecycle behavior on
-# top of the Runtime MCP registration. Only hosts with a documented installer
-# contract are attempted; every other detected client stays on MCP/hooks.
+# Host packages add skills, commands and host-specific lifecycle behavior on
+# top of Runtime MCP registration. Every detected host with a documented
+# package surface is installed automatically; MCP remains the compatibility
+# path for clients without a package API.
 if install_detected_host_plugins; then
   ok "plugins nativos reconciliados para os hosts detectados"
 else
-  warn "Runtime/MCP estão prontos, mas um ou mais plugins nativos exigem ação manual; consulte PLUGIN.md"
+  err "Runtime/MCP estão prontos, mas a instalação automática de um ou mais plugins detectados falhou; consulte PLUGIN.md"
 fi
 report_login_state
 ok "MCP direto: $DEST_PATH serve --mcp --stdio; SIMPLICIO_MCP_URL=${SIMPLICIO_MCP_URL}"

--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -1,34 +1,29 @@
 # Simplicio Hermes native adapter
 
-`simplicio-hermes` is a thin native middleware adapter. It calls the
-deterministic Runtime bridges `prepare_model_call` and
-`record_model_result`; it does not call an LLM, select a model, activate fan
-out, or duplicate Mapper/Runtime logic.
+`simplicio-hermes` ships a native Python plugin for current Hermes Agent and a
+thin JavaScript middleware adapter for compatible embedders. Both call the
+deterministic Runtime bridges `prepare_model_call` and `record_model_result`;
+neither calls an LLM, selects a model, activates fan-out, or duplicates
+Mapper/Runtime logic.
 
-The adapter registers `on_session_start`, `llm_request`, `llm_execution`,
-`post_api_request`, and `api_request_error`. `llm_request` must complete before
-Hermes sends the provider request. The exact provider, model, tools, streaming
-flags, cache directives, and provider-specific options are copied unchanged.
-Only the bounded `ContextPacket` returned by Runtime is added to `messages` or
-Responses `input`.
+The native plugin registers `on_session_start`, `pre_llm_call`,
+`post_llm_call`, and `on_session_end`. `pre_llm_call` completes before Hermes
+enters its tool-calling loop and injects only the bounded Runtime context
+receipt. `post_llm_call` records the matching provider result receipt. Hermes'
+native `pre_llm_call` contract is context-only and fail-open, so the plugin does
+not claim that a Runtime failure can block the provider call.
 
-```js
-import { createHermesPlugin } from "simplicio-hermes";
-
-const plugin = createHermesPlugin({ runtime, mode: "enforce" });
-// Hermes registers plugin.hooks using its native middleware registry.
+```bash
+hermes plugins install wesleysimplicio/simplicio/plugins/simplicio-hermes --force --enable
+hermes plugins doctor simplicio-hermes --ci
 ```
 
-Use `enforce` when a request must not proceed without a preparation receipt;
-use `best_effort` only when Hermes' fail-open behavior is explicitly desired.
-Every status has a stable reason code, and `protected` is false until context,
-provider-path, and usage receipt stages are all observed.
+The official Simplicio installers run both commands automatically when `hermes`
+is detected. Restart a running Hermes CLI or gateway after installation so its
+plugin registry reloads.
 
-## Installation boundary
-
-The package and manifest are shipped here, but the repository does not contain
-a Hermes executable or a verified Hermes 0.20.x plugin-install API. Therefore
-the generic host registry remains fail-closed for `hermes-agent` until a clean
-profile proves installation, repair, plugin enablement, MCP availability, and
-multi-step provider coverage. `hermes mcp test simplicio` alone must not turn
-the protected status green.
+The JavaScript adapter remains available through `index.mjs` for embedders that
+provide the richer `llm_request`/`llm_execution` middleware contract. A clean
+Hermes installation is verified through the native manifest parser and hook
+registration path; `hermes mcp test simplicio` alone is not treated as plugin
+proof.

--- a/plugins/simplicio-hermes/__init__.py
+++ b/plugins/simplicio-hermes/__init__.py
@@ -1,0 +1,5 @@
+"""Native Hermes Agent plugin entry point."""
+
+from .hermes_plugin import register
+
+__all__ = ["register"]

--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -1,0 +1,261 @@
+"""Native Hermes hooks backed by the verified Simplicio Runtime MCP."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+from pathlib import Path
+import queue
+import subprocess
+import threading
+import uuid
+from typing import Any
+
+
+LOGGER = logging.getLogger(__name__)
+_PROTOCOL_VERSION = "2024-11-05"
+_DEFAULT_TIMEOUT_SECONDS = 20.0
+_MAX_CONTEXT_BYTES = 16_384
+
+
+class SimplicioHermesError(RuntimeError):
+    """Raised when the Runtime preparation path cannot produce a receipt."""
+
+
+def _runtime_candidates() -> list[Path]:
+    home = Path.home()
+    executable = "simplicio.exe" if os.name == "nt" else "simplicio"
+    return [
+        home / ".simplicio" / "bin" / executable,
+        home / ".local" / "bin" / executable,
+    ]
+
+
+def _find_runtime() -> Path:
+    for candidate in _runtime_candidates():
+        if candidate.is_file() and (os.name == "nt" or os.access(candidate, os.X_OK)):
+            return candidate
+    raise SimplicioHermesError("verified Simplicio Runtime binary was not found")
+
+
+class RuntimeMcpBridge:
+    """Small newline-delimited MCP client owned by the Hermes plugin process."""
+
+    def __init__(self, binary: Path | None = None, timeout: float = _DEFAULT_TIMEOUT_SECONDS):
+        self.binary = binary
+        self.timeout = timeout
+        self._process: subprocess.Popen[str] | None = None
+        self._lock = threading.RLock()
+        self._next_id = 1
+
+    def _readline(self) -> str:
+        if self._process is None or self._process.stdout is None:
+            raise SimplicioHermesError("Runtime MCP process is not available")
+        result: queue.Queue[str | BaseException] = queue.Queue(maxsize=1)
+
+        def read() -> None:
+            try:
+                result.put(self._process.stdout.readline())
+            except BaseException as error:  # pragma: no cover - defensive transport guard
+                result.put(error)
+
+        threading.Thread(target=read, daemon=True).start()
+        try:
+            value = result.get(timeout=self.timeout)
+        except queue.Empty as error:
+            self.close()
+            raise SimplicioHermesError("Runtime MCP response timed out") from error
+        if isinstance(value, BaseException):
+            raise SimplicioHermesError("Runtime MCP response could not be read") from value
+        if not value:
+            self.close()
+            raise SimplicioHermesError("Runtime MCP process closed stdout")
+        return value
+
+    def _write(self, message: dict[str, Any]) -> None:
+        if self._process is None or self._process.stdin is None:
+            raise SimplicioHermesError("Runtime MCP process is not available")
+        self._process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self._process.stdin.flush()
+
+    def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        request_id = self._next_id
+        self._next_id += 1
+        self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        while True:
+            try:
+                response = json.loads(self._readline())
+            except json.JSONDecodeError as error:
+                raise SimplicioHermesError("Runtime MCP returned invalid JSON") from error
+            if response.get("id") != request_id:
+                continue
+            if "error" in response:
+                raise SimplicioHermesError(f"Runtime MCP {method} failed: {response['error']}")
+            result = response.get("result")
+            if not isinstance(result, dict):
+                raise SimplicioHermesError(f"Runtime MCP {method} returned no result")
+            return result
+
+    def _ensure_started(self) -> None:
+        if self._process is not None and self._process.poll() is None:
+            return
+        binary = self.binary or _find_runtime()
+        self._process = subprocess.Popen(
+            [str(binary), "serve", "--mcp", "--stdio", "--no-facade-mode"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            bufsize=1,
+        )
+        initialized = self._request(
+            "initialize",
+            {
+                "protocolVersion": _PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "simplicio-hermes", "version": "0.2.0"},
+            },
+        )
+        server_info = initialized.get("serverInfo", {})
+        if server_info.get("name") != "simplicio":
+            self.close()
+            raise SimplicioHermesError("unexpected Runtime MCP server identity")
+        self._write({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+    @staticmethod
+    def _content_payload(result: dict[str, Any]) -> dict[str, Any]:
+        for item in result.get("content", []):
+            if not isinstance(item, dict) or item.get("type") != "text":
+                continue
+            text = item.get("text")
+            if not isinstance(text, str):
+                continue
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                return {"text": text}
+            if isinstance(payload, dict):
+                return payload
+        raise SimplicioHermesError("Runtime MCP tool returned no text receipt")
+
+    def call(self, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self._ensure_started()
+            return self._content_payload(
+                self._request("tools/call", {"name": tool, "arguments": arguments})
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            process, self._process = self._process, None
+            if process is None:
+                return
+            if process.stdin is not None:
+                try:
+                    process.stdin.close()
+                except OSError:
+                    pass
+            if process.poll() is None:
+                process.terminate()
+
+
+_BRIDGE = RuntimeMcpBridge()
+_PREPARED: dict[str, dict[str, Any]] = {}
+_STATE_LOCK = threading.RLock()
+
+
+def _bounded_context(receipt: dict[str, Any]) -> str:
+    packet = receipt.get("context_packet") or receipt.get("context") or receipt
+    encoded = json.dumps(packet, ensure_ascii=False, separators=(",", ":"))
+    raw = encoded.encode("utf-8")
+    if len(raw) > _MAX_CONTEXT_BYTES:
+        encoded = raw[:_MAX_CONTEXT_BYTES].decode("utf-8", errors="ignore")
+    return "Simplicio Runtime context (verified pre_llm_call receipt):\n" + encoded
+
+
+def _pre_llm_call(
+    session_id: str = "",
+    user_message: str = "",
+    model: str = "",
+    platform: str = "",
+    **kwargs: Any,
+) -> dict[str, str] | None:
+    host_session_id = session_id or str(uuid.uuid4())
+    turn_id = str(kwargs.get("turn_id") or uuid.uuid4())
+    api_request_id = str(kwargs.get("api_request_id") or uuid.uuid4())
+    provider = str(kwargs.get("provider") or platform or "unknown")
+    selected_model = str(model or kwargs.get("model") or "unknown")
+    arguments = {
+        "repo": str(kwargs.get("cwd") or os.getcwd()),
+        "host": "hermes",
+        "host_session_id": host_session_id,
+        "turn_id": turn_id,
+        "api_request_id": api_request_id,
+        "provider": provider,
+        "model": selected_model,
+        "task": str(user_message),
+        "protection_mode": "best_effort",
+    }
+    try:
+        receipt = _BRIDGE.call("simplicio_prepare_model_call", arguments)
+    except Exception as error:  # Hermes pre_llm_call is context-only and fail-open by contract.
+        LOGGER.warning("Simplicio pre_llm_call preparation failed: %s", error)
+        return None
+    with _STATE_LOCK:
+        _PREPARED[host_session_id] = {"arguments": arguments, "receipt": receipt}
+    return {"context": _bounded_context(receipt)}
+
+
+def _post_llm_call(
+    session_id: str = "",
+    model: str = "",
+    platform: str = "",
+    **kwargs: Any,
+) -> None:
+    with _STATE_LOCK:
+        prepared = _PREPARED.get(session_id)
+    if prepared is None:
+        return
+    original = prepared["arguments"]
+    arguments = {
+        "repo": original["repo"],
+        "host": "hermes",
+        "host_session_id": original["host_session_id"],
+        "turn_id": original["turn_id"],
+        "api_request_id": original["api_request_id"],
+        "provider": str(kwargs.get("provider") or platform or original["provider"]),
+        "model": str(model or kwargs.get("model") or original["model"]),
+        "provider_request_id": str(kwargs.get("provider_request_id") or original["api_request_id"]),
+        "status": "completed",
+        "prepared_receipt": prepared["receipt"],
+    }
+    try:
+        _BRIDGE.call("simplicio_record_model_result", arguments)
+    except Exception as error:
+        LOGGER.warning("Simplicio post_llm_call receipt failed: %s", error)
+
+
+def _on_session_start(**_kwargs: Any) -> None:
+    return None
+
+
+def _on_session_end(session_id: str = "", **_kwargs: Any) -> None:
+    with _STATE_LOCK:
+        _PREPARED.pop(session_id, None)
+
+
+def register(ctx: Any) -> None:
+    """Register the native Hermes lifecycle hooks."""
+    ctx.register_hook("on_session_start", _on_session_start)
+    ctx.register_hook("pre_llm_call", _pre_llm_call)
+    ctx.register_hook("post_llm_call", _post_llm_call)
+    ctx.register_hook("on_session_end", _on_session_end)
+
+
+atexit.register(_BRIDGE.close)
+
+
+__all__ = ["RuntimeMcpBridge", "SimplicioHermesError", "register"]

--- a/plugins/simplicio-hermes/plugin.yaml
+++ b/plugins/simplicio-hermes/plugin.yaml
@@ -1,0 +1,9 @@
+name: simplicio-hermes
+version: 0.2.0
+description: Simplicio Runtime context preparation and provider receipts for Hermes Agent.
+author: Wesley Simplicio
+provides_hooks:
+  - on_session_start
+  - pre_llm_call
+  - post_llm_call
+  - on_session_end

--- a/plugins/simplicio/README.md
+++ b/plugins/simplicio/README.md
@@ -15,6 +15,7 @@ surface, and ships the same governed Simplicio skills.
 | Claude Code | `.claude-plugin/plugin.json` | Native Claude Code plugin |
 | Cursor, GitHub Copilot, Kiro, Qwen Code | `plugin.json` + `mcp.json` | Agent Plugins v1 |
 | Gemini CLI | `gemini-extension.json` | Native Gemini extension |
+| Hermes Agent | `../simplicio-hermes/plugin.yaml` | Native Hermes Python plugin |
 | Other CLI/IDE/agent harnesses | Runtime `mcp register` | MCP/config or guided integration |
 
 The package does not pretend every product has the same plugin API. The

--- a/plugins/simplicio/host-surfaces.json
+++ b/plugins/simplicio/host-surfaces.json
@@ -15,7 +15,7 @@
     {"id":"antigravity","name":"Antigravity","surface":"runtime-mcp","preHooks":"runtime-managed"},
     {"id":"pi","name":"Pi","surface":"runtime-mcp","preHooks":"runtime-managed"},
     {"id":"oh-my-pi","name":"oh-my-pi","surface":"runtime-mcp","preHooks":"runtime-managed"},
-    {"id":"hermes","name":"Hermes Agent","surface":"runtime-mcp","preHooks":"runtime-managed"},
+    {"id":"hermes","name":"Hermes Agent","surface":"native-plugin","manifest":"../simplicio-hermes/plugin.yaml","preHooks":"host-managed"},
     {"id":"devin","name":"Devin","surface":"guided-runtime","preHooks":"runtime-managed"},
     {"id":"goose","name":"Goose","surface":"runtime-mcp","preHooks":"runtime-managed"},
     {"id":"auggie","name":"Auggie","surface":"runtime-mcp","preHooks":"runtime-managed"},

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).parents[1]
+ADAPTER = ROOT / "plugins" / "simplicio-hermes" / "hermes_plugin.py"
+
+
+def load_adapter() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("test_simplicio_hermes_adapter", ADAPTER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.hooks = {}
+
+    def register_hook(self, name, callback) -> None:
+        self.hooks[name] = callback
+
+
+class FakeBridge:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def call(self, tool, arguments):
+        self.calls.append((tool, arguments))
+        if tool == "simplicio_prepare_model_call":
+            return {"context_packet": {"summary": "bounded context", "digest": "abc123"}}
+        return {"status": "recorded"}
+
+
+def test_hermes_manifest_and_package_entrypoint_are_installable() -> None:
+    package_manifest = (
+        ROOT / "plugins" / "simplicio-hermes" / "plugin.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert "name: simplicio-hermes" in package_manifest
+    assert "  - pre_llm_call" in package_manifest
+    assert "  - post_llm_call" in package_manifest
+    assert (ROOT / "plugins" / "simplicio-hermes" / "__init__.py").is_file()
+
+
+def test_hermes_pre_llm_hook_prepares_context_and_post_hook_records_receipt() -> None:
+    adapter = load_adapter()
+    bridge = FakeBridge()
+    adapter._BRIDGE = bridge
+    adapter._PREPARED.clear()
+    context = FakeContext()
+    adapter.register(context)
+
+    assert set(context.hooks) == {
+        "on_session_start",
+        "pre_llm_call",
+        "post_llm_call",
+        "on_session_end",
+    }
+
+    result = context.hooks["pre_llm_call"](
+        session_id="session-1",
+        user_message="Map this repository",
+        model="hermes-model",
+        platform="openrouter",
+        cwd=str(ROOT),
+    )
+    assert result is not None
+    assert "bounded context" in result["context"]
+    prepare_tool, prepare_args = bridge.calls[0]
+    assert prepare_tool == "simplicio_prepare_model_call"
+    assert prepare_args["host"] == "hermes"
+    assert prepare_args["host_session_id"] == "session-1"
+    assert prepare_args["task"] == "Map this repository"
+
+    context.hooks["post_llm_call"](
+        session_id="session-1",
+        model="hermes-model",
+        platform="openrouter",
+        provider_request_id="provider-1",
+    )
+    record_tool, record_args = bridge.calls[1]
+    assert record_tool == "simplicio_record_model_result"
+    assert record_args["prepared_receipt"]["context_packet"]["digest"] == "abc123"
+    assert record_args["provider_request_id"] == "provider-1"
+
+    json.dumps(record_args)

--- a/tests/test_installer_host_plugins_contract.py
+++ b/tests/test_installer_host_plugins_contract.py
@@ -14,9 +14,20 @@ def test_shell_installs_documented_native_plugins_after_runtime_registration() -
     assert "codex plugin add simplicio@simplicio-codex" in text
     assert 'command -v claude' in text
     assert 'claude plugin marketplace add "$REPO"' in text
-    assert "claude plugin install simplicio@simplicio --scope user" in text
+    assert 'MARKETPLACE_PLUGINS="simplicio simplicio-loop simplicio-prompt simplicio-sprint simplicio-hermes"' in text
+    assert 'claude plugin install "$plugin_name@simplicio" --scope user' in text
     assert 'command -v gemini' in text
     assert 'gemini extensions install "$plugin_dir" --consent' in text
+    assert 'command -v copilot' in text
+    assert 'copilot plugin install "$plugin_name@simplicio"' in text
+    assert 'command -v qwen' in text
+    assert 'qwen extensions install "$REPO:$plugin_name"' in text
+    assert 'command -v hermes' in text
+    assert 'hermes plugins install "$REPO/plugins/simplicio-hermes" --force --enable' in text
+    assert 'hermes plugins doctor simplicio-hermes --ci' in text
+    assert '"$HOME/.cursor/plugins/local/simplicio"' in text
+    assert '"$HOME/.kiro/powers/simplicio"' in text
+    assert 'err "Runtime/MCP estão prontos, mas a instalação automática' in text
     assert text.index(registration) < text.index(plugin_install, text.index(registration))
 
 
@@ -30,13 +41,24 @@ def test_powershell_installs_documented_native_plugins_after_runtime_registratio
     assert '@("plugin", "add", "simplicio@simplicio-codex")' in text
     assert "Get-Command claude -CommandType Application" in text
     assert '@("plugin", "marketplace", "add", $Repo)' in text
-    assert '@("plugin", "install", "simplicio@simplicio", "--scope", "user")' in text
+    assert '$MarketplacePlugins = @("simplicio", "simplicio-loop", "simplicio-prompt", "simplicio-sprint", "simplicio-hermes")' in text
+    assert '@("plugin", "install", "$pluginName@simplicio", "--scope", "user")' in text
     assert "Get-Command gemini -CommandType Application" in text
     assert '@("extensions", "install", $manifest.DirectoryName, "--consent")' in text
+    assert "Get-Command copilot -CommandType Application" in text
+    assert '@("plugin", "install", "$pluginName@simplicio")' in text
+    assert "Get-Command qwen -CommandType Application" in text
+    assert '@("extensions", "install", "${Repo}:$pluginName")' in text
+    assert "Get-Command hermes -CommandType Application" in text
+    assert '@("plugins", "install", "$Repo/plugins/simplicio-hermes", "--force", "--enable")' in text
+    assert '@("plugins", "doctor", "simplicio-hermes", "--ci")' in text
+    assert '".cursor\\plugins\\local\\simplicio"' in text
+    assert '".kiro\\powers\\simplicio"' in text
+    assert 'Write-Error "Runtime/MCP are ready, but automatic installation' in text
     assert text.index(registration) < text.index(plugin_install, text.index(registration))
 
 
-def test_host_plugin_bootstrap_is_idempotent_and_does_not_guess_unsupported_clis() -> None:
+def test_host_plugin_bootstrap_is_idempotent_and_uses_documented_surfaces() -> None:
     shell = (ROOT / "install.sh").read_text(encoding="utf-8")
     powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
     bootstrap = (
@@ -45,12 +67,7 @@ def test_host_plugin_bootstrap_is_idempotent_and_does_not_guess_unsupported_clis
 
     for text in (shell, powershell):
         assert "SIMPLICIO_INSTALL_HOST_PLUGINS" in text
-        for unsupported in (
-            "cursor plugin install",
-            "code plugin install",
-            "kiro plugin install",
-            "qwen plugin install",
-        ):
+        for unsupported in ("cursor plugin install", "code plugin install", "kiro plugin install"):
             assert unsupported not in text.lower()
 
     assert 'SIMPLICIO_INSTALL_HOST_PLUGINS: "0"' in bootstrap


### PR DESCRIPTION
## Summary

- Installs every compatible published Simplicio plugin automatically after Runtime MCP/hooks registration.
- Installs all five marketplace plugins in Claude Code, GitHub Copilot CLI, and Qwen Code.
- Installs the native Codex and Gemini packages plus the portable Agent Plugin for detected Cursor and Kiro installations.
- Adds a valid native Hermes Python plugin, installs it from the repository subdirectory with --enable, validates it with Hermes doctor, injects bounded Runtime context from pre_llm_call, and records the correlated post_llm_call receipt.
- Fails the installer clearly when a detected compatible host package cannot be installed.

## Tracking issue

Related: direct maintainer request (no issue).

## Quality evidence

- [x] Local deterministic quality gate is green: 253 tests and 30 subtests passed.
- [x] Shell syntax and PowerShell parser passed.
- [x] Hermes plugin doctor passed through the real manifest parser, importer, and hook registry.
- [x] Live Hermes-to-Runtime prepare and record round-trip passed.
- [x] Node bootstrap and native middleware tests passed.
- [x] Repository source policy and patch whitespace passed.
- [x] No test is skipped.
- [x] No benchmark behavior changed.

## Regression test

- tests/test_installer_host_plugins_contract.py verifies every documented automatic installer surface and fail-closed completion.
- tests/test_hermes_native_plugin.py verifies the native Hermes manifest, four hook registrations, bounded context injection, and correlated result recording.

## Exceptions

GitHub-hosted Actions currently cannot start because the account is locked by an unrelated billing issue. The equivalent repository policy and full test suite pass locally.