### PR TITLE
[Desktop][P0] Apps / Capability Center: todas as capacidades com interface clean e ações reais

### DIFF
--- a/apps/desktop/src/capability_registry.test.ts
+++ b/apps/desktop/src/capability_registry.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createCapabilityRegistry } from "./capability_registry";
+import { createDemoSnapshot } from "./demo";
+
+describe("capability.registry/v1", () => {
+  it("keeps the five human capability categories stable", () => {
+    const registry = createCapabilityRegistry(createDemoSnapshot("active"));
+    expect(registry.schema).toBe("capability.registry/v1");
+    expect(registry.capabilities.map((item) => item.category)).toEqual(["Create", "Explore", "Act", "Build", "Learn"]);
+    expect(registry.capabilities.every((item) => item.available === false)).toBe(true);
+  });
+
+  it("requires a healthy Runtime source before exposing an app", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    expect(createCapabilityRegistry(snapshot).capabilities.every((item) => item.available)).toBe(true);
+  });
+});

--- a/apps/desktop/src/capability_registry.ts
+++ b/apps/desktop/src/capability_registry.ts
@@ -1,0 +1,43 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export type CapabilityCategory = "Create" | "Explore" | "Act" | "Build" | "Learn";
+
+export interface CapabilityDescriptor {
+  id: string;
+  category: CapabilityCategory;
+  name: string;
+  description: string;
+  available: boolean;
+  requiresApproval: boolean;
+  reasonCode: string;
+}
+
+export interface CapabilityRegistry {
+  schema: "capability.registry/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  capabilities: CapabilityDescriptor[];
+  reasonCode: "capability.registry_ready" | "capability.registry_unavailable";
+}
+
+export function createCapabilityRegistry(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): CapabilityRegistry {
+  const descriptions: Array<Pick<CapabilityDescriptor, "id" | "category" | "name" | "description" | "requiresApproval">> = [
+    { id: "video.studio", category: "Create", name: "Video Studio", description: "Criar vídeos com um Work Item observável.", requiresApproval: true },
+    { id: "browser.research", category: "Explore", name: "Browser & Research", description: "Pesquisar com evidência e artifacts vinculados.", requiresApproval: true },
+    { id: "computer.use", category: "Act", name: "Computer", description: "Operar uma sessão Computer com lease explícito.", requiresApproval: true },
+    { id: "build.workspace", category: "Build", name: "Files, PDF & Code", description: "Construir em um Workspace governado.", requiresApproval: true },
+    { id: "teach.compiler", category: "Learn", name: "Teach Simplicio", description: "Gravar e revisar uma rotina reproduzível.", requiresApproval: true },
+  ];
+  const runtime = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return {
+    schema: "capability.registry/v1",
+    generatedAt,
+    source: snapshot.source,
+    capabilities: descriptions.map((capability) => ({
+      ...capability,
+      available: runtime,
+      reasonCode: runtime ? "capability_probe_verified" : "capability_unverified",
+    })),
+    reasonCode: runtime ? "capability.registry_ready" : "capability.registry_unavailable",
+  };
+}

--- a/docs/desktop/CAPABILITY-CENTER.md
+++ b/docs/desktop/CAPABILITY-CENTER.md
@@ -1,0 +1,12 @@
+# Capability Center
+
+`capability.registry/v1` is the single discovery surface for Desktop Apps and
+the `+ New` launcher. Each entry has a stable capability ID, human category,
+approval requirement and probe reason code. The UI does not infer availability
+from an installed icon or provider configuration.
+
+The five categories are Create, Explore, Act, Build and Learn. A capability is
+actionable only after a healthy Runtime probe; otherwise the card remains
+disabled with the returned reason code. Executing a capability is a Runtime
+action descriptor and produces the same Work Item, Live, Chat and artifact
+receipts used elsewhere in the app.


### PR DESCRIPTION
Parent Desktop: #219
Workspace parent: #238
Design: #236/#248
Runtime: capability registry `simplicio-runtime#5161`, Agent API #5168, search #5217, artifacts #5218.
Related: #235 Capability Apps, #243 + New, #246 Flagship Apps, #250 OmniSearch, #251 Library.

## Objetivo
`Apps` é a área clean onde qualquer pessoa descobre **o que o Simplicio consegue fazer** e abre uma capability como aplicação, sem catálogo técnico poluído.

## Human categories
### Create
Video, Image, Audio, Presentation, Document, Website, Design.

### Explore
Research, Browser, Files/PDF, Data, Knowledge.

### Act
Computer, Email, Calendar, GitHub, Messaging, Deploy, Cloud.

### Build
Code, Automation, Integration, API, Database, Testing.

### Learn
Memory, Skills, Learning Journey, Study.

Categorias/filtros sob demanda; home mostra Search, Recent/Favorites e tiles simples.

## App tile
Icon, name, subtle real status. No long description/owner/schema/many buttons. Open selects focused App workspace.

## App detail
Primary action Open/Run/Configure/Connect/Install/Authorize; recent Work Items/artifacts; Team assignment; Use in Chat; permissions/status. Advanced: capability ID/schema/owner/risk/probes/token cost/receipts.

## Integration
- + New starts common Apps.
- Flagship first-party workflows in #246.
- Capability UI descriptors/widgets in #235.
- Outputs go to Library #251.
- OmniSearch #250 finds Apps/actions.
- Human form and LLM tool use same capability ID/request schema.

## Availability
`available` only after backend probe/conformance. Auth required/unavailable/degraded/unsupported show reason/remediation. Mutable actions use Runtime approval/gate.

## Acceptance
- [ ] User finds Video/Browser/Computer/Files/Code in <=2 steps.
- [ ] All real capabilities discoverable via Search/filters/OmniSearch.
- [ ] Home remains clean.
- [ ] Every action real or disabled honestly.
- [ ] Same schema request from form and LLM.
- [ ] Artifact/Work Item/Live/token integration.
- [ ] E2E covers read-only, mutable, auth-required, plugin/MCP and unavailable.