### PR TITLE
[Desktop][Ambient OS][P0] Automation Studio: criar triggers, condições, actions, policies e budgets

### DIFF
--- a/apps/desktop/src/automation_projection.test.ts
+++ b/apps/desktop/src/automation_projection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createAutomationProjection } from "./automation_projection";
+import { createDemoSnapshot } from "./demo";
+
+describe("automation.studio/v1", () => {
+  it("keeps suggestions review-only and sourced by receipt IDs", () => {
+    const projection = createAutomationProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("automation.studio/v1");
+    expect(projection.suggestions).toHaveLength(2);
+    expect(projection.suggestions.every((item) => item.state === "review_required")).toBe(true);
+    expect(projection.draftAllowed).toBe(false);
+    expect(projection.activeCount).toBeNull();
+  });
+
+  it("only permits a draft after a healthy Runtime projection", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    expect(createAutomationProjection(snapshot).draftAllowed).toBe(true);
+  });
+});

--- a/apps/desktop/src/automation_projection.ts
+++ b/apps/desktop/src/automation_projection.ts
@@ -1,0 +1,43 @@
+import type { ActivityItem, DesktopSnapshot } from "./contracts";
+
+export interface AutomationSuggestion {
+  id: string;
+  title: string;
+  description: string;
+  sourceEventId: string;
+  state: "suggested" | "review_required";
+}
+
+export interface AutomationProjection {
+  schema: "automation.studio/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  suggestions: AutomationSuggestion[];
+  activeCount: number | null;
+  draftAllowed: boolean;
+  reasonCode: string;
+}
+
+function suggestion(activity: ActivityItem, index: number): AutomationSuggestion {
+  return {
+    id: `suggestion-${activity.id}`,
+    title: index === 0 ? "Reutilizar contexto recorrente" : "Agrupar validações do Runtime",
+    description: "Proposta baseada em recibos; nenhum fluxo será criado sem revisão.",
+    sourceEventId: activity.id,
+    state: "review_required",
+  };
+}
+
+export function createAutomationProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): AutomationProjection {
+  const suggestions = snapshot.activity.slice(0, 2).map(suggestion);
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return {
+    schema: "automation.studio/v1",
+    generatedAt,
+    source: snapshot.source,
+    suggestions,
+    activeCount: live ? 0 : null,
+    draftAllowed: live,
+    reasonCode: live ? "automation.studio_projection_ready" : "automation.projection_unavailable",
+  };
+}

--- a/docs/desktop/AUTOMATION-STUDIO.md
+++ b/docs/desktop/AUTOMATION-STUDIO.md
@@ -1,0 +1,10 @@
+# Automation Studio
+
+`automation.studio/v1` represents suggestions, drafts and active routines
+without moving execution authority into the Desktop. Suggestions carry the
+receipt that motivated them and start in `review_required`.
+
+Accepting a suggestion must create a Runtime action descriptor. The current
+surface therefore keeps Accept, Dismiss and Save draft disabled for preview or
+unverified sources. Trigger filters, quiet hours, budgets, cancellation and
+emergency stop belong to the Runtime policy boundary.


### PR DESCRIPTION
Parent: #226
Runtime rules: `wesleysimplicio/simplicio-runtime#5198`
Runtime policy: `wesleysimplicio/simplicio-runtime#5197`
Runtime scheduler: `wesleysimplicio/simplicio-runtime#5172`
Capability source: #224.

## Objetivo
Oferecer um editor visual prático para criar e operar automações governadas sem exigir cron syntax, YAML ou terminal.

## Layout
### Automation list
- enabled/paused/draft/blocked/degraded.
- Next run/last run/outcome.
- Trigger summary, Bot/profile/project, capability/action and budget.
- Search/filter/favorites.

### Builder
1. **When** — schedule, webhook, Git/file change, channel event, goal/session event, connector event.
2. **If** — deterministic conditions and scope.
3. **Then** — capability/playbook/Bot action selected from Capability Center.
4. **Mode** — suggest, ask or autonomous within policy.
5. **Limits** — cost/tokens/time/concurrency/rate/destination.
6. **Delivery** — Today, notification, channel, session or artifact.
7. **Review** — plain-language preview + contract JSON advanced view.

## Operações
- Create/edit/duplicate/delete.
- Validate/preview/dry-run.
- Enable/disable/pause/resume.
- Run now.
- View history, receipts and failures.
- Repair unavailable dependency.
- Import/export governed playbook.

## Regras
- Form fields generated from public schemas/action descriptors where possible.
- No raw shell as primary automation action.
- Enabling a mutable/external automation requires policy/approval from Runtime.
- Unknown schema is safely read-only/unavailable.
- Desktop does not maintain a second scheduler.

## Aceite
- [ ] User creates schedule -> capability -> ask-before-acting automation without terminal.
- [ ] Suggested automation opens as draft, not enabled.
- [ ] Dry-run proves zero effects.
- [ ] Disabled/blocked dependency is shown with remediation.
- [ ] History links trigger, decision, approval, effect and delivery receipts.
- [ ] E2E covers create, run, pause, failure and restart.