### PR TITLE
[Desktop][Workspace OS][P0] Spaces & Teams: switcher, templates, members, shared memory e policies

### DIFF
--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -6,6 +6,7 @@ import { createAmbientProjection } from "../ambient";
 import { createChatProjection } from "../chat_projection";
 import { createCapabilityRegistry } from "../capability_registry";
 import { createAutomationProjection } from "../automation_projection";
+import { createWorkspaceProjection } from "../workspace_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -101,15 +102,18 @@ function ChatsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCe
 }
 
 function TeamsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCenter: BotCenterSnapshot }) {
-  const room = botCenter.rooms[0];
+  const workspace = createWorkspaceProjection(snapshot, botCenter);
+  const space = workspace.spaces[0];
+  const team = workspace.teams[0];
+  const room = botCenter.rooms.find((candidate) => team?.roomIds.includes(candidate.roomId));
   return (
     <div className="page product-page">
       <SurfaceHeading view="teams" snapshot={snapshot} />
       <div className="workspace-layout">
-        <section className="panel teams-panel"><div className="panel-heading"><div><span className="eyebrow">Spaces</span><h2>Teams</h2></div><ActionButton>Criar Team</ActionButton></div><div className="space-card active"><span className="space-avatar">P</span><div><strong>Personal</strong><span>Workspace padrão · 2 Bots projetados</span></div><span className="space-state">ativo</span></div><div className="space-card"><span className="space-avatar muted">+</span><div><strong>Novo Space</strong><span>Disponível quando o Workspace API estiver pronto</span></div></div><div className="team-subsection"><span className="eyebrow">Team Rooms</span>{room ? <div className="room-row"><span className="room-icon"><Glyph name="teams" size={16} /></span><div><strong>{room.displayName}</strong><span>{room.members.map((member) => member.label).join(" · ")}</span></div><span className="room-unread">{room.unread}</span></div> : <p className="empty-state">Nenhuma Room projetada.</p>}</div></section>
+        <section className="panel teams-panel"><div className="panel-heading"><div><span className="eyebrow">Spaces</span><h2>Teams</h2></div><ActionButton>Criar Team</ActionButton></div><div className="space-card active"><span className="space-avatar">P</span><div><strong>{space?.displayName ?? "Personal"}</strong><span>Workspace padrão · {team?.memberIds.length ?? 0} membros projetados</span></div><span className="space-state">{space?.active ? "ativo" : "inativo"}</span></div><div className="space-card"><span className="space-avatar muted">+</span><div><strong>Novo Space</strong><span>Disponível quando o Workspace API estiver pronto</span></div></div><div className="team-subsection"><span className="eyebrow">Team Rooms</span>{room ? <div className="room-row"><span className="room-icon"><Glyph name="teams" size={16} /></span><div><strong>{room.displayName}</strong><span>{room.members.map((member) => member.label).join(" · ")}</span></div><span className="room-unread">{room.unread}</span></div> : <p className="empty-state">Nenhuma Room projetada.</p>}</div></section>
         <section className="panel work-item-panel"><div className="panel-heading"><div><span className="eyebrow">Work Items</span><h2>Mission Control</h2></div><span className="attention-chip">1 atenção</span></div><article className="work-item-card"><div className="work-item-title"><span className="work-item-status blocked" /><div><strong>Revisar integração do Desktop</strong><span>WI-01 · Cora · {room?.displayName ?? "sem Room"}</span></div></div><p>O item está aguardando aprovação e não será iniciado automaticamente.</p><div className="work-item-footer"><span>blocked · approval_required</span><ActionButton>Assumir</ActionButton></div></article><div className="live-dock"><div><span className="eyebrow">Live Dock</span><strong>Nenhuma sessão ativa</strong></div><Glyph name="live" size={22} /></div></section>
       </div>
-      <UnavailableNotice code="workspace.projection_unavailable">Membership, reassign, threads e criação de Work Items precisam do Workspace/Session Service do Runtime.</UnavailableNotice>
+      <UnavailableNotice code={workspace.reasonCode}>Membership, reassign, threads e criação de Work Items precisam do Workspace/Session Service do Runtime.</UnavailableNotice>
     </div>
   );
 }

--- a/apps/desktop/src/workspace_projection.test.ts
+++ b/apps/desktop/src/workspace_projection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter } from "./bot_center";
+import { createDemoSnapshot } from "./demo";
+import { createWorkspaceProjection } from "./workspace_projection";
+
+describe("workspace/v1", () => {
+  it("keeps Space, Team, Room and shared memory identity linked", () => {
+    const snapshot = createDemoSnapshot("active");
+    const projection = createWorkspaceProjection(snapshot, createDemoBotCenter());
+    expect(projection.schema).toBe("workspace/v1");
+    expect(projection.spaces[0].teamIds).toContain("team-desktop");
+    expect(projection.teams[0].roomIds).toContain("room-desktop");
+    expect(projection.teams[0].sharedMemoryScope).toBe("space-personal/team-desktop");
+  });
+
+  it("does not present preview membership as a live Workspace", () => {
+    const snapshot = createDemoSnapshot("active");
+    expect(createWorkspaceProjection(snapshot, createDemoBotCenter()).reasonCode).toBe("workspace.projection_unavailable");
+  });
+});

--- a/apps/desktop/src/workspace_projection.ts
+++ b/apps/desktop/src/workspace_projection.ts
@@ -1,0 +1,43 @@
+import type { BotCenterSnapshot, DesktopSnapshot } from "./contracts";
+
+export interface WorkspaceTeam {
+  teamId: string;
+  displayName: string;
+  memberIds: string[];
+  roomIds: string[];
+  sharedMemoryScope: string;
+}
+
+export interface WorkspaceSpace {
+  spaceId: string;
+  displayName: string;
+  teamIds: string[];
+  active: boolean;
+}
+
+export interface WorkspaceProjection {
+  schema: "workspace/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  spaces: WorkspaceSpace[];
+  teams: WorkspaceTeam[];
+  reasonCode: string;
+}
+
+export function createWorkspaceProjection(snapshot: DesktopSnapshot, botCenter: BotCenterSnapshot, generatedAt = snapshot.generatedAt): WorkspaceProjection {
+  const room = botCenter.rooms[0];
+  return {
+    schema: "workspace/v1",
+    generatedAt,
+    source: snapshot.source,
+    spaces: [{ spaceId: "space-personal", displayName: "Personal", teamIds: ["team-desktop"], active: true }],
+    teams: [{
+      teamId: "team-desktop",
+      displayName: "Desktop",
+      memberIds: room?.members.map((member) => member.id) ?? [],
+      roomIds: room ? [room.roomId] : [],
+      sharedMemoryScope: "space-personal/team-desktop",
+    }],
+    reasonCode: snapshot.source === "runtime" ? "workspace.projection_ready" : "workspace.projection_unavailable",
+  };
+}

--- a/docs/desktop/WORKSPACE-CONTRACT.md
+++ b/docs/desktop/WORKSPACE-CONTRACT.md
@@ -1,0 +1,10 @@
+# Workspace projection
+
+`workspace/v1` binds Spaces, Teams, Rooms and shared-memory scopes without
+duplicating Session Service or Bot membership in the Desktop. A Team and its
+Room keep stable IDs so Chat, Work Items, Live and Library can link to the
+same object.
+
+The preview can render structure for layout review, but membership, invites,
+reassignments and shared-memory writes remain disabled until the Runtime
+publishes a verified Workspace projection.


### PR DESCRIPTION
Parent: #238
Runtime contracts: `simplicio-runtime#5209`
Related: #216 Bot Center, #220 Projects, #221 Onboarding.

## Objetivo
Criar uma experiência simples para separar vida pessoal, estudo, criação, empresa e software, e montar times de humanos + Bots sem expor a complexidade técnica do Runtime.

## Space switcher
Na toolbar:
`Personal ▾`, `Study ▾`, `Creator Studio ▾`, `Company ▾`.

Popover permite trocar, criar, renomear, arquivar e abrir configurações. Troca atualiza Teams/Chats/Apps sem misturar memória.

## Teams home
- tiles/lista clean de Teams;
- avatar stack de Bots/humans;
- resumo do que faz;
- live status discreto;
- room principal e work items recentes;
- create from template.

## Team detail
Abas/contexto progressivo:
- Overview;
- Room;
- Work;
- Members;
- Apps;
- Automations;
- Memory & Permissions em Advanced.

## Templates
- Personal Assistants;
- Study Team;
- Creator Studio;
- Business Operations;
- Software Team;
- Blank.

Preview mostra Bots, Apps e permissões antes de criar. Criação não ativa agents/providers.

## Member management
Add/remove/move human ou Bot, role, default mode, allowed Apps, private/shared memory indicator e invite/pairing quando aplicável.

## Aceite
- [ ] Criar Space/Team em poucos passos.
- [ ] Trocar Space não vaza chats/memory.
- [ ] Bot participa de dois Teams com estado correto.
- [ ] UI mostra policy/permission backend, sem calcular localmente.
- [ ] Templates são editáveis antes de criar.
- [ ] Drag/drop ou Move To usa operation real/revision.
- [ ] Keyboard/accessibility e empty/error/unavailable states.