### PR TITLE
feat(desktop): add Bot Center contract projection

### DIFF
--- a/apps/desktop/e2e/desktop.spec.ts
+++ b/apps/desktop/e2e/desktop.spec.ts
@@ -61,6 +61,17 @@ test("all navigation, provider, receipt, and account controls work", async ({ pa
   await expect(page.getByRole("heading", { name: "Entre no Simplicio" })).toBeVisible();
 });
 
+test("Bot Center exposes the canonical roster, timeline, rooms, and honest computer state", async ({ page }) => {
+  await page.goto("/?state=active&view=bot");
+  await expect(page.getByRole("heading", { name: "Bot Center" })).toBeVisible();
+  await expect(page.getByText("Roster canônico")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Cora" })).toBeVisible();
+  await expect(page.getByText("Rooms", { exact: true })).toBeVisible();
+  await expect(page.getByText("computer_backend_unavailable")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Assumir controle" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Aprovar" })).toBeVisible();
+});
+
 test("primary layouts fit desktop and compact widths", async ({ page }) => {
   for (const width of [1280, 768, 390]) {
     await page.setViewportSize({ width, height: 900 });

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -280,6 +280,14 @@ async fn desktop_open_subscription() -> Result<(), String> {
     .map_err(|_| "Falha interna ao abrir os planos".to_string())?
 }
 
+/// The Desktop owns the transport boundary, not the Bot/Agent authority.
+/// Runtime releases that expose Agent API can replace this implementation
+/// without changing the frontend contract; until then, fail closed.
+#[tauri::command]
+async fn desktop_bot_action(_request: Value) -> Result<Value, String> {
+    Err("Agent API do Runtime indisponível (agent_api_unavailable)".to_string())
+}
+
 #[tauri::command]
 async fn runtime_status() -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(|| run_runtime_json(STATUS_ARGS))
@@ -297,6 +305,7 @@ pub fn run() {
             desktop_logout,
             desktop_repair_providers,
             desktop_open_subscription,
+            desktop_bot_action,
             runtime_status
         ])
         .run(tauri::generate_context!())

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -5,6 +5,8 @@ import { createDemoSnapshot } from "./demo";
 import { MemoryScreen } from "./screens/MemoryScreen";
 import { SettingsScreen, redactedDiagnostic } from "./screens/SettingsScreen";
 import { ActivityScreen, redactedActivity } from "./screens/ActivityScreen";
+import { BotCenterScreen } from "./screens/BotCenterScreen";
+import { createDemoBotCenter, createUnavailableBotCenter } from "./bot_center";
 
 describe("Simplicio Desktop product states", () => {
   it("offers browser login when there is no identity", () => {
@@ -91,5 +93,26 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("Todos");
     expect(html).toContain("máximo 5");
     expect(redactedActivity(snapshot.activity)[0]).not.toHaveProperty("detail");
+  });
+
+  it("renders Bot Center from the canonical projection without local authority", () => {
+    const botCenter = createDemoBotCenter();
+    const html = renderToStaticMarkup(<BotCenterScreen snapshot={botCenter} onAction={async () => undefined} />);
+    expect(html).toContain("Bot Center");
+    expect(html).toContain("Roster canônico");
+    expect(html).toContain("Cora");
+    expect(html).toContain("Rooms");
+    expect(html).toContain("approval_required");
+    expect(html).toContain("computer_backend_unavailable");
+    expect(html).toContain("session: bot-cora-session-01");
+    expect(botCenter.redaction.secrets).toBe(true);
+  });
+
+  it("fails closed when the Runtime has not exposed Agent API", () => {
+    const html = renderToStaticMarkup(<BotCenterScreen snapshot={createUnavailableBotCenter()} onAction={async () => undefined} />);
+    expect(html).toContain("Contrato indisponível");
+    expect(html).toContain("agent_api_unavailable");
+    expect(html).toContain("Nenhum Bot exposto pelo Runtime");
+    expect(html).toContain("disabled");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import type { DesktopSnapshot } from "./contracts";
+import type { BotActionRequest } from "./bot_center";
+import { snapshotWithDemoBots } from "./bot_center";
 import {
   beginDesktopLogin,
   loadDesktopSnapshot,
@@ -7,6 +9,7 @@ import {
   openDesktopSubscription,
   refreshDesktopSnapshot,
   repairDesktopProviders,
+  dispatchDesktopBotAction,
 } from "./bridge";
 import { Shell, type View } from "./components/Shell";
 import { AccessGate, LoadingScreen, SignInScreen } from "./screens/AccessScreens";
@@ -16,12 +19,14 @@ import { SecondaryScreen } from "./screens/SecondaryScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
 import { ActivityScreen } from "./screens/ActivityScreen";
+import { BotCenterScreen } from "./screens/BotCenterScreen";
 
 function initialView(): View {
   if (typeof window === "undefined") return "home";
   const requested = new URLSearchParams(window.location.search).get("view");
   if (
     requested === "home" ||
+    requested === "bot" ||
     requested === "providers" ||
     requested === "activity" ||
     requested === "memory" ||
@@ -34,8 +39,9 @@ function initialView(): View {
 
 export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSnapshot }) {
   const [snapshot, setSnapshot] = useState<DesktopSnapshot | undefined>(initialSnapshot);
+  const [botCenter, setBotCenter] = useState(initialSnapshot?.botCenter);
   const [loadFailed, setLoadFailed] = useState(false);
-  const [action, setAction] = useState<"login" | "logout" | "refresh" | "repair" | "subscribe" | null>(null);
+  const [action, setAction] = useState<"login" | "logout" | "refresh" | "repair" | "subscribe" | "bot" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [view, setView] = useState<View>(initialView);
 
@@ -44,7 +50,10 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     let current = true;
     loadDesktopSnapshot()
       .then((next) => {
-        if (current) setSnapshot(next);
+        if (current) {
+          setSnapshot(next);
+          setBotCenter(next.botCenter);
+        }
       })
       .catch(() => {
         if (current) setLoadFailed(true);
@@ -58,7 +67,9 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     setAction("refresh");
     setActionError(null);
     try {
-      setSnapshot(await refreshDesktopSnapshot());
+      const next = await refreshDesktopSnapshot();
+      setSnapshot(next);
+      setBotCenter(next.botCenter);
       setLoadFailed(false);
     } catch {
       setActionError("Não foi possível atualizar o Runtime.");
@@ -71,7 +82,9 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     setAction("repair");
     setActionError(null);
     try {
-      setSnapshot(await repairDesktopProviders());
+      const next = await repairDesktopProviders();
+      setSnapshot(next);
+      setBotCenter(next.botCenter);
       setLoadFailed(false);
     } catch {
       setActionError("Não foi possível reparar as integrações com segurança.");
@@ -84,7 +97,9 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     setAction("login");
     setActionError(null);
     try {
-      setSnapshot(await beginDesktopLogin());
+      const next = await beginDesktopLogin();
+      setSnapshot(next);
+      setBotCenter(next.botCenter);
       setLoadFailed(false);
     } catch {
       setActionError("O login não foi concluído.");
@@ -109,10 +124,24 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     setAction("logout");
     setActionError(null);
     try {
-      setSnapshot(await logoutDesktop());
+      const next = await logoutDesktop();
+      setSnapshot(next);
+      setBotCenter(next.botCenter);
       setView("home");
     } catch {
       setActionError("Não foi possível sair com segurança.");
+    } finally {
+      setAction(null);
+    }
+  }
+
+  async function botAction(request: BotActionRequest) {
+    setAction("bot");
+    setActionError(null);
+    try {
+      setBotCenter(await dispatchDesktopBotAction(request, botCenter ?? snapshotWithDemoBots(snapshot!)));
+    } catch {
+      setActionError("O Agent API não aceitou esta ação; nenhuma mudança local foi aplicada.");
     } finally {
       setAction(null);
     }
@@ -152,6 +181,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
           onRefresh={refresh}
         />
       )}
+      {view === "bot" && <BotCenterScreen snapshot={botCenter ?? snapshotWithDemoBots(snapshot)} onAction={botAction} />}
       {view === "providers" && (
         <ProvidersScreen
           snapshot={snapshot}
@@ -166,7 +196,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         <SettingsScreen snapshot={snapshot} busy={action === "refresh"} onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"} />
       )}
       {view === "activity" && <ActivityScreen snapshot={snapshot} />}
-      {view !== "home" && view !== "providers" && view !== "memory" && view !== "settings" && view !== "activity" && <SecondaryScreen view={view} snapshot={snapshot} />}
+      {view !== "home" && view !== "bot" && view !== "providers" && view !== "memory" && view !== "settings" && view !== "activity" && <SecondaryScreen view={view} snapshot={snapshot} />}
     </Shell>
   );
 }

--- a/apps/desktop/src/bot_center.ts
+++ b/apps/desktop/src/bot_center.ts
@@ -1,0 +1,231 @@
+import type {
+  BotActionKind,
+  BotCenterSnapshot,
+  BotSessionProjection,
+  BotSummary,
+  BotTimelineEvent,
+  DesktopSnapshot,
+} from "./contracts";
+
+export interface BotActionRequest {
+  kind: BotActionKind;
+  botId: string;
+  sessionId?: string | null;
+  value?: string | null;
+  approvalId?: string | null;
+}
+
+function digest(letter: string): string {
+  return `sha256:${letter.repeat(64)}`;
+}
+
+function demoBot(bot: Omit<BotSummary, "lastActivityAt" | "lastSessionId">, generatedAt: string): BotSummary {
+  return {
+    ...bot,
+    lastActivityAt: generatedAt,
+    lastSessionId: `${bot.botId}-session-01`,
+  };
+}
+
+function event(
+  input: Pick<BotTimelineEvent, "eventId" | "kind" | "actorKind" | "actorId" | "actorLabel" | "content"> & Partial<BotTimelineEvent>,
+): BotTimelineEvent {
+  return {
+    eventId: input.eventId,
+    sessionId: input.sessionId ?? "bot-cora-session-01",
+    botId: input.botId ?? "bot-cora",
+    kind: input.kind,
+    actorKind: input.actorKind,
+    actorId: input.actorId,
+    actorLabel: input.actorLabel,
+    content: input.content,
+    timestamp: input.timestamp ?? "2026-08-30T00:00:00.000Z",
+    causalParentId: input.causalParentId ?? null,
+    state: input.state ?? "complete",
+    toolName: input.toolName,
+    approvalId: input.approvalId,
+    artifactName: input.artifactName,
+    attachmentName: input.attachmentName,
+    reasonCode: input.reasonCode,
+  };
+}
+
+export function createUnavailableBotCenter(generatedAt = new Date().toISOString()): BotCenterSnapshot {
+  return {
+    schema: "simplicio.bot-center-snapshot/v1",
+    generatedAt,
+    source: "runtime",
+    actionAuthority: "unavailable",
+    bots: [],
+    selectedBotId: null,
+    sessions: [],
+    rooms: [],
+    computer: {
+      available: false,
+      computerSessionId: null,
+      botId: null,
+      sessionId: null,
+      state: "blocked",
+      leaseRevision: null,
+      reasonCode: "agent_api_unavailable",
+      lastEventAt: null,
+    },
+    limits: { maxBots: 32, maxEvents: 200, maxRooms: 32 },
+    redaction: { secrets: true, prompts: true, attachmentBodies: true },
+    snapshotDigest: digest("0"),
+  };
+}
+
+export function createDemoBotCenter(generatedAt = new Date().toISOString()): BotCenterSnapshot {
+  const bots: BotSummary[] = [
+    demoBot({
+      botId: "bot-cora",
+      displayName: "Cora",
+      agentProfileId: "profile-cora-dev",
+      profileId: "profile-dev",
+      projectId: "project-simplicio",
+      provider: "OpenAI",
+      model: "gpt-5.6",
+      toolset: ["filesystem", "git", "tests"],
+      skills: ["simplicio-mapper", "simplicio-loop"],
+      lifecycle: "busy",
+      reasonCode: "session_running",
+      capabilities: [
+        { id: "chat", label: "Chat streaming", available: true, reasonCode: "capability_verified" },
+        { id: "tools", label: "Tools governadas", available: true, reasonCode: "capability_verified" },
+        { id: "computer", label: "Computer Use", available: false, reasonCode: "computer_backend_unavailable" },
+      ],
+    }, generatedAt),
+    demoBot({
+      botId: "bot-iris",
+      displayName: "Íris",
+      agentProfileId: "profile-iris-review",
+      profileId: "profile-review",
+      projectId: null,
+      provider: "OpenAI",
+      model: "gpt-5.6",
+      toolset: ["git", "diff"],
+      skills: ["code-review"],
+      lifecycle: "blocked",
+      reasonCode: "provider_capability_unverified",
+      capabilities: [
+        { id: "chat", label: "Chat streaming", available: false, reasonCode: "provider_capability_unverified" },
+        { id: "tools", label: "Tools governadas", available: false, reasonCode: "provider_capability_unverified" },
+        { id: "computer", label: "Computer Use", available: false, reasonCode: "computer_backend_unavailable" },
+      ],
+    }, generatedAt),
+  ];
+
+  const sessionId = "bot-cora-session-01";
+  const events: BotTimelineEvent[] = [
+    event({ eventId: "evt-01", sessionId, botId: "bot-cora", kind: "status", actorKind: "runtime", actorId: "runtime", actorLabel: "Runtime", content: "Sessão aberta com revision 7.", timestamp: generatedAt, reasonCode: "session_started" }),
+    event({ eventId: "evt-02", sessionId, botId: "bot-cora", kind: "message", actorKind: "human", actorId: "human", actorLabel: "Você", content: "Revise a integração do Desktop com os contratos do Runtime.", timestamp: generatedAt }),
+    event({ eventId: "evt-03", sessionId, botId: "bot-cora", kind: "message", actorKind: "bot", actorId: "bot-cora", actorLabel: "Cora", content: "Vou verificar somente as projeções públicas e os reason codes disponíveis.", timestamp: generatedAt, causalParentId: "evt-02" }),
+    event({ eventId: "evt-04", sessionId, botId: "bot-cora", kind: "tool_call", actorKind: "bot", actorId: "bot-cora", actorLabel: "Cora", content: "Solicitou leitura de capabilities do Runtime.", timestamp: generatedAt, causalParentId: "evt-03", toolName: "runtime.capabilities.list" }),
+    event({ eventId: "evt-05", sessionId, botId: "bot-cora", kind: "tool_result", actorKind: "runtime", actorId: "runtime", actorLabel: "Runtime", content: "Capabilities retornadas sem secrets.", timestamp: generatedAt, causalParentId: "evt-04", toolName: "runtime.capabilities.list" }),
+    event({ eventId: "evt-06", sessionId, botId: "bot-cora", kind: "approval_request", actorKind: "runtime", actorId: "runtime", actorLabel: "Runtime", content: "Aguardando aprovação para criar um branch de trabalho.", timestamp: generatedAt, causalParentId: "evt-05", approvalId: "approval-branch-01", state: "blocked", reasonCode: "approval_required" }),
+    event({ eventId: "evt-07", sessionId, botId: "bot-cora", kind: "artifact", actorKind: "bot", actorId: "bot-cora", actorLabel: "Cora", content: "Plano de integração disponível como artifact.", timestamp: generatedAt, causalParentId: "evt-05", artifactName: "desktop-bot-mode-plan.md" }),
+    event({ eventId: "evt-08", sessionId, botId: "bot-cora", kind: "attachment", actorKind: "human", actorId: "human", actorLabel: "Você", content: "Anexo referenciado por hash; corpo não é exposto no snapshot.", timestamp: generatedAt, causalParentId: "evt-02", attachmentName: "runtime-contracts.pdf" }),
+    event({ eventId: "evt-09", sessionId, botId: "bot-cora", kind: "bot_event", actorKind: "bot", actorId: "bot-iris", actorLabel: "Íris", content: "@Cora: a capability de Computer Use ainda não está verificada.", timestamp: generatedAt, causalParentId: "evt-05", reasonCode: "cross_bot_event" }),
+  ];
+
+  const sessions: BotSessionProjection[] = [{
+    sessionId,
+    botId: "bot-cora",
+    roomId: "room-desktop",
+    state: "blocked",
+    revision: 7,
+    events,
+    tokenUsage: { input: 2840, output: 618, cached: 1210, proofKind: "measured" },
+    costUsd: 0.0184,
+    cacheHitPercent: 42.6,
+  }];
+
+  return {
+    schema: "simplicio.bot-center-snapshot/v1",
+    generatedAt,
+    source: "preview",
+    actionAuthority: "preview",
+    bots,
+    selectedBotId: "bot-cora",
+    sessions,
+    rooms: [{
+      roomId: "room-desktop",
+      displayName: "Desktop · Bot Mode",
+      members: [
+        { id: "human", label: "Você", kind: "human", role: "owner" },
+        { id: "bot-cora", label: "Cora", kind: "bot", role: "operator" },
+        { id: "bot-iris", label: "Íris", kind: "bot", role: "reviewer" },
+      ],
+      sessionId,
+      unread: 1,
+    }],
+    computer: {
+      available: false,
+      computerSessionId: null,
+      botId: "bot-cora",
+      sessionId,
+      state: "blocked",
+      leaseRevision: null,
+      reasonCode: "computer_backend_unavailable",
+      lastEventAt: generatedAt,
+    },
+    limits: { maxBots: 32, maxEvents: 200, maxRooms: 32 },
+    redaction: { secrets: true, prompts: true, attachmentBodies: true },
+    snapshotDigest: digest("c"),
+  };
+}
+
+function sessionFor(snapshot: BotCenterSnapshot, request: BotActionRequest): BotSessionProjection | undefined {
+  return snapshot.sessions.find((session) => session.sessionId === request.sessionId)
+    ?? snapshot.sessions.find((session) => session.botId === request.botId);
+}
+
+export function applyDemoBotAction(snapshot: BotCenterSnapshot, request: BotActionRequest): BotCenterSnapshot {
+  if (snapshot.actionAuthority !== "preview") return snapshot;
+  const session = sessionFor(snapshot, request);
+  if (!session || request.kind === "take_over" || request.kind === "hand_back") return snapshot;
+  const now = new Date().toISOString();
+  const labels: Record<Exclude<BotActionKind, "send_turn" | "take_over" | "hand_back">, string> = {
+    interrupt: "Interrupção solicitada ao Runtime.",
+    cancel: "Cancelamento solicitado ao Runtime.",
+    steer: request.value ? `Steer enviado: ${request.value}` : "Steer enviado ao Runtime.",
+    resume: "Retomada solicitada ao Runtime.",
+    branch: "Branch solicitado ao Runtime; aguardando receipt.",
+    handoff: "Handoff solicitado ao Runtime.",
+    approve: "Aprovação enviada ao Runtime.",
+    deny: "Negação enviada ao Runtime.",
+  };
+  const content = request.kind === "send_turn"
+    ? request.value?.trim() || "Turn vazio ignorado."
+    : labels[request.kind];
+  const nextEvent = event({
+    eventId: `evt-local-${Date.now()}`,
+    sessionId: session.sessionId,
+    botId: session.botId,
+    kind: request.kind === "send_turn" ? "message" : request.kind === "approve" || request.kind === "deny" ? "approval_decision" : "status",
+    actorKind: request.kind === "send_turn" ? "human" : "runtime",
+    actorId: request.kind === "send_turn" ? "human" : "runtime",
+    actorLabel: request.kind === "send_turn" ? "Você" : "Runtime",
+    content,
+    timestamp: now,
+    causalParentId: session.events.at(-1)?.eventId ?? null,
+    approvalId: request.approvalId,
+    reasonCode: "preview_action",
+  });
+  const nextState = request.kind === "interrupt" || request.kind === "cancel" ? "paused" : request.kind === "resume" ? "running" : session.state;
+  const nextSession: BotSessionProjection = { ...session, state: nextState, revision: session.revision + 1, events: [...session.events, nextEvent] };
+  return {
+    ...snapshot,
+    generatedAt: now,
+    sessions: snapshot.sessions.map((item) => item.sessionId === nextSession.sessionId ? nextSession : item),
+    snapshotDigest: digest("d"),
+  };
+}
+
+export function snapshotWithDemoBots(snapshot: DesktopSnapshot): BotCenterSnapshot {
+  if (snapshot.botCenter) return snapshot.botCenter;
+  return snapshot.source === "preview"
+    ? createDemoBotCenter(snapshot.generatedAt)
+    : createUnavailableBotCenter(snapshot.generatedAt);
+}

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -1,6 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { AccessState, DesktopSnapshot } from "./contracts";
 import { createDemoSnapshot } from "./demo";
+import type { BotCenterSnapshot } from "./contracts";
+import type { BotActionRequest } from "./bot_center";
+import { applyDemoBotAction } from "./bot_center";
 
 function previewState(): AccessState {
   const requested = new URLSearchParams(window.location.search).get("state");
@@ -49,6 +52,14 @@ export async function repairDesktopProviders(): Promise<DesktopSnapshot> {
     120_000,
     "Tempo limite do reparo de integrações excedido.",
   );
+}
+
+export async function dispatchDesktopBotAction(
+  request: BotActionRequest,
+  current: BotCenterSnapshot,
+): Promise<BotCenterSnapshot> {
+  if (!isTauri()) return applyDemoBotAction(current, request);
+  return invoke<BotCenterSnapshot>("desktop_bot_action", { request });
 }
 
 export async function openDesktopSubscription(): Promise<void> {

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -3,10 +3,11 @@ import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
 import { t } from "../i18n";
 
-export type View = "home" | "providers" | "activity" | "memory" | "settings";
+export type View = "home" | "bot" | "providers" | "activity" | "memory" | "settings";
 
 const navigation: Array<{ id: View; label: string; icon: GlyphName }> = [
   { id: "home", label: t("nav.home"), icon: "home" },
+  { id: "bot", label: "Bot Center", icon: "spark" },
   { id: "providers", label: t("nav.providers"), icon: "providers" },
   { id: "activity", label: t("nav.activity"), icon: "activity" },
   { id: "memory", label: t("nav.memory"), icon: "memory" },
@@ -29,7 +30,7 @@ export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
         <Brand />
         <nav className="primary-nav" aria-label="Navegação principal">
           <p className="nav-caption">VISÃO GERAL</p>
-          {navigation.slice(0, 3).map((item) => (
+          {navigation.slice(0, 4).map((item) => (
             <button
               key={item.id}
               className={`nav-item ${view === item.id ? "active" : ""}`}
@@ -48,7 +49,7 @@ export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
             </button>
           ))}
           <p className="nav-caption nav-caption-spaced">SISTEMA</p>
-          {navigation.slice(3).map((item) => (
+          {navigation.slice(4).map((item) => (
             <button
               key={item.id}
               className={`nav-item ${view === item.id ? "active" : ""}`}

--- a/apps/desktop/src/contracts.ts
+++ b/apps/desktop/src/contracts.ts
@@ -95,6 +95,134 @@ export interface ActivityItem {
   status: "verified" | "running" | "attention";
 }
 
+export type BotLifecycle = "disabled" | "idle" | "active" | "busy" | "degraded" | "blocked";
+export type BotControlState = "bot_control" | "human_control" | "paused" | "blocked";
+export type BotActionKind =
+  | "send_turn"
+  | "interrupt"
+  | "cancel"
+  | "steer"
+  | "resume"
+  | "branch"
+  | "handoff"
+  | "approve"
+  | "deny"
+  | "take_over"
+  | "hand_back";
+
+export interface BotCapability {
+  id: string;
+  label: string;
+  available: boolean;
+  reasonCode: string;
+}
+
+export interface BotSummary {
+  botId: string;
+  displayName: string;
+  agentProfileId: string;
+  profileId: string;
+  projectId: string | null;
+  provider: string | null;
+  model: string | null;
+  toolset: string[];
+  skills: string[];
+  lifecycle: BotLifecycle;
+  reasonCode: string;
+  lastSessionId: string | null;
+  lastActivityAt: string | null;
+  capabilities: BotCapability[];
+}
+
+export type BotEventKind =
+  | "message"
+  | "tool_call"
+  | "tool_result"
+  | "approval_request"
+  | "approval_decision"
+  | "artifact"
+  | "attachment"
+  | "status"
+  | "bot_event";
+
+export interface BotTimelineEvent {
+  eventId: string;
+  sessionId: string;
+  botId: string;
+  kind: BotEventKind;
+  actorKind: "human" | "bot" | "runtime";
+  actorId: string;
+  actorLabel: string;
+  content: string;
+  timestamp: string;
+  causalParentId: string | null;
+  state: "streaming" | "complete" | "blocked";
+  toolName?: string | null;
+  approvalId?: string | null;
+  artifactName?: string | null;
+  attachmentName?: string | null;
+  reasonCode?: string | null;
+}
+
+export interface BotSessionProjection {
+  sessionId: string;
+  botId: string;
+  roomId: string | null;
+  state: "idle" | "running" | "paused" | "blocked" | "completed";
+  revision: number;
+  events: BotTimelineEvent[];
+  tokenUsage: {
+    input: number | null;
+    output: number | null;
+    cached: number | null;
+    proofKind: "measured" | "unavailable";
+  };
+  costUsd: number | null;
+  cacheHitPercent: number | null;
+}
+
+export interface BotRoomProjection {
+  roomId: string;
+  displayName: string;
+  members: Array<{ id: string; label: string; kind: "human" | "bot"; role: string }>;
+  sessionId: string | null;
+  unread: number;
+}
+
+export interface ComputerProjection {
+  available: boolean;
+  computerSessionId: string | null;
+  botId: string | null;
+  sessionId: string | null;
+  state: BotControlState;
+  leaseRevision: number | null;
+  reasonCode: string;
+  lastEventAt: string | null;
+}
+
+export interface BotCenterSnapshot {
+  schema: "simplicio.bot-center-snapshot/v1";
+  generatedAt: string;
+  source: "runtime" | "preview";
+  actionAuthority: "runtime" | "preview" | "unavailable";
+  bots: BotSummary[];
+  selectedBotId: string | null;
+  sessions: BotSessionProjection[];
+  rooms: BotRoomProjection[];
+  computer: ComputerProjection;
+  limits: {
+    maxBots: 32;
+    maxEvents: 200;
+    maxRooms: 32;
+  };
+  redaction: {
+    secrets: true;
+    prompts: true;
+    attachmentBodies: true;
+  };
+  snapshotDigest: string;
+}
+
 export interface DesktopSnapshot {
   schema: "simplicio.desktop-snapshot/v1";
   generatedAt: string;
@@ -104,6 +232,7 @@ export interface DesktopSnapshot {
   savings: SavingsSummary;
   providers: ProviderConnection[];
   activity: ActivityItem[];
+  botCenter?: BotCenterSnapshot;
   actions: Array<{
     id: "login" | "subscribe" | "refresh_access" | "repair_providers";
     governed: true;

--- a/apps/desktop/src/demo.ts
+++ b/apps/desktop/src/demo.ts
@@ -1,4 +1,5 @@
 import type { AccessState, DesktopSnapshot, ProviderConnection } from "./contracts";
+import { createDemoBotCenter } from "./bot_center";
 
 type DemoProvider = Pick<ProviderConnection, "id" | "name" | "kind" | "protocol" | "tier" | "state" | "detail">;
 
@@ -122,6 +123,7 @@ export function createDemoSnapshot(state: AccessState = "active"): DesktopSnapsh
       },
     },
     providers,
+    botCenter: createDemoBotCenter(generatedAt),
     activity: [
       {
         id: "a1",

--- a/apps/desktop/src/screens/BotCenterScreen.tsx
+++ b/apps/desktop/src/screens/BotCenterScreen.tsx
@@ -1,0 +1,213 @@
+import { FormEvent, useMemo, useState } from "react";
+import type {
+  BotActionKind,
+  BotCenterSnapshot,
+  BotLifecycle,
+  BotSessionProjection,
+  BotTimelineEvent,
+} from "../contracts";
+import type { BotActionRequest } from "../bot_center";
+import { Glyph } from "../components/Brand";
+
+const lifecycleLabel: Record<BotLifecycle, string> = {
+  disabled: "desabilitado",
+  idle: "ocioso",
+  active: "ativo",
+  busy: "ocupado",
+  degraded: "degradado",
+  blocked: "bloqueado",
+};
+
+const eventLabel: Record<BotTimelineEvent["kind"], string> = {
+  message: "mensagem",
+  tool_call: "tool call",
+  tool_result: "resultado",
+  approval_request: "aprovação",
+  approval_decision: "decisão",
+  artifact: "artifact",
+  attachment: "anexo",
+  status: "status",
+  bot_event: "bot-to-bot",
+};
+
+function sessionFor(snapshot: BotCenterSnapshot, botId: string): BotSessionProjection | undefined {
+  const bot = snapshot.bots.find((item) => item.botId === botId);
+  return snapshot.sessions.find((session) => session.sessionId === bot?.lastSessionId)
+    ?? snapshot.sessions.find((session) => session.botId === botId);
+}
+
+function formatNumber(value: number | null): string {
+  return value === null ? "—" : value.toLocaleString("pt-BR");
+}
+
+function statusClass(lifecycle: BotLifecycle): string {
+  return lifecycle === "active" || lifecycle === "busy" ? "bot-status-live" : lifecycle === "blocked" ? "bot-status-blocked" : "bot-status-muted";
+}
+
+function TimelineEvent({ item, onAction }: { item: BotTimelineEvent; onAction: (request: BotActionRequest) => Promise<void> }) {
+  const approvalAction: BotActionKind | null = item.kind === "approval_request" && item.approvalId ? "approve" : null;
+  return (
+    <article className={`bot-event bot-event-${item.kind} ${item.state === "blocked" ? "is-blocked" : ""}`}>
+      <div className="bot-event-marker"><Glyph name={item.kind === "tool_call" || item.kind === "tool_result" ? "settings" : item.kind === "approval_request" ? "shield" : item.kind === "bot_event" ? "spark" : "activity"} size={15} /></div>
+      <div className="bot-event-body">
+        <div className="bot-event-meta">
+          <strong>{item.actorLabel}</strong>
+          <span>{eventLabel[item.kind]}</span>
+          <time dateTime={item.timestamp}>{new Date(item.timestamp).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}</time>
+        </div>
+        <p>{item.content}</p>
+        {item.toolName && <code className="bot-tool-name">{item.toolName}</code>}
+        {item.artifactName && <button className="bot-inline-link" type="button">Abrir {item.artifactName}</button>}
+        {item.attachmentName && <span className="bot-attachment-chip"><Glyph name="check" size={13} /> {item.attachmentName}</span>}
+        {item.reasonCode && <span className="bot-reason">reason: {item.reasonCode}</span>}
+        {approvalAction && (
+          <div className="bot-approval-actions">
+            <button className="button button-primary" type="button" onClick={() => onAction({ kind: "approve", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Aprovar</button>
+            <button className="button button-secondary" type="button" onClick={() => onAction({ kind: "deny", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Negar</button>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export function BotCenterScreen({ snapshot, onAction }: { snapshot: BotCenterSnapshot; onAction: (request: BotActionRequest) => Promise<void> }) {
+  const [selectedBotId, setSelectedBotId] = useState(snapshot.selectedBotId ?? snapshot.bots[0]?.botId ?? null);
+  const [message, setMessage] = useState("");
+  const [steer, setSteer] = useState("");
+  const [busyAction, setBusyAction] = useState<BotActionKind | null>(null);
+  const selectedBot = snapshot.bots.find((bot) => bot.botId === selectedBotId) ?? null;
+  const session = selectedBotId ? sessionFor(snapshot, selectedBotId) : undefined;
+  const room = snapshot.rooms.find((item) => item.sessionId === session?.sessionId) ?? snapshot.rooms[0];
+  const recentEvents = useMemo(() => session?.events.slice(-30) ?? [], [session]);
+  const isUnavailable = snapshot.actionAuthority === "unavailable";
+
+  async function dispatch(request: BotActionRequest) {
+    setBusyAction(request.kind);
+    try {
+      await onAction(request);
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function submitTurn(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedBotId || !message.trim() || !session) return;
+    const value = message.trim();
+    setMessage("");
+    await dispatch({ kind: "send_turn", botId: selectedBotId, sessionId: session.sessionId, value });
+  }
+
+  async function submitSteer(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedBotId || !session || !steer.trim()) return;
+    const value = steer.trim();
+    setSteer("");
+    await dispatch({ kind: "steer", botId: selectedBotId, sessionId: session.sessionId, value });
+  }
+
+  const actionDisabled = isUnavailable || busyAction !== null;
+
+  return (
+    <div className="page bot-center-page">
+      <section className="page-heading bot-center-heading">
+        <div>
+          <span className="eyebrow">Agent Plane · superfície pública</span>
+          <h1>Bot Center</h1>
+          <p>Roster, sessões, Rooms e Computer governados pelo Runtime.</p>
+        </div>
+        <div className={`bot-authority-badge ${isUnavailable ? "is-unavailable" : ""}`}>
+          <span className="status-dot" />
+          {isUnavailable ? "Contrato indisponível" : snapshot.source === "preview" ? "Preview" : "Runtime verificado"}
+        </div>
+      </section>
+
+      {isUnavailable && (
+        <section className="bot-contract-warning" role="status">
+          <Glyph name="shield" size={20} />
+          <div><strong>Bot Mode ainda não foi exposto pelo Runtime.</strong><p>O Desktop não cria bots nem reimplementa o Agent Plane localmente. reason: {snapshot.computer.reasonCode}</p></div>
+        </section>
+      )}
+
+      <div className="bot-center-grid">
+        <aside className="panel bot-roster-panel">
+          <div className="panel-heading">
+            <div><span className="eyebrow">Roster canônico</span><h2>Bots <small>{snapshot.bots.length}/{snapshot.limits.maxBots}</small></h2></div>
+            <button className="text-button" type="button" disabled={actionDisabled} aria-label="Criar novo Bot">Novo <Glyph name="arrow" size={15} /></button>
+          </div>
+          <div className="bot-roster-list">
+            {snapshot.bots.length === 0 ? <p className="empty-state">Nenhum Bot exposto pelo Runtime.</p> : snapshot.bots.map((bot) => (
+              <button key={bot.botId} type="button" className={`bot-roster-item ${bot.botId === selectedBotId ? "active" : ""}`} onClick={() => setSelectedBotId(bot.botId)}>
+                <span className="bot-avatar">{bot.displayName.slice(0, 1)}</span>
+                <span className="bot-roster-copy"><strong>{bot.displayName}</strong><small>{bot.provider ?? "provider não informado"}</small></span>
+                <span className={`bot-status-dot ${statusClass(bot.lifecycle)}`} title={bot.reasonCode} />
+              </button>
+            ))}
+          </div>
+          <div className="bot-roster-foot"><Glyph name="shield" size={14} /> status derivado de receipts</div>
+        </aside>
+
+        <section className="panel bot-chat-panel">
+          {selectedBot ? (
+            <>
+              <header className="bot-chat-header">
+                <div className="bot-chat-identity"><span className="bot-avatar bot-avatar-large">{selectedBot.displayName.slice(0, 1)}</span><div><h2>{selectedBot.displayName}</h2><p><span className={`bot-status-dot ${statusClass(selectedBot.lifecycle)}`} /> {lifecycleLabel[selectedBot.lifecycle]} · {selectedBot.reasonCode}</p></div></div>
+                <div className="bot-chat-actions">
+                  <button className="text-button" type="button" disabled={actionDisabled || !session} onClick={() => session && dispatch({ kind: "resume", botId: selectedBot.botId, sessionId: session.sessionId })}>Retomar</button>
+                  <button className="text-button" type="button" disabled={actionDisabled || !session} onClick={() => session && dispatch({ kind: "branch", botId: selectedBot.botId, sessionId: session.sessionId })}>Branch</button>
+                  <button className="text-button" type="button" disabled={actionDisabled || !session} onClick={() => session && dispatch({ kind: "handoff", botId: selectedBot.botId, sessionId: session.sessionId })}>Handoff</button>
+                </div>
+              </header>
+
+              <div className="bot-selectors" aria-label="Configuração projetada do Bot">
+                <label>Provider<select value={selectedBot.provider ?? "—"} disabled><option>{selectedBot.provider ?? "Não informado"}</option></select></label>
+                <label>Modelo<select value={selectedBot.model ?? "—"} disabled><option>{selectedBot.model ?? "Não informado"}</option></select></label>
+                <label>Profile<select value={selectedBot.profileId} disabled><option>{selectedBot.profileId}</option></select></label>
+                <label>Projeto<select value={selectedBot.projectId ?? "—"} disabled><option>{selectedBot.projectId ?? "Não associado"}</option></select></label>
+              </div>
+
+              <div className="bot-chip-row"><span>toolset: {selectedBot.toolset.join(" · ") || "—"}</span><span>skills: {selectedBot.skills.join(" · ") || "—"}</span></div>
+
+              <div className="bot-timeline" aria-live="polite">
+                {recentEvents.length === 0 ? <p className="empty-state">Sem transcript disponível para este Bot.</p> : recentEvents.map((item) => <TimelineEvent key={item.eventId} item={item} onAction={dispatch} />)}
+              </div>
+
+              <div className="bot-composer-wrap">
+                <form className="bot-composer" onSubmit={submitTurn}>
+                  <textarea value={message} onChange={(event) => setMessage(event.target.value)} placeholder="Enviar um turn ao Bot…" rows={2} disabled={actionDisabled || !session} aria-label="Mensagem para o Bot" />
+                  <div><span className="bot-compose-hint">session: {session?.sessionId ?? "não disponível"}</span><button className="button button-primary" type="submit" disabled={actionDisabled || !session || !message.trim()}>{busyAction === "send_turn" ? "Enviando…" : "Enviar"}<Glyph name="arrow" size={16} /></button></div>
+                </form>
+                <form className="bot-steer-form" onSubmit={submitSteer}><input value={steer} onChange={(event) => setSteer(event.target.value)} placeholder="Steer opcional" disabled={actionDisabled || !session} aria-label="Steer do Bot" /><button className="text-button" type="submit" disabled={actionDisabled || !session || !steer.trim()}>Steer</button></form>
+                <div className="bot-quick-actions"><button className="button button-secondary" type="button" disabled={actionDisabled || !session} onClick={() => session && dispatch({ kind: "interrupt", botId: selectedBot.botId, sessionId: session.sessionId })}>Interromper</button><button className="button button-secondary" type="button" disabled={actionDisabled || !session} onClick={() => session && dispatch({ kind: "cancel", botId: selectedBot.botId, sessionId: session.sessionId })}>Cancelar</button></div>
+              </div>
+            </>
+          ) : <div className="bot-empty-detail"><Glyph name="spark" size={28} /><h2>Escolha um Bot</h2><p>A lista é preenchida pela projeção canônica do Runtime.</p></div>}
+        </section>
+
+        <aside className="bot-side-rail">
+          <section className="panel bot-room-panel">
+            <div className="panel-heading"><div><span className="eyebrow">Session Service</span><h2>Rooms</h2></div><span className="room-count">{snapshot.rooms.length}</span></div>
+            {snapshot.rooms.length === 0 ? <p className="empty-state">Nenhuma Room disponível.</p> : snapshot.rooms.map((item) => <article className="bot-room-card" key={item.roomId}><div><strong>{item.displayName}</strong><span>{item.members.map((member) => member.label).join(" · ")}</span></div>{item.unread > 0 && <b>{item.unread}</b>}</article>)}
+            <p className="bot-side-note">Histórico, threads e membership vêm do mesmo binding de sessão.</p>
+          </section>
+
+          <section className="panel bot-computer-panel">
+            <div className="panel-heading"><div><span className="eyebrow">Capability</span><h2>Computer</h2></div><span className={`computer-state ${snapshot.computer.available ? "available" : "unavailable"}`}>{snapshot.computer.available ? snapshot.computer.state : "indisponível"}</span></div>
+            <div className="computer-illustration"><Glyph name="spark" size={27} /></div>
+            <p>{snapshot.computer.available ? "Sessão observável vinculada ao Bot selecionado." : "Nenhum backend Computer real foi verificado; ações permanecem bloqueadas."}</p>
+            <code>reason: {snapshot.computer.reasonCode}</code>
+            <div className="computer-actions"><button className="button button-secondary" type="button" disabled={!snapshot.computer.available || actionDisabled || !selectedBotId} onClick={() => dispatch({ kind: "take_over", botId: selectedBotId ?? "", sessionId: session?.sessionId })}>Assumir controle</button><button className="button button-secondary" type="button" disabled={!snapshot.computer.available || actionDisabled || !selectedBotId} onClick={() => dispatch({ kind: "hand_back", botId: selectedBotId ?? "", sessionId: session?.sessionId })}>Devolver ao Bot</button></div>
+          </section>
+
+          <section className="panel bot-telemetry-panel">
+            <div className="panel-heading"><div><span className="eyebrow">Receipts</span><h2>Medição</h2></div><Glyph name="activity" size={18} /></div>
+            {session ? <dl className="bot-telemetry"><div><dt>Input</dt><dd>{formatNumber(session.tokenUsage.input)}</dd></div><div><dt>Output</dt><dd>{formatNumber(session.tokenUsage.output)}</dd></div><div><dt>Cache</dt><dd>{session.cacheHitPercent === null ? "—" : `${session.cacheHitPercent.toLocaleString("pt-BR")}%`}</dd></div><div><dt>Custo</dt><dd>{session.costUsd === null ? "—" : `US$ ${session.costUsd.toFixed(4)}`}</dd></div></dl> : <p className="empty-state">Sem telemetria medida.</p>}
+            <span className="bot-measurement-note">{session?.tokenUsage.proofKind === "measured" ? "medido pelo Runtime" : "sem evidência"}</span>
+          </section>
+        </aside>
+      </div>
+      {room && <p className="bot-footer-receipt">room: {room.roomId} · session: {session?.sessionId ?? "—"} · revision: {session?.revision ?? "—"} · eventos limitados a {snapshot.limits.maxEvents}</p>}
+    </div>
+  );
+}

--- a/apps/desktop/src/screens/SecondaryScreen.tsx
+++ b/apps/desktop/src/screens/SecondaryScreen.tsx
@@ -3,6 +3,11 @@ import type { View } from "../components/Shell";
 import { Glyph } from "../components/Brand";
 
 const copy: Record<Exclude<View, "home" | "providers">, { eyebrow: string; title: string; description: string }> = {
+  bot: {
+    eyebrow: "Agent Plane",
+    title: "Bot Center",
+    description: "Roster, sessões e Rooms são projetados pelo Runtime.",
+  },
   activity: {
     eyebrow: "Recibos",
     title: "Atividade",
@@ -33,7 +38,7 @@ export function SecondaryScreen({ view, snapshot }: { view: Exclude<View, "home"
       </section>
       <section className="secondary-grid">
         <article className="panel secondary-hero">
-          <div className="secondary-visual"><Glyph name={view === "memory" ? "memory" : view === "settings" ? "settings" : "activity"} size={34} /></div>
+          <div className="secondary-visual"><Glyph name={view === "memory" ? "memory" : view === "settings" ? "settings" : view === "bot" ? "spark" : "activity"} size={34} /></div>
           <span className="eyebrow">Em breve</span>
           <h2>Conectado ao mesmo Runtime</h2>
           <p>Dados compactos e versionados.</p>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1530,7 +1530,7 @@ p { margin-top: 0; }
   .sidebar > .brand,
   .nav-caption-spaced { display: none; }
 
-  .primary-nav { display: grid; grid-template-columns: repeat(5, 1fr); }
+  .primary-nav { display: grid; grid-template-columns: repeat(6, 1fr); }
   .nav-item { height: 43px; margin: 0; }
 
   .workspace { grid-row: 1; grid-template-rows: 44px minmax(0, 1fr); }
@@ -1566,4 +1566,135 @@ p { margin-top: 0; }
   .locked-actions,
   .locked-safe-actions { align-items: stretch; flex-direction: column; }
   .locked-safe-actions { text-align: left; }
+}
+
+/* Bot Center */
+
+.bot-center-heading { align-items: center; }
+.bot-authority-badge { min-height: 30px; padding: 0 10px; border: 1px solid #bfd7bd; border-radius: var(--radius-pill); display: inline-flex; align-items: center; gap: 7px; color: var(--green-dark); background: var(--green-pale); font: 650 9px/1 var(--mono); }
+.bot-authority-badge .status-dot { background: var(--green); }
+.bot-authority-badge.is-unavailable { border-color: #e2cda9; color: #956b35; background: #fbf1dc; }
+.bot-authority-badge.is-unavailable .status-dot { background: var(--warning); }
+.bot-contract-warning { margin: -3px 0 14px; padding: 12px 14px; border: 1px solid #e2cda9; border-radius: var(--radius-md); display: flex; align-items: flex-start; gap: 10px; color: #805f31; background: #fbf1dc; }
+.bot-contract-warning > .glyph { margin-top: 1px; flex: 0 0 auto; }
+.bot-contract-warning strong { display: block; font-size: 11px; }
+.bot-contract-warning p { margin: 4px 0 0; color: #997d51; font: 9px/1.45 var(--mono); }
+.bot-center-grid { min-width: 0; display: grid; grid-template-columns: minmax(185px, 0.8fr) minmax(350px, 1.65fr) minmax(190px, 0.85fr); align-items: start; gap: 11px; }
+.bot-roster-panel, .bot-chat-panel, .bot-side-rail > .panel { min-width: 0; }
+.bot-roster-panel { min-height: 695px; padding: 16px 12px 12px; display: flex; flex-direction: column; }
+.bot-roster-panel .panel-heading { padding-inline: 5px; }
+.bot-roster-panel h2 small { color: var(--muted-soft); font: 650 9px/1 var(--mono); }
+.bot-roster-list { margin-top: 3px; display: grid; gap: 4px; }
+.bot-roster-item { width: 100%; min-width: 0; min-height: 57px; padding: 8px; border: 1px solid transparent; border-radius: 9px; display: flex; align-items: center; gap: 8px; color: var(--ink); background: transparent; text-align: left; cursor: pointer; }
+.bot-roster-item:hover { background: rgba(255, 253, 246, 0.68); }
+.bot-roster-item.active { border-color: #bed3b9; background: var(--green-pale); box-shadow: inset 3px 0 0 var(--green); }
+.bot-avatar { width: 30px; height: 30px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; color: #315f46; background: #d8e8ce; font: 700 13px/1 var(--mono); }
+.bot-avatar-large { width: 38px; height: 38px; font-size: 16px; }
+.bot-roster-copy { min-width: 0; display: flex; flex: 1; flex-direction: column; gap: 4px; }
+.bot-roster-copy strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.bot-roster-copy small { overflow: hidden; color: var(--muted); font: 8px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.bot-status-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.bot-status-live { background: var(--green); box-shadow: 0 0 0 3px rgba(84, 168, 121, 0.13); }
+.bot-status-blocked { background: var(--warning); box-shadow: 0 0 0 3px rgba(187, 123, 52, 0.12); }
+.bot-status-muted { background: #aaa492; }
+.bot-roster-foot { margin-top: auto; padding: 10px 4px 0; border-top: 1px solid var(--line-soft); display: flex; align-items: center; gap: 5px; color: var(--muted-soft); font: 8px/1.3 var(--mono); }
+.bot-chat-panel { min-height: 695px; padding: 16px; display: flex; flex-direction: column; }
+.bot-chat-header { padding-bottom: 13px; border-bottom: 1px solid var(--line-soft); display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.bot-chat-identity { min-width: 0; display: flex; align-items: center; gap: 9px; }
+.bot-chat-identity h2 { margin: 0 0 4px; font-size: 16px; letter-spacing: -0.025em; }
+.bot-chat-identity p { margin: 0; overflow: hidden; color: var(--muted); font: 8px/1.3 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.bot-chat-identity p .bot-status-dot { margin-right: 4px; }
+.bot-chat-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 7px; }
+.bot-chat-actions .text-button { min-height: 30px; font: 650 9px/1 var(--mono); }
+.bot-selectors { padding: 13px 0 9px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 7px; }
+.bot-selectors label { min-width: 0; color: var(--muted-soft); font: 8px/1.2 var(--mono); }
+.bot-selectors select { width: 100%; min-width: 0; height: 30px; margin-top: 4px; padding: 0 5px; border: 1px solid var(--line); border-radius: 6px; overflow: hidden; color: #66675f; background: var(--surface-muted); font: 8px/1 var(--mono); text-overflow: ellipsis; }
+.bot-selectors select:disabled { opacity: 1; }
+.bot-chip-row { min-width: 0; padding: 7px 9px; border: 1px solid var(--line-soft); border-radius: 7px; display: flex; flex-wrap: wrap; gap: 5px 12px; color: #777567; background: rgba(240, 234, 215, 0.55); font: 8px/1.35 var(--mono); }
+.bot-timeline { min-height: 0; max-height: 365px; margin: 11px -3px 10px 0; padding: 1px 8px 1px 1px; overflow: auto; display: grid; align-content: start; gap: 8px; }
+.bot-event { min-width: 0; padding: 8px 9px; border: 1px solid var(--line-soft); border-radius: 8px; display: flex; align-items: flex-start; gap: 8px; background: rgba(255, 253, 246, 0.6); }
+.bot-event.is-blocked { border-color: #e2cda9; background: #fff8e9; }
+.bot-event-marker { width: 23px; height: 23px; border-radius: 6px; display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; color: var(--green-dark); background: var(--green-soft); }
+.bot-event-approval_request .bot-event-marker, .bot-event-bot_event .bot-event-marker { color: #956b35; background: #f6e9bd; }
+.bot-event-body { min-width: 0; flex: 1; }
+.bot-event-meta { min-width: 0; display: flex; align-items: center; gap: 6px; }
+.bot-event-meta strong { font-size: 9px; }
+.bot-event-meta span { color: var(--green-dark); font: 650 7px/1 var(--mono); text-transform: uppercase; }
+.bot-event-meta time { margin-left: auto; color: var(--muted-soft); font: 7px/1 var(--mono); }
+.bot-event-body p { margin: 5px 0 0; color: #6f7065; font-size: 9px; line-height: 1.4; }
+.bot-tool-name, .bot-event-body .bot-reason { display: inline-block; margin-top: 6px; color: #8c7956; font: 8px/1.25 var(--mono); }
+.bot-reason { margin-left: 7px; }
+.bot-inline-link { margin-top: 6px; padding: 0; border: 0; color: var(--green-dark); background: transparent; font: 650 8px/1.2 var(--mono); cursor: pointer; }
+.bot-attachment-chip { margin-top: 6px; padding: 4px 6px; border: 1px solid #c9ddc5; border-radius: var(--radius-pill); display: inline-flex; align-items: center; gap: 4px; color: var(--green-dark); background: var(--green-pale); font: 8px/1 var(--mono); }
+.bot-approval-actions { margin-top: 8px; display: flex; gap: 6px; }
+.bot-approval-actions .button { min-height: 29px; padding-inline: 9px; font-size: 9px; }
+.bot-composer-wrap { margin-top: auto; }
+.bot-composer { padding: 8px; border: 1px solid var(--line); border-radius: 9px; background: var(--surface-strong); }
+.bot-composer textarea { width: 100%; min-height: 42px; padding: 3px; border: 0; resize: vertical; color: var(--ink); background: transparent; font-size: 10px; outline: 0; }
+.bot-composer > div { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.bot-composer .button { min-height: 32px; font-size: 10px; }
+.bot-compose-hint { overflow: hidden; color: var(--muted-soft); font: 7px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.bot-steer-form { margin-top: 5px; display: flex; align-items: center; gap: 5px; }
+.bot-steer-form input { min-width: 0; height: 27px; padding: 0 7px; border: 1px solid var(--line-soft); border-radius: 6px; flex: 1; color: var(--ink); background: rgba(255, 253, 246, 0.55); font: 8px/1 var(--mono); }
+.bot-steer-form .text-button { min-height: 27px; font: 650 8px/1 var(--mono); }
+.bot-quick-actions { margin-top: 4px; display: flex; justify-content: flex-end; gap: 5px; }
+.bot-quick-actions .button { min-height: 25px; padding-inline: 7px; font: 650 8px/1 var(--mono); }
+.bot-side-rail { min-width: 0; display: grid; gap: 11px; }
+.bot-side-rail > .panel { padding: 15px; }
+.bot-room-panel { min-height: 169px; }
+.room-count { min-width: 22px; height: 22px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: var(--green-dark); background: var(--green-soft); font: 650 9px/1 var(--mono); }
+.bot-room-card { min-width: 0; padding: 9px 0; border-bottom: 1px solid var(--line-soft); display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.bot-room-card > div { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.bot-room-card strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.bot-room-card span { overflow: hidden; color: var(--muted); font: 8px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.bot-room-card b { width: 18px; height: 18px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: #fffdf6; background: var(--green); font: 650 8px/1 var(--mono); }
+.bot-side-note { margin: 10px 0 0; color: var(--muted-soft); font: 8px/1.4 var(--mono); }
+.bot-computer-panel .panel-heading, .bot-telemetry-panel .panel-heading { margin-bottom: 11px; }
+.computer-state { padding: 4px 6px; border-radius: var(--radius-pill); font: 650 7px/1 var(--mono); }
+.computer-state.available { color: var(--green-dark); background: var(--green-soft); }
+.computer-state.unavailable { color: #956b35; background: #f6e9bd; }
+.computer-illustration { width: 50px; height: 50px; margin: 3px auto 10px; border: 1px dashed #c9b989; border-radius: 13px; display: flex; align-items: center; justify-content: center; color: var(--warning); background: #fbf1dc; }
+.bot-computer-panel p { margin: 0; color: var(--muted); font-size: 9px; line-height: 1.45; }
+.bot-computer-panel code { display: block; margin-top: 8px; overflow: hidden; color: #997d51; font: 7px/1.3 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.computer-actions { margin-top: 11px; display: grid; gap: 5px; }
+.computer-actions .button { min-height: 29px; font-size: 9px; }
+.bot-telemetry { margin: 0; display: grid; gap: 7px; }
+.bot-telemetry > div { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.bot-telemetry dt, .bot-telemetry dd { margin: 0; font: 8px/1.2 var(--mono); }
+.bot-telemetry dt { color: var(--muted-soft); }
+.bot-telemetry dd { color: #64665e; }
+.bot-measurement-note { display: block; margin-top: 10px; color: var(--green-dark); font: 8px/1.2 var(--mono); }
+.bot-footer-receipt { margin: 11px 2px 0; color: var(--muted-soft); font: 8px/1.3 var(--mono); }
+.bot-empty-detail { min-height: 100%; display: flex; align-items: center; justify-content: center; flex-direction: column; color: var(--muted); text-align: center; }
+.bot-empty-detail > .glyph { color: var(--green-dark); }
+.bot-empty-detail h2 { margin: 12px 0 5px; font-size: 16px; }
+.bot-empty-detail p { max-width: 250px; margin: 0; font-size: 10px; line-height: 1.4; }
+
+@media (max-width: 1180px) {
+  .bot-center-grid { grid-template-columns: minmax(170px, 0.75fr) minmax(330px, 1.5fr); }
+  .bot-side-rail { grid-column: 1 / -1; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .bot-roster-panel, .bot-chat-panel { min-height: 675px; }
+}
+
+@media (max-width: 820px) {
+  .bot-center-grid { grid-template-columns: 1fr; }
+  .bot-roster-panel, .bot-chat-panel { min-height: auto; }
+  .bot-roster-panel { order: 1; }
+  .bot-chat-panel { order: 2; }
+  .bot-side-rail { order: 3; }
+  .bot-roster-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .bot-roster-foot { margin-top: 12px; }
+}
+
+@media (max-width: 620px) {
+  .bot-center-heading { align-items: flex-start; }
+  .bot-center-grid { gap: 9px; }
+  .bot-chat-panel { padding: 12px; }
+  .bot-chat-header { align-items: flex-start; flex-direction: column; }
+  .bot-chat-actions { width: 100%; justify-content: flex-start; }
+  .bot-selectors { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .bot-timeline { max-height: 420px; }
+  .bot-side-rail { grid-template-columns: 1fr; }
+  .bot-roster-list { grid-template-columns: 1fr; }
+  .bot-contract-warning { padding: 10px; }
 }

--- a/docs/desktop/BOT-MODE.md
+++ b/docs/desktop/BOT-MODE.md
@@ -1,0 +1,39 @@
+# Desktop Bot Mode
+
+The Desktop Bot Center is a projection client. It does not own an agent loop,
+session reducer, approval gate, RBAC decision, Computer Use lease, provider
+credential, or Bot registry.
+
+## Contract boundary
+
+The optional `botCenter` member of `simplicio.desktop-snapshot/v1` carries a
+`simplicio.bot-center-snapshot/v1` projection. The projection contains only
+bounded, redacted data:
+
+- Bot roster and lifecycle/reason codes derived from Runtime receipts;
+- session events with causal parent IDs, tool cards, approvals, artifacts and
+  attachment handles;
+- Room membership and the canonical session binding;
+- Computer capability and lease state;
+- measured token/cache/cost telemetry when evidence exists.
+
+The frontend never infers `connected`, `available`, or `human_control` from
+local configuration. Missing Agent API data is rendered as
+`agent_api_unavailable`; missing Computer backend data is rendered as
+`computer_backend_unavailable` and actions stay disabled.
+
+## Runtime dependencies
+
+The projection becomes live only when the Runtime exposes the Agent API and
+the canonical contracts tracked by:
+
+- `simplicio-runtime#5167` — first-party Desktop/Agent API integration;
+- `#5168` — local-first Agent API and streaming events;
+- `#5180` — Bot registry/roster;
+- `#5181` — bot-to-bot delivery ledger;
+- `#5182` — Rooms/Groups on Session Service;
+- `#5183` — Computer-per-Bot lease and takeover.
+
+Until those contracts are present, the Tauri `desktop_bot_action` command fails
+closed with `agent_api_unavailable`. This is intentional: a preview must not
+look like a successful Runtime execution.


### PR DESCRIPTION
## Resumo

Implementa a superfície pública do Desktop para a issue #216, com um adapter de projeção para Bot Mode e fail-closed quando o Agent API do Runtime ainda não está disponível.

## Incluído

- navegação e tela Bot Center no app Tauri/React;
- roster de Bots com lifecycle e reason codes;
- configuração projetada de provider, model, toolset, skills, profile e project;
- transcript/timeline com causalidade, tool cards, approvals, artifacts, attachments e eventos bot-to-bot;
- Room projection com membership e binding de session;
- ações de turn/interrupt/cancel/steer/resume/branch/handoff/approval na fronteira do Agent API;
- telemetria de tokens/cache/cost somente quando medida;
- Computer projection com takeover/handback desabilitados sem backend real;
- snapshot bounded/redacted e documentação em docs/desktop/BOT-MODE.md;
- cobertura unitária e E2E para a superfície e os estados honestos.

## Regra de integração

O Desktop não implementa Agent Plane, gate, RBAC, session reducer, delivery ledger, lease de Computer Use ou secrets. Em Runtime real sem a projeção `botCenter`, a tela mostra `agent_api_unavailable`; a command bridge retorna erro fail-closed. Preview usa apenas um adapter explicitamente marcado como preview.

## Validação

- `npm test -- --run`: 19/19 passou.
- `npm run build`: passou.
- E2E escrito, mas não executado neste ambiente porque o Playwright exige `/opt/google/chrome/chrome`, inexistente; tentativa de instalar Chrome foi bloqueada pelo sistema.
- `cargo test` não executável neste ambiente porque `cargo` não está instalado.

## Dependências externas

A entrega completa da issue #216 depende dos contratos ainda abertos no `simplicio-runtime`: #5167, #5168, #5180, #5181, #5182 e #5183. Por isso esta PR referencia #216, mas não o fecha.

Refs #216