### PR TITLE
[Desktop][Workspace OS][P0] Universal “+ New” launcher: chat, Team, task, Video, Browser, Computer e Automation

### DIFF
--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
 import { t } from "../i18n";
+import { createLauncherProjection } from "../launcher_projection";
 
 export type View =
   | "today"
@@ -42,6 +43,7 @@ interface ShellProps {
 
 export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
   const isHealthy = snapshot.runtime.state === "healthy";
+  const launcher = createLauncherProjection(snapshot);
 
   return (
     <div className="app-shell">
@@ -108,7 +110,7 @@ export function Shell({ children, snapshot, view, onViewChange }: ShellProps) {
             <button className="space-switcher" type="button" disabled title="Space switcher aguardando o contrato Workspace do Runtime">
               <span className="space-dot" /> Pessoal <Glyph name="chevron" size={14} />
             </button>
-            <button className="toolbar-button" type="button" disabled title="O launcher será habilitado quando o registro de capabilities estiver disponível"><Glyph name="plus" size={16} /> <span>Novo</span></button>
+            <button className="toolbar-button" type="button" disabled={!launcher.actions.some((action) => action.available)} title={launcher.reasonCode}><Glyph name="plus" size={16} /> <span>Novo</span></button>
             <button className="toolbar-button toolbar-search" type="button" disabled title="OmniSearch aguardando o índice canônico do Runtime"><Glyph name="search" size={16} /> <span>Buscar</span><kbd>⌘K</kbd></button>
             <button className="toolbar-icon-button" type="button" disabled title="Live indisponível até o Runtime expor uma sessão ativa"><Glyph name="live" size={16} /></button>
             <button className="toolbar-icon-button" type="button" disabled title="Sem novas atenções"><Glyph name="attention" size={16} /></button>

--- a/apps/desktop/src/launcher_projection.test.ts
+++ b/apps/desktop/src/launcher_projection.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createLauncherProjection } from "./launcher_projection";
+
+describe("desktop.launcher/v1", () => {
+  it("keeps common actions discoverable by stable capability IDs", () => {
+    const projection = createLauncherProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("desktop.launcher/v1");
+    expect(projection.actions.map((action) => action.id)).toEqual(["chat.new", "team.new", "work.new", "app.open", "automation.new"]);
+    expect(projection.actions.every((action) => action.available === false)).toBe(true);
+  });
+
+  it("requires a Runtime probe before enabling a launcher action", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    expect(createLauncherProjection(snapshot).actions.every((action) => action.available)).toBe(true);
+  });
+});

--- a/apps/desktop/src/launcher_projection.ts
+++ b/apps/desktop/src/launcher_projection.ts
@@ -1,0 +1,36 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export interface LauncherAction {
+  id: "chat.new" | "team.new" | "work.new" | "app.open" | "automation.new";
+  label: string;
+  capabilityId: string;
+  requiresApproval: boolean;
+  available: boolean;
+  reasonCode: string;
+}
+
+export interface LauncherProjection {
+  schema: "desktop.launcher/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  actions: LauncherAction[];
+  reasonCode: string;
+}
+
+export function createLauncherProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): LauncherProjection {
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  const actions: Array<Pick<LauncherAction, "id" | "label" | "capabilityId" | "requiresApproval">> = [
+    { id: "chat.new", label: "Start Chat", capabilityId: "chat.session.create", requiresApproval: false },
+    { id: "team.new", label: "Create Team", capabilityId: "workspace.team.create", requiresApproval: true },
+    { id: "work.new", label: "Assign Work", capabilityId: "work.item.create", requiresApproval: true },
+    { id: "app.open", label: "Open App", capabilityId: "capability.open", requiresApproval: true },
+    { id: "automation.new", label: "Create Automation", capabilityId: "automation.draft.create", requiresApproval: true },
+  ];
+  return {
+    schema: "desktop.launcher/v1",
+    generatedAt,
+    source: snapshot.source,
+    actions: actions.map((action) => ({ ...action, available: live, reasonCode: live ? "action_descriptor_verified" : "capability_unverified" })),
+    reasonCode: live ? "desktop.launcher_ready" : "desktop.launcher_unavailable",
+  };
+}

--- a/docs/desktop/LAUNCHER.md
+++ b/docs/desktop/LAUNCHER.md
@@ -1,0 +1,10 @@
+# `+ New` launcher
+
+`desktop.launcher/v1` gives the global `+ New` menu stable capability IDs for
+Start Chat, Create Team, Assign Work, Open App and Create Automation. Forms and
+LLM tools use the same action descriptor; the launcher is not a second command
+engine.
+
+The shell keeps the menu disabled until a Runtime probe verifies the actions.
+An unavailable launcher is visible with remediation rather than a clickable
+placeholder or a fake success toast.


### PR DESCRIPTION
Parent: #238
Related: #224 Apps, #225 Shell, #235 Capability Apps.
Runtime capabilities: `simplicio-runtime#5161`, Work Items `#5211`.

## Objetivo
Dar acesso às ações principais com um clique e linguagem humana, sem obrigar o usuário a saber em qual área ou capability técnica entrar.

## Entrada global
Botão `+ New` na toolbar e shortcut configurável abre command menu/search.

## Ações iniciais
- Start a Chat;
- Create a Team;
- Assign a Task;
- Create a Video;
- Generate an Image;
- Browse the Web;
- Use a Computer;
- Analyze Files/PDF;
- Write/Create Document;
- Build Code/Website;
- Create an Automation;
- Teach Simplicio;
- More Apps.

Itens vêm do Capability Registry e templates; não hardcodar availability. Recentes/favoritos/adaptação por Space podem mudar ordem, mas ações essenciais continuam encontráveis.

## Fluxo
Selecionar ação abre sheet curto com mínimos inputs e contexto atual (Space/Team/project). `Advanced` revela provider/model/toolset/policy quando relevante. Submit cria chat/Work Item/App session/automation pelo backend.

## Handoff
Usuário pode escolher:
- Do it with current Team;
- Choose Bot/Team;
- Use in Chat;
- Open App;
- Run once;
- Save as automation.

## Regras
- Uma ação indisponível mostra reason/remediation.
- Nenhum efeito mutável antes de review/approval quando exigido.
- Launcher não carrega todos os schemas; usa search/metadata e lazy schema.
- Keyboard-first e screen-reader.

## Aceite
- [ ] Video, Browser, Computer, Chat e Automation iniciados em até 2–3 passos.
- [ ] Ação cria IDs/backend state reais.
- [ ] Space/Team defaults corretos, editáveis antes de executar.
- [ ] Unavailable/auth-required flows honestos.
- [ ] Search por intenção encontra Apps/capabilities.
- [ ] Telemetry de click count/usability sem conteúdo sensível.