### PR TITLE
[Desktop][Ambient OS][P0] Today Dashboard: atenção, trabalho ativo, goals, Bots e economia

### DIFF
--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -1,6 +1,7 @@
 import type { BotCenterSnapshot, DesktopSnapshot } from "../contracts";
 import type { View } from "../components/Shell";
 import { Glyph } from "../components/Brand";
+import { createTodayProjection } from "../today_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -42,9 +43,8 @@ function ActionButton({ children, title = "Ação bloqueada até o Runtime confi
 }
 
 function TodayScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
-  const focus = snapshot.activity[0];
-  const inProgress = snapshot.activity.filter((item) => item.status === "running").slice(0, 3);
-  const upNext = snapshot.activity.filter((item) => item.status !== "running").slice(1, 4);
+  const projection = createTodayProjection(snapshot);
+  const { focus, inProgress, upNext } = projection;
   return (
     <div className="page product-page">
       <SurfaceHeading view="today" snapshot={snapshot} />

--- a/apps/desktop/src/today_projection.test.ts
+++ b/apps/desktop/src/today_projection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createTodayProjection } from "./today_projection";
+
+describe("ambient.today/v1", () => {
+  it("keeps the dashboard bounded and projection-first", () => {
+    const projection = createTodayProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("ambient.today/v1");
+    expect(projection.limits).toEqual({ focus: 1, inProgress: 3, upNext: 3 });
+    expect(projection.inProgress).toHaveLength(0);
+    expect(projection.upNext.length).toBeLessThanOrEqual(3);
+    expect(projection.reasonCode).toBe("ambient.today_projection_unavailable");
+  });
+
+  it("does not claim the Runtime projection without a Runtime source", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    expect(createTodayProjection(snapshot).reasonCode).toBe("ambient.today_projection_ready");
+  });
+});

--- a/apps/desktop/src/today_projection.ts
+++ b/apps/desktop/src/today_projection.ts
@@ -1,0 +1,50 @@
+import type { ActivityItem, DesktopSnapshot } from "./contracts";
+
+export interface TodayQueueItem {
+  id: string;
+  title: string;
+  detail: string;
+  provider: string;
+  status: ActivityItem["status"];
+  occurredAt: string;
+}
+
+export interface TodayProjection {
+  schema: "ambient.today/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  focus: TodayQueueItem | null;
+  inProgress: TodayQueueItem[];
+  upNext: TodayQueueItem[];
+  limits: { focus: 1; inProgress: 3; upNext: 3 };
+  reasonCode: "ambient.today_projection_unavailable" | "ambient.today_projection_ready";
+}
+
+function item(activity: ActivityItem): TodayQueueItem {
+  return {
+    id: activity.id,
+    title: activity.title,
+    detail: activity.detail,
+    provider: activity.provider,
+    status: activity.status,
+    occurredAt: activity.occurredAt,
+  };
+}
+
+/**
+ * The Desktop only projects a bounded queue. Ordering and lifecycle remain
+ * Runtime authority once `ambient.today/v1` is available.
+ */
+export function createTodayProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): TodayProjection {
+  const activities = snapshot.activity.map(item);
+  return {
+    schema: "ambient.today/v1",
+    generatedAt,
+    source: snapshot.source,
+    focus: activities[0] ?? null,
+    inProgress: activities.filter((entry) => entry.status === "running").slice(0, 3),
+    upNext: activities.filter((entry) => entry.status !== "running").slice(1, 4),
+    limits: { focus: 1, inProgress: 3, upNext: 3 },
+    reasonCode: snapshot.source === "runtime" ? "ambient.today_projection_ready" : "ambient.today_projection_unavailable",
+  };
+}


### PR DESCRIPTION
Parent: #226
Design authority: #236
Runtime contract: `wesleysimplicio/simplicio-runtime#5199`
Depends on Desktop shell/chat: #225, #218.

## Objetivo
Implementar **Today** como uma home operacional clean e silenciosa, derivada de `ambient.today/v1`, sem transformar a primeira tela em dashboard de métricas.

## Regra acima da dobra
Mostrar no máximo:
1. saudação/resumo de uma linha;
2. **Focus** — somente o item mais importante;
3. **In Progress** — lista compacta, até 3 itens;
4. **Up Next** — próximas ações/sugestões, até 3 itens.

Não exibir simultaneamente cards separados de goals, Bots, automations, schedule, deliveries, economy e system health. Esses dados entram nos itens compactos, abaixo da dobra, em widgets opt-in ou nas telas especializadas.

## Modelo visual
```text
Boa noite, Wesley
Duas coisas merecem sua atenção.

FOCUS
┌─────────────────────────────────────────────────────────┐
│ Aprovar publicação da release                          │
│ Release Bot · simplicio-runtime              [Revisar]  │
└─────────────────────────────────────────────────────────┘

EM ANDAMENTO
Bot Coder       Validando PR #128                    68%
Goal Desktop    Preparando pacote Windows       Em curso

A SEGUIR
Automatizar auditoria semanal                 Revisar
Daily report                                   18:00

Ver toda a atividade
```

## Item model
Cada linha/card mostra somente:
- título;
- uma linha de contexto;
- estado/progresso essencial;
- no máximo uma ação primária visível.

Priority, freshness, profile/project/bot/session, evidence, cost, risk e ações secundárias aparecem no inspector/sheet quando o usuário abre detalhes.

## Interações
- Focus: `Review/Open/Approve` conforme action descriptor.
- In Progress: abrir sessão/Bot/goal/automation.
- Up Next: Review/Dismiss/Snooze quando aplicável.
- `Ver toda a atividade` abre Activity Center.
- Attention inbox concentra todos os approvals/blockers restantes.
- Schedule, Economy e Health acessíveis abaixo da dobra ou por Apps/Insights, sem competir com Focus.

## Inspector
- Fechado por padrão.
- Abre ao selecionar item ou pedir detalhes.
- Mostra receipts, evidence, preview, diagnostics, custo, risco e ações secundárias.
- Não reserva largura quando fechado.

## Personalização
Usuário pode fixar poucos widgets read-only via #235. Limite de widgets e tamanhos controlados; a configuração padrão permanece mínima.

## Estados
Loading, empty, stale, degraded, disconnected, error e unavailable devem usar uma mensagem curta, um ícone discreto e no máximo uma ação principal.

## Honestidade
- Frontend não reordena prioridades nem recalcula métricas.
- Estimated/measured/unverified permanecem distinguíveis quando exibidos.
- Source unavailable é explícito.
- Nenhum CTA sem backend action descriptor.

## Aceite
- [ ] No máximo 4 blocos acima da dobra.
- [ ] Focus contém somente um item.
- [ ] In Progress e Up Next têm limite inicial de 3 itens.
- [ ] Sem right rail/status bar permanentes.
- [ ] Mesma revisão/order que CLI/API fixture.
- [ ] Ack/snooze/resolution sobrevive reconnect/restart.
- [ ] Approval executado atualiza Chat/Activity sem reload completo.
- [ ] Usability test identifica o item mais importante em poucos segundos.
- [ ] E2E cobre estados clean e inspector sob demanda.