### PR TITLE
[Desktop][Hermes parity][P0] Chat first-party: streaming, sessions, tool cards, approvals e artifacts

### DIFF
--- a/apps/desktop/src/chat_projection.test.ts
+++ b/apps/desktop/src/chat_projection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter, createUnavailableBotCenter } from "./bot_center";
+import { createChatProjection } from "./chat_projection";
+
+describe("chat.session/v1", () => {
+  it("keeps session identity, revision and causal events together", () => {
+    const projection = createChatProjection(createDemoBotCenter());
+    expect(projection.schema).toBe("chat.session/v1");
+    expect(projection.sessionId).toBe("bot-cora-session-01");
+    expect(projection.revision).toBe(7);
+    expect(projection.events.some((event) => event.causalParentId !== null)).toBe(true);
+    expect(projection.redaction.secrets).toBe(true);
+  });
+
+  it("blocks mutating chat actions without Agent API authority", () => {
+    const projection = createChatProjection(createUnavailableBotCenter());
+    expect(projection.state).toBe("unavailable");
+    expect(projection.actions).toEqual({ send: false, interrupt: false, cancel: false, steer: false });
+    expect(projection.reasonCode).toBe("agent_api_unavailable");
+  });
+});

--- a/apps/desktop/src/chat_projection.ts
+++ b/apps/desktop/src/chat_projection.ts
@@ -1,0 +1,31 @@
+import type { BotCenterSnapshot, BotTimelineEvent } from "./contracts";
+
+export interface ChatProjection {
+  schema: "chat.session/v1";
+  generatedAt: string;
+  source: BotCenterSnapshot["source"];
+  sessionId: string | null;
+  state: "idle" | "running" | "paused" | "blocked" | "completed" | "unavailable";
+  revision: number | null;
+  events: BotTimelineEvent[];
+  actions: { send: boolean; interrupt: boolean; cancel: boolean; steer: boolean };
+  redaction: { prompts: true; attachmentBodies: true; secrets: true };
+  reasonCode: string;
+}
+
+export function createChatProjection(botCenter: BotCenterSnapshot, generatedAt = botCenter.generatedAt): ChatProjection {
+  const session = botCenter.sessions[0];
+  const live = botCenter.actionAuthority === "runtime";
+  return {
+    schema: "chat.session/v1",
+    generatedAt,
+    source: botCenter.source,
+    sessionId: session?.sessionId ?? null,
+    state: session?.state ?? "unavailable",
+    revision: session?.revision ?? null,
+    events: session?.events ?? [],
+    actions: { send: live, interrupt: live, cancel: live, steer: live },
+    redaction: { prompts: true, attachmentBodies: true, secrets: true },
+    reasonCode: live ? "chat.session_projection_ready" : "agent_api_unavailable",
+  };
+}

--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -3,6 +3,9 @@ import type { View } from "../components/Shell";
 import { Glyph } from "../components/Brand";
 import { createTodayProjection } from "../today_projection";
 import { createAmbientProjection } from "../ambient";
+import { createChatProjection } from "../chat_projection";
+import { createCapabilityRegistry } from "../capability_registry";
+import { createAutomationProjection } from "../automation_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -79,15 +82,16 @@ function QueueRow({ title, detail, status }: { title: string; detail: string; st
 }
 
 function ChatsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCenter: BotCenterSnapshot }) {
+  const projection = createChatProjection(botCenter);
   const session = botCenter.sessions[0];
-  const events = session?.events ?? [];
+  const events = projection.events;
   return (
     <div className="page product-page">
       <SurfaceHeading view="chats" snapshot={snapshot} />
       <div className="chat-layout">
         <aside className="panel session-list"><div className="panel-heading"><div><span className="eyebrow">Sessões</span><h2>Chats</h2></div><span className="queue-count">{botCenter.sessions.length}</span></div><button className="session-card active" type="button"><span className="bot-avatar">C</span><span><strong>Cora</strong><small>{session?.state ?? "sem sessão"} · {session?.revision ? `rev. ${session.revision}` : "—"}</small></span></button><ActionButton title="Criar sessão exige o Agent API do Runtime">+ Novo chat</ActionButton></aside>
-        <section className="panel chat-session"><div className="chat-session-head"><div><span className="eyebrow">Session Service</span><h2>Cora <small>· {session?.sessionId ?? "sem sessão"}</small></h2></div><div className="chat-head-actions"><ActionButton>Steer</ActionButton><ActionButton>Cancelar</ActionButton></div></div>
-          <UnavailableNotice code={botCenter.actionAuthority === "preview" ? "agent_api_preview_only" : "agent_api_unavailable"}>O histórico é redigido e limitado; streaming, approvals e envio dependem do contrato canônico do Runtime.</UnavailableNotice>
+        <section className="panel chat-session"><div className="chat-session-head"><div><span className="eyebrow">Session Service</span><h2>Cora <small>· {projection.sessionId ?? "sem sessão"}</small></h2></div><div className="chat-head-actions"><ActionButton>Steer</ActionButton><ActionButton>Cancelar</ActionButton></div></div>
+          <UnavailableNotice code={projection.reasonCode}>O histórico é redigido e limitado; streaming, approvals e envio dependem do contrato canônico do Runtime.</UnavailableNotice>
           <div className="chat-events">{events.filter((event) => event.kind === "message" || event.kind === "tool_result" || event.kind === "approval_request" || event.kind === "artifact").map((event) => <article className={`chat-event ${event.actorKind} ${event.state === "blocked" ? "blocked" : ""}`} key={event.eventId}><span className="chat-event-avatar">{event.actorKind === "human" ? "V" : event.actorKind === "bot" ? "C" : "R"}</span><div><div className="chat-event-meta"><strong>{event.actorLabel}</strong><span>{event.kind.replaceAll("_", " ")}</span></div><p>{event.content}</p>{event.toolName && <code>tool: {event.toolName}</code>}{event.approvalId && <code>approval: {event.approvalId}</code>}{event.artifactName && <button className="inline-link" type="button" disabled>{event.artifactName}</button>}</div></article>)}</div>
           <div className="chat-composer"><textarea aria-label="Mensagem do chat" placeholder="Escreva uma mensagem…" disabled /><div><span>Enviar cria um evento no Runtime e requer sessão ativa.</span><ActionButton>Enviar</ActionButton></div></div>
         </section>
@@ -111,27 +115,23 @@ function TeamsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCe
 }
 
 function AutomationsScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
-  const suggestions = snapshot.activity.slice(0, 2);
+  const projection = createAutomationProjection(snapshot);
+  const suggestions = projection.suggestions;
   return (
     <div className="page product-page">
       <SurfaceHeading view="automations" snapshot={snapshot} />
-      <div className="automation-layout"><section className="panel suggestion-panel"><div className="panel-heading"><div><span className="eyebrow">Inbox</span><h2>Sugestões</h2></div><span className="queue-count">{suggestions.length}</span></div>{suggestions.length ? suggestions.map((item, index) => <article className="suggestion-card" key={item.id}><span className="suggestion-icon"><Glyph name="spark" size={17} /></span><div><strong>{index === 0 ? "Reutilizar contexto recorrente" : "Agrupar validações do Runtime"}</strong><p>Proposta baseada em recibos; nenhum fluxo será criado sem revisão.</p><span>{item.provider} · {item.occurredAt}</span></div><div className="suggestion-actions"><ActionButton>Aceitar</ActionButton><ActionButton>Descartar</ActionButton></div></article>) : <p className="empty-state">Nenhuma sugestão disponível.</p>}</section><section className="panel studio-panel"><div className="panel-heading"><div><span className="eyebrow">Studio</span><h2>Nova automação</h2></div><Glyph name="automation" size={18} /></div><div className="studio-step"><span>1</span><div><strong>Quando</strong><p>Escolha um evento do Runtime ou uma rotina.</p></div></div><div className="studio-step"><span>2</span><div><strong>Fazer</strong><p>Selecione uma capability e sua política.</p></div></div><div className="studio-step"><span>3</span><div><strong>Revisar</strong><p>Salvar cria apenas um rascunho versionado.</p></div></div><ActionButton>Salvar rascunho</ActionButton></section></div>
+      <div className="automation-layout"><section className="panel suggestion-panel"><div className="panel-heading"><div><span className="eyebrow">Inbox</span><h2>Sugestões</h2></div><span className="queue-count">{suggestions.length}</span></div>{suggestions.length ? suggestions.map((item) => <article className="suggestion-card" key={item.id}><span className="suggestion-icon"><Glyph name="spark" size={17} /></span><div><strong>{item.title}</strong><p>{item.description}</p><span>receipt: {item.sourceEventId} · {item.state}</span></div><div className="suggestion-actions"><ActionButton>Aceitar</ActionButton><ActionButton>Descartar</ActionButton></div></article>) : <p className="empty-state">Nenhuma sugestão disponível.</p>}</section><section className="panel studio-panel"><div className="panel-heading"><div><span className="eyebrow">Studio</span><h2>Nova automação</h2></div><Glyph name="automation" size={18} /></div><div className="studio-step"><span>1</span><div><strong>Quando</strong><p>Escolha um evento do Runtime ou uma rotina.</p></div></div><div className="studio-step"><span>2</span><div><strong>Fazer</strong><p>Selecione uma capability e sua política.</p></div></div><div className="studio-step"><span>3</span><div><strong>Revisar</strong><p>Salvar cria apenas um rascunho versionado.</p></div></div><ActionButton>Salvar rascunho</ActionButton></section></div>
       <section className="panel automation-receipts"><div className="panel-heading"><div><span className="eyebrow">Activity Center</span><h2>Recibos recentes</h2></div><ActionButton>Exportar</ActionButton></div><div className="receipt-strip"><span><strong>{snapshot.activity.length}</strong> eventos limitados</span><span><strong>—</strong> automações ativas</span><span><strong>—</strong> ações aguardando você</span></div></section>
-      <UnavailableNotice code="automation.projection_unavailable">Triggers, budgets, quiet hours, cancelamento e políticas são autoridade do Runtime; a UI fica sem efeito até a capability ser verificada.</UnavailableNotice>
+      <UnavailableNotice code={projection.reasonCode}>Triggers, budgets, quiet hours, cancelamento e políticas são autoridade do Runtime; a UI fica sem efeito até a capability ser verificada.</UnavailableNotice>
     </div>
   );
 }
 
 function AppsScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
-  const apps = [
-    ["Create", "Video Studio", "video", "capability_unverified"],
-    ["Explore", "Browser & Research", "browser", "backend_unavailable"],
-    ["Act", "Computer", "computer", "computer_backend_unavailable"],
-    ["Build", "Files, PDF & Code", "code", "runtime_projection_unavailable"],
-    ["Learn", "Teach Simplicio", "learn", "compiler_unavailable"],
-  ];
+  const registry = createCapabilityRegistry(snapshot);
+  const apps = registry.capabilities;
   return (
-    <div className="page product-page"><SurfaceHeading view="apps" snapshot={snapshot} /><div className="apps-toolbar"><div className="search-field"><Glyph name="search" size={16} /><span>Buscar capabilities, artifacts ou comandos</span><kbd>⌘K</kbd></div><ActionButton>Favoritos</ActionButton></div><section className="app-grid">{apps.map(([category, name, icon, reason]) => <article className="panel app-card" key={name}><div className="app-card-head"><span className={`app-icon app-${icon}`}><Glyph name={icon === "learn" ? "spark" : icon === "browser" ? "search" : icon === "computer" ? "live" : icon === "code" ? "providers" : "apps"} size={19} /></span><span className="app-category">{category}</span></div><h2>{name}</h2><p>Capability compartilhada com Chat, Work Items, Live e artifacts.</p><code>{reason}</code><ActionButton>Abrir</ActionButton></article>)}</section><div className="apps-bottom-grid"><section className="panel library-card"><div className="panel-heading"><div><span className="eyebrow">Artifact Graph</span><h2>Library</h2></div><ActionButton>Ver tudo</ActionButton></div><p>Artifacts, versões e proveniência aparecem quando o Runtime fornecer handles canônicos.</p><div className="library-row"><span className="file-icon">MD</span><div><strong>desktop-bot-mode-plan.md</strong><span>preview · sem cópia local</span></div></div></section><section className="panel token-card"><div className="panel-heading"><div><span className="eyebrow">Receipts</span><h2>Token Reports</h2></div><Glyph name="activity" size={18} /></div><strong className="report-value">—</strong><p>Sem métrica agregada verificável para este período.</p><code>proof: unavailable</code></section></div><UnavailableNotice code="capability.registry_unavailable">Apps só ficam acionáveis depois de um probe do backend; o launcher não presume capacidades instaladas.</UnavailableNotice></div>
+    <div className="page product-page"><SurfaceHeading view="apps" snapshot={snapshot} /><div className="apps-toolbar"><div className="search-field"><Glyph name="search" size={16} /><span>Buscar capabilities, artifacts ou comandos</span><kbd>⌘K</kbd></div><ActionButton>Favoritos</ActionButton></div><section className="app-grid">{apps.map((app) => <article className="panel app-card" key={app.id}><div className="app-card-head"><span className="app-icon"><Glyph name={app.category === "Learn" ? "spark" : app.category === "Explore" ? "search" : app.category === "Act" ? "live" : app.category === "Build" ? "providers" : "apps"} size={19} /></span><span className="app-category">{app.category}</span></div><h2>{app.name}</h2><p>{app.description}</p><code>{app.reasonCode}</code><ActionButton>Abrir</ActionButton></article>)}</section><div className="apps-bottom-grid"><section className="panel library-card"><div className="panel-heading"><div><span className="eyebrow">Artifact Graph</span><h2>Library</h2></div><ActionButton>Ver tudo</ActionButton></div><p>Artifacts, versões e proveniência aparecem quando o Runtime fornecer handles canônicos.</p><div className="library-row"><span className="file-icon">MD</span><div><strong>desktop-bot-mode-plan.md</strong><span>preview · sem cópia local</span></div></div></section><section className="panel token-card"><div className="panel-heading"><div><span className="eyebrow">Receipts</span><h2>Token Reports</h2></div><Glyph name="activity" size={18} /></div><strong className="report-value">—</strong><p>Sem métrica agregada verificável para este período.</p><code>proof: unavailable</code></section></div><UnavailableNotice code={registry.reasonCode}>Apps só ficam acionáveis depois de um probe do backend; o launcher não presume capacidades instaladas.</UnavailableNotice></div>
   );
 }
 

--- a/docs/desktop/CHAT-CONTRACT.md
+++ b/docs/desktop/CHAT-CONTRACT.md
@@ -1,0 +1,12 @@
+# Chat session contract
+
+`chat.session/v1` is a Desktop projection of the Runtime Session Service. It
+keeps the canonical session ID, revision, causal event IDs and bounded event
+list together. Tool results, approvals, artifacts and attachment handles are
+rendered as event kinds; prompt bodies, credentials and attachment bodies are
+always redacted.
+
+The composer and session controls are enabled only when the projection source
+is `runtime` and the Agent API is authoritative. Preview data is useful for
+layout and accessibility checks, but cannot send, steer, cancel or interrupt a
+real session.


### PR DESCRIPTION
Cross-repo parent: `wesleysimplicio/simplicio-runtime#5156`
Runtime dependencies: `#5157`, `#5159`, `#5161`, `#5164`, `#5168`, `#5169`.
Related Bot Mode UI: #216.

## Objetivo
Implementar em `wesleysimplicio/simplicio` a superfície Desktop pública de chat, mantendo toda lógica de Agent/Runtime no backend. O usuário deve conseguir digitar uma tarefa e acompanhar tudo que a LLM faz com economia e evidência.

## UX
- Chat streaming incremental.
- Multi-session: new/resume/switch/rename/branch.
- Tool cards com estado queued/running/approval/completed/failed/cancelled.
- Approval allow/deny consumindo contrato do Runtime.
- Artifacts: markdown, arquivos, diff, HTML/web preview, imagens e resultados estruturados.
- Attachments por drag/drop/file picker.
- Cancel/interrupt/steer.
- Background tasks/reviewer e status de agents.
- Goals/subgoals/heartbeat status quando disponíveis.
- Handoff para Bot Mode/canais.
- Indicadores medidos de input/output/reasoning/cache/tool-schema/Map-Fast reuse.

## Regras arquiteturais
- Desktop nunca executa provider, tool mutável ou gate por conta própria.
- Desktop usa Agent API/contracts públicos; nada de endpoint privado necessário apenas à UI.
- `session_id`, `turn_id`, `tool_call_id` e receipts vêm do backend.
- Reconexão/replay deve ser idempotente.
- Capability unavailable deve aparecer indisponível com reason code, nunca simulada.

## Aceite
- [ ] Usuário inicia chat e recebe streaming real.
- [ ] Tool mutável aparece no card e só executa após Runtime gate/approval quando necessário.
- [ ] Fechar/reabrir app preserva e retoma sessão.
- [ ] CLI consegue retomar exatamente a mesma sessão criada no Desktop.
- [ ] Cancel/steer funcionam durante execução.
- [ ] E2E instalado cobre chat -> tool -> edit -> validate -> receipt.