### PR TITLE
[Desktop][Workspace OS][P0] Multi-Chat Workspace: tabs, direct chats, rooms, task threads e runs

### DIFF
--- a/apps/desktop/src/multi_chat_projection.test.ts
+++ b/apps/desktop/src/multi_chat_projection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter } from "./bot_center";
+import { createMultiChatProjection } from "./multi_chat_projection";
+
+describe("chat.workspace/v1", () => {
+  it("lists sessions by canonical IDs and revisions", () => {
+    const projection = createMultiChatProjection(createDemoBotCenter());
+    expect(projection.schema).toBe("chat.workspace/v1");
+    expect(projection.selectedSessionId).toBe("bot-cora-session-01");
+    expect(projection.sessions[0]).toMatchObject({ botId: "bot-cora", revision: 7 });
+    expect(projection.sessions[0].unread).toBeGreaterThan(0);
+  });
+
+  it("does not expose a create-session effect in preview", () => {
+    expect(createMultiChatProjection(createDemoBotCenter()).reasonCode).toBe("chat.workspace_projection_unavailable");
+  });
+});

--- a/apps/desktop/src/multi_chat_projection.ts
+++ b/apps/desktop/src/multi_chat_projection.ts
@@ -1,0 +1,38 @@
+import type { BotCenterSnapshot } from "./contracts";
+
+export interface ChatSessionSummary {
+  sessionId: string;
+  botId: string;
+  title: string;
+  state: "idle" | "running" | "paused" | "blocked" | "completed";
+  revision: number;
+  unread: number;
+}
+
+export interface MultiChatProjection {
+  schema: "chat.workspace/v1";
+  generatedAt: string;
+  source: BotCenterSnapshot["source"];
+  selectedSessionId: string | null;
+  sessions: ChatSessionSummary[];
+  reasonCode: string;
+}
+
+export function createMultiChatProjection(botCenter: BotCenterSnapshot, generatedAt = botCenter.generatedAt): MultiChatProjection {
+  const sessions = botCenter.sessions.map((session) => ({
+    sessionId: session.sessionId,
+    botId: session.botId,
+    title: botCenter.bots.find((bot) => bot.botId === session.botId)?.displayName ?? session.botId,
+    state: session.state,
+    revision: session.revision,
+    unread: session.events.filter((event) => event.actorKind === "bot" && event.state === "complete").length,
+  }));
+  return {
+    schema: "chat.workspace/v1",
+    generatedAt,
+    source: botCenter.source,
+    selectedSessionId: sessions[0]?.sessionId ?? null,
+    sessions,
+    reasonCode: botCenter.actionAuthority === "runtime" ? "chat.workspace_projection_ready" : "chat.workspace_projection_unavailable",
+  };
+}

--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -7,6 +7,7 @@ import { createChatProjection } from "../chat_projection";
 import { createCapabilityRegistry } from "../capability_registry";
 import { createAutomationProjection } from "../automation_projection";
 import { createWorkspaceProjection } from "../workspace_projection";
+import { createMultiChatProjection } from "../multi_chat_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -84,13 +85,14 @@ function QueueRow({ title, detail, status }: { title: string; detail: string; st
 
 function ChatsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCenter: BotCenterSnapshot }) {
   const projection = createChatProjection(botCenter);
+  const workspace = createMultiChatProjection(botCenter);
   const session = botCenter.sessions[0];
   const events = projection.events;
   return (
     <div className="page product-page">
       <SurfaceHeading view="chats" snapshot={snapshot} />
       <div className="chat-layout">
-        <aside className="panel session-list"><div className="panel-heading"><div><span className="eyebrow">Sessões</span><h2>Chats</h2></div><span className="queue-count">{botCenter.sessions.length}</span></div><button className="session-card active" type="button"><span className="bot-avatar">C</span><span><strong>Cora</strong><small>{session?.state ?? "sem sessão"} · {session?.revision ? `rev. ${session.revision}` : "—"}</small></span></button><ActionButton title="Criar sessão exige o Agent API do Runtime">+ Novo chat</ActionButton></aside>
+        <aside className="panel session-list"><div className="panel-heading"><div><span className="eyebrow">Sessões</span><h2>Chats</h2></div><span className="queue-count">{workspace.sessions.length}</span></div>{workspace.sessions.map((chat) => <button className={`session-card ${workspace.selectedSessionId === chat.sessionId ? "active" : ""}`} type="button" key={chat.sessionId}><span className="bot-avatar">{chat.title.slice(0, 1).toUpperCase()}</span><span><strong>{chat.title}</strong><small>{chat.state} · rev. {chat.revision} · {chat.unread} eventos</small></span></button>)}<ActionButton title="Criar sessão exige o Agent API do Runtime">+ Novo chat</ActionButton></aside>
         <section className="panel chat-session"><div className="chat-session-head"><div><span className="eyebrow">Session Service</span><h2>Cora <small>· {projection.sessionId ?? "sem sessão"}</small></h2></div><div className="chat-head-actions"><ActionButton>Steer</ActionButton><ActionButton>Cancelar</ActionButton></div></div>
           <UnavailableNotice code={projection.reasonCode}>O histórico é redigido e limitado; streaming, approvals e envio dependem do contrato canônico do Runtime.</UnavailableNotice>
           <div className="chat-events">{events.filter((event) => event.kind === "message" || event.kind === "tool_result" || event.kind === "approval_request" || event.kind === "artifact").map((event) => <article className={`chat-event ${event.actorKind} ${event.state === "blocked" ? "blocked" : ""}`} key={event.eventId}><span className="chat-event-avatar">{event.actorKind === "human" ? "V" : event.actorKind === "bot" ? "C" : "R"}</span><div><div className="chat-event-meta"><strong>{event.actorLabel}</strong><span>{event.kind.replaceAll("_", " ")}</span></div><p>{event.content}</p>{event.toolName && <code>tool: {event.toolName}</code>}{event.approvalId && <code>approval: {event.approvalId}</code>}{event.artifactName && <button className="inline-link" type="button" disabled>{event.artifactName}</button>}</div></article>)}</div>

--- a/docs/desktop/MULTI-CHAT.md
+++ b/docs/desktop/MULTI-CHAT.md
@@ -1,0 +1,9 @@
+# Multi-chat workspace
+
+`chat.workspace/v1` is a bounded session index. It links each chat to the
+canonical `session_id`, Bot ID and Runtime revision, so switching or reopening
+a chat never creates a local duplicate session.
+
+New, resume, rename and branch are Runtime operations. The preview renders the
+index and keeps those controls disabled until Session Service authority is
+verified.


### PR DESCRIPTION
Parent: #238
Runtime contract: `simplicio-runtime#5210`
Extends: #218 Chat, #216 Rooms/Bot Mode.

## Objetivo
Permitir vários chats simultâneos e facilmente encontráveis, como um workspace moderno, sem confundir tab aberta com sessão canônica.

## Chats index
- Pinned;
- Team Rooms;
- Direct;
- Task Threads;
- Automation Runs;
- Recent/Archived;
- search/filter by Space/Team/project/Bot/date/type.

## Tab strip
- várias conversas abertas;
- pin/reorder/close/reopen;
- unread/attention indicator;
- Cmd/Ctrl+click abre nova tab;
- optional split view de duas tabs;
- move tab to window quando suportado;
- closing tab never deletes conversation.

## Contextual sidebar
Quando Chats ativo, mostra apenas categorias/conversas relevantes. Não criar segunda sidebar permanente em outras áreas.

## Conversation header
- type/Team/participants;
- Discuss/Execute/Review quando room;
- linked Work Item/project;
- search, members, details e handoff em menu contextual.

## Reconnect
Tabs são preferência local/profile-scoped; transcript/unread/lineage vêm do Runtime. Reconnect/replay não duplica conteúdo.

## Aceite
- [ ] Direct, room, task e automation histories aparecem no mesmo index.
- [ ] 10+ chats abertos continuam navegáveis sem poluição.
- [ ] Split view não mistura composer/destination.
- [ ] CLI/gateway-created conversation aparece automaticamente.
- [ ] Close/reopen preserva sessão.
- [ ] Search e keyboard shortcuts funcionam.
- [ ] Unknown/deleted/stale conversation degrada com recuperação clara.