### PR TITLE
[Desktop][Workspace OS][P0] Live Agent Dock + Mission Control fluido

### DIFF
--- a/apps/desktop/src/live_projection.test.ts
+++ b/apps/desktop/src/live_projection.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter } from "./bot_center";
+import { createDemoSnapshot } from "./demo";
+import { createLiveProjection } from "./live_projection";
+
+describe("live.mission-control/v1", () => {
+  it("keeps Live contextual and linked to canonical sessions", () => {
+    const snapshot = createDemoSnapshot("active");
+    const projection = createLiveProjection(snapshot, createDemoBotCenter());
+    expect(projection.schema).toBe("live.mission-control/v1");
+    expect(projection.visible).toBe(true);
+    expect(projection.tasks[0]).toMatchObject({ workItemId: "WI-01", sessionId: "bot-cora-session-01", botId: "bot-cora" });
+    expect(projection.reasonCode).toBe("live.mission_control_projection_unavailable");
+  });
+
+  it("does not show a permanent Live affordance for completed work", () => {
+    const snapshot = createDemoSnapshot("active");
+    const bots = createDemoBotCenter();
+    bots.sessions[0].state = "completed";
+    expect(createLiveProjection(snapshot, bots).visible).toBe(false);
+  });
+});

--- a/apps/desktop/src/live_projection.ts
+++ b/apps/desktop/src/live_projection.ts
@@ -1,0 +1,35 @@
+import type { BotCenterSnapshot, DesktopSnapshot } from "./contracts";
+
+export interface LiveTask {
+  workItemId: string;
+  sessionId: string;
+  botId: string;
+  state: "working" | "waiting" | "paused" | "blocked" | "completed";
+}
+
+export interface LiveProjection {
+  schema: "live.mission-control/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  visible: boolean;
+  tasks: LiveTask[];
+  reasonCode: string;
+}
+
+export function createLiveProjection(snapshot: DesktopSnapshot, botCenter: BotCenterSnapshot, generatedAt = snapshot.generatedAt): LiveProjection {
+  const tasks: LiveTask[] = botCenter.sessions.map((session) => ({
+    workItemId: "WI-01",
+    sessionId: session.sessionId,
+    botId: session.botId,
+    state: session.state === "running" ? "working" : session.state === "idle" ? "waiting" : session.state,
+  }));
+  const visible = tasks.some((task) => task.state === "working" || task.state === "waiting" || task.state === "paused" || task.state === "blocked");
+  return {
+    schema: "live.mission-control/v1",
+    generatedAt,
+    source: snapshot.source,
+    visible,
+    tasks,
+    reasonCode: snapshot.source === "runtime" ? "live.mission_control_projection_ready" : "live.mission_control_projection_unavailable",
+  };
+}

--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -9,6 +9,7 @@ import { createAutomationProjection } from "../automation_projection";
 import { createWorkspaceProjection } from "../workspace_projection";
 import { createMultiChatProjection } from "../multi_chat_projection";
 import { createWorkItemProjection } from "../work_item_projection";
+import { createLiveProjection } from "../live_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -110,12 +111,13 @@ function TeamsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCe
   const team = workspace.teams[0];
   const room = botCenter.rooms.find((candidate) => team?.roomIds.includes(candidate.roomId));
   const workItem = createWorkItemProjection(snapshot, botCenter);
+  const live = createLiveProjection(snapshot, botCenter);
   return (
     <div className="page product-page">
       <SurfaceHeading view="teams" snapshot={snapshot} />
       <div className="workspace-layout">
         <section className="panel teams-panel"><div className="panel-heading"><div><span className="eyebrow">Spaces</span><h2>Teams</h2></div><ActionButton>Criar Team</ActionButton></div><div className="space-card active"><span className="space-avatar">P</span><div><strong>{space?.displayName ?? "Personal"}</strong><span>Workspace padrão · {team?.memberIds.length ?? 0} membros projetados</span></div><span className="space-state">{space?.active ? "ativo" : "inativo"}</span></div><div className="space-card"><span className="space-avatar muted">+</span><div><strong>Novo Space</strong><span>Disponível quando o Workspace API estiver pronto</span></div></div><div className="team-subsection"><span className="eyebrow">Team Rooms</span>{room ? <div className="room-row"><span className="room-icon"><Glyph name="teams" size={16} /></span><div><strong>{room.displayName}</strong><span>{room.members.map((member) => member.label).join(" · ")}</span></div><span className="room-unread">{room.unread}</span></div> : <p className="empty-state">Nenhuma Room projetada.</p>}</div></section>
-        <section className="panel work-item-panel"><div className="panel-heading"><div><span className="eyebrow">Work Items</span><h2>Mission Control</h2></div><span className="attention-chip">{workItem.status === "blocked" ? "1 atenção" : workItem.status}</span></div><article className="work-item-card"><div className="work-item-title"><span className={`work-item-status ${workItem.status === "blocked" ? "blocked" : "running"}`} /><div><strong>{workItem.title}</strong><span>{workItem.workItemId} · {workItem.botId ?? "sem Bot"} · {room?.displayName ?? "sem Room"}</span></div></div><p>{workItem.status === "blocked" ? "O item está aguardando aprovação e não será iniciado automaticamente." : "Estado projetado pelo Runtime."}</p><div className="work-item-footer"><span>{workItem.status} · {workItem.approvalId ?? workItem.reasonCode}</span><ActionButton>Assumir</ActionButton></div></article><div className="live-dock"><div><span className="eyebrow">Live Dock</span><strong>Nenhuma sessão ativa</strong></div><Glyph name="live" size={22} /></div></section>
+        <section className="panel work-item-panel"><div className="panel-heading"><div><span className="eyebrow">Work Items</span><h2>Mission Control</h2></div><span className="attention-chip">{workItem.status === "blocked" ? "1 atenção" : workItem.status}</span></div><article className="work-item-card"><div className="work-item-title"><span className={`work-item-status ${workItem.status === "blocked" ? "blocked" : "running"}`} /><div><strong>{workItem.title}</strong><span>{workItem.workItemId} · {workItem.botId ?? "sem Bot"} · {room?.displayName ?? "sem Room"}</span></div></div><p>{workItem.status === "blocked" ? "O item está aguardando aprovação e não será iniciado automaticamente." : "Estado projetado pelo Runtime."}</p><div className="work-item-footer"><span>{workItem.status} · {workItem.approvalId ?? workItem.reasonCode}</span><ActionButton>Assumir</ActionButton></div></article>{live.visible ? <div className="live-dock"><div><span className="eyebrow">Live Dock</span><strong>{live.tasks.length} sessão(ões) com atenção</strong></div><Glyph name="live" size={22} /></div> : <div className="live-dock is-hidden"><div><span className="eyebrow">Live Dock</span><strong>Oculto até existir trabalho ativo</strong></div><Glyph name="live" size={22} /></div>}</section>
       </div>
       <UnavailableNotice code={workspace.reasonCode}>Membership, reassign, threads e criação de Work Items precisam do Workspace/Session Service do Runtime.</UnavailableNotice>
     </div>

--- a/docs/desktop/LIVE-MISSION-CONTROL.md
+++ b/docs/desktop/LIVE-MISSION-CONTROL.md
@@ -1,0 +1,9 @@
+# Live Dock and Mission Control
+
+`live.mission-control/v1` is a contextual projection of active Work Items and
+their canonical sessions. Live is visible only while work is running, waiting,
+paused or blocked; completed or empty work does not reserve a permanent rail.
+
+The projection exposes enough identity to open the Work Item, Chat or Computer
+session. Control actions still require Runtime descriptors, approval and the
+same revision used by the session stream.


### PR DESCRIPTION
Parent: #238
Runtime projection: `simplicio-runtime#5213`
Related: #216 Bot/Computer takeover, #230 Activity, #236 Design.

## Objetivo
Mostrar o que cada Bot/agent está fazendo e permitir intervenção imediata sem manter um painel técnico aberto o tempo todo.

## Live Dock
Pill discreto aparece somente quando há trabalho/atenção:
`3 working · 1 needs you`.

- fade/scale suave ao surgir;
- desaparece após conclusão/TTL;
- estados compreensíveis sem animação;
- não ocupa status bar permanente.

## Mission Control
Sheet/popover amplo ao clicar, agrupado por:
- Needs You;
- Working;
- Waiting;
- Paused/Blocked;
- Completed Recently.

Cada row mostra avatar, Bot/agent, tarefa, stage, progress essencial, Team/Space, resource indicator e uma ação primária.

## Detalhes e ações
Open Chat, Open Work Item, Steer, Pause/Resume, Cancel, Reassign, Move To Team, Review, Open Artifact, Open Browser/Computer, Take Control/Hand Back, Retry/Reconcile — conforme action descriptors reais.

## Manipulação
- drag/drop para reassign/move quando permitido;
- alternative menu/keyboard;
- optimistic UI só após ack/revision strategy; rollback visual em conflito;
- agrupamento por Team/Work Item/priority;
- filters/search sob demanda.

## Motion
Shared-layout transition entre dock, row e Work Item; progress updates sem relayout agressivo; completed faz confirmação curta e fade para Activity. Reduced-motion equivalente.

## Aceite
- [ ] Abrir Live não inicia agents/providers.
- [ ] Estado/ordem/progress iguais ao Runtime.
- [ ] Steer/reassign/takeover atingem actor/resource correto.
- [ ] Reconnect preserva cursor e não duplica rows.
- [ ] 100+ items continuam performáticos/virtualizados.
- [ ] Motion nunca bloqueia ação e reduced-motion passa.
- [ ] Completed permanece encontrável em Activity.