### PR TITLE
[Desktop][Workspace OS][P0] Work Item Canvas: objetivo, responsáveis, progresso, artifacts, approvals e tokens

### DIFF
--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -8,6 +8,7 @@ import { createCapabilityRegistry } from "../capability_registry";
 import { createAutomationProjection } from "../automation_projection";
 import { createWorkspaceProjection } from "../workspace_projection";
 import { createMultiChatProjection } from "../multi_chat_projection";
+import { createWorkItemProjection } from "../work_item_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -108,12 +109,13 @@ function TeamsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCe
   const space = workspace.spaces[0];
   const team = workspace.teams[0];
   const room = botCenter.rooms.find((candidate) => team?.roomIds.includes(candidate.roomId));
+  const workItem = createWorkItemProjection(snapshot, botCenter);
   return (
     <div className="page product-page">
       <SurfaceHeading view="teams" snapshot={snapshot} />
       <div className="workspace-layout">
         <section className="panel teams-panel"><div className="panel-heading"><div><span className="eyebrow">Spaces</span><h2>Teams</h2></div><ActionButton>Criar Team</ActionButton></div><div className="space-card active"><span className="space-avatar">P</span><div><strong>{space?.displayName ?? "Personal"}</strong><span>Workspace padrão · {team?.memberIds.length ?? 0} membros projetados</span></div><span className="space-state">{space?.active ? "ativo" : "inativo"}</span></div><div className="space-card"><span className="space-avatar muted">+</span><div><strong>Novo Space</strong><span>Disponível quando o Workspace API estiver pronto</span></div></div><div className="team-subsection"><span className="eyebrow">Team Rooms</span>{room ? <div className="room-row"><span className="room-icon"><Glyph name="teams" size={16} /></span><div><strong>{room.displayName}</strong><span>{room.members.map((member) => member.label).join(" · ")}</span></div><span className="room-unread">{room.unread}</span></div> : <p className="empty-state">Nenhuma Room projetada.</p>}</div></section>
-        <section className="panel work-item-panel"><div className="panel-heading"><div><span className="eyebrow">Work Items</span><h2>Mission Control</h2></div><span className="attention-chip">1 atenção</span></div><article className="work-item-card"><div className="work-item-title"><span className="work-item-status blocked" /><div><strong>Revisar integração do Desktop</strong><span>WI-01 · Cora · {room?.displayName ?? "sem Room"}</span></div></div><p>O item está aguardando aprovação e não será iniciado automaticamente.</p><div className="work-item-footer"><span>blocked · approval_required</span><ActionButton>Assumir</ActionButton></div></article><div className="live-dock"><div><span className="eyebrow">Live Dock</span><strong>Nenhuma sessão ativa</strong></div><Glyph name="live" size={22} /></div></section>
+        <section className="panel work-item-panel"><div className="panel-heading"><div><span className="eyebrow">Work Items</span><h2>Mission Control</h2></div><span className="attention-chip">{workItem.status === "blocked" ? "1 atenção" : workItem.status}</span></div><article className="work-item-card"><div className="work-item-title"><span className={`work-item-status ${workItem.status === "blocked" ? "blocked" : "running"}`} /><div><strong>{workItem.title}</strong><span>{workItem.workItemId} · {workItem.botId ?? "sem Bot"} · {room?.displayName ?? "sem Room"}</span></div></div><p>{workItem.status === "blocked" ? "O item está aguardando aprovação e não será iniciado automaticamente." : "Estado projetado pelo Runtime."}</p><div className="work-item-footer"><span>{workItem.status} · {workItem.approvalId ?? workItem.reasonCode}</span><ActionButton>Assumir</ActionButton></div></article><div className="live-dock"><div><span className="eyebrow">Live Dock</span><strong>Nenhuma sessão ativa</strong></div><Glyph name="live" size={22} /></div></section>
       </div>
       <UnavailableNotice code={workspace.reasonCode}>Membership, reassign, threads e criação de Work Items precisam do Workspace/Session Service do Runtime.</UnavailableNotice>
     </div>

--- a/apps/desktop/src/work_item_projection.test.ts
+++ b/apps/desktop/src/work_item_projection.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter } from "./bot_center";
+import { createDemoSnapshot } from "./demo";
+import { createWorkItemProjection } from "./work_item_projection";
+
+describe("work.item/v1", () => {
+  it("binds Work Item to Team, Room, Bot, Session and approval", () => {
+    const snapshot = createDemoSnapshot("active");
+    const item = createWorkItemProjection(snapshot, createDemoBotCenter());
+    expect(item.schema).toBe("work.item/v1");
+    expect(item.status).toBe("blocked");
+    expect(item.teamId).toBe("team-desktop");
+    expect(item.roomId).toBe("room-desktop");
+    expect(item.sessionId).toBe("bot-cora-session-01");
+    expect(item.approvalId).toBe("approval-branch-01");
+    expect(item.action).toBe("unavailable");
+  });
+
+  it("never turns a preview Work Item into an executable action", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    expect(createWorkItemProjection(snapshot, createDemoBotCenter()).action).toBe("approve");
+  });
+});

--- a/apps/desktop/src/work_item_projection.ts
+++ b/apps/desktop/src/work_item_projection.ts
@@ -1,0 +1,38 @@
+import type { BotCenterSnapshot, DesktopSnapshot } from "./contracts";
+
+export interface WorkItemProjection {
+  schema: "work.item/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  workItemId: string;
+  title: string;
+  status: "queued" | "running" | "paused" | "blocked" | "completed" | "failed";
+  teamId: string;
+  roomId: string | null;
+  botId: string | null;
+  sessionId: string | null;
+  approvalId: string | null;
+  action: "open" | "approve" | "resume" | "unavailable";
+  reasonCode: string;
+}
+
+export function createWorkItemProjection(snapshot: DesktopSnapshot, botCenter: BotCenterSnapshot, generatedAt = snapshot.generatedAt): WorkItemProjection {
+  const session = botCenter.sessions[0];
+  const approval = session?.events.find((event) => event.kind === "approval_request");
+  const status = session?.state === "running" ? "running" : session?.state === "completed" ? "completed" : approval ? "blocked" : "queued";
+  return {
+    schema: "work.item/v1",
+    generatedAt,
+    source: snapshot.source,
+    workItemId: "WI-01",
+    title: "Revisar integração do Desktop",
+    status,
+    teamId: "team-desktop",
+    roomId: session?.roomId ?? null,
+    botId: session?.botId ?? null,
+    sessionId: session?.sessionId ?? null,
+    approvalId: approval?.approvalId ?? null,
+    action: snapshot.source === "runtime" ? (approval ? "approve" : "open") : "unavailable",
+    reasonCode: snapshot.source === "runtime" ? "work.item_projection_ready" : "work.item_projection_unavailable",
+  };
+}

--- a/docs/desktop/WORK-ITEMS.md
+++ b/docs/desktop/WORK-ITEMS.md
@@ -1,0 +1,9 @@
+# Work Item projection
+
+`work.item/v1` is the shared identity that connects a task to its Space/Team,
+Room, Bot, session and approval. The Desktop renders progress from Runtime
+state; it does not run a local queue or infer completion from a button click.
+
+The Work Item card exposes only the action permitted by the Runtime action
+descriptor. Preview and stale projections show the item and its reason code,
+but keep Approve/Resume/Assume unavailable.


### PR DESCRIPTION
Parent: #238
Runtime contract: `simplicio-runtime#5211`
Related: #218 Chat, #237 Token Reports.

## Objetivo
Mostrar trabalho concreto de forma independente do transcript, permitindo acompanhar, mover, orientar e revisar uma tarefa inteira em uma tela clean.

## Summary header
- title/objective;
- Team/Space/project;
- state e progress;
- coordinator/assignees avatar stack;
- primary action contextual;
- overflow para ações secundárias.

## Sections com disclosure
- Overview e acceptance criteria;
- subtasks/dependencies;
- conversation/task thread;
- Live activity;
- artifacts/deliverables;
- approvals/blockers;
- tokens/cost/time;
- evidence/receipts/diagnostics em Advanced.

## Interações
- assign/reassign/add Bot;
- move to Team/Space;
- split/merge child tasks;
- pause/resume/cancel/steer;
- review/approve/reopen;
- open App/resource used;
- preview/download artifact;
- make routine/automation;
- open full token report.

## Layout
Uma coluna principal legível; timeline/detalhes em inspector sob demanda. Não exibir DAG, logs e métricas todos ao mesmo tempo.

## Aceite
- [ ] Work Item criado no chat abre canvas sem perder thread.
- [ ] Progress/status é idêntico ao Runtime.
- [ ] Reassign/move mostra confirmação somente quando consequential.
- [ ] Artifacts e receipts corretos abrem em preview.
- [ ] Token/cost totals reconciliam com #5207/#237.
- [ ] Completion bloqueada aparece com critério/evidence faltante.
- [ ] Drag/drop possui alternativa keyboard/menu e usa revision real.