### PR TITLE
[Desktop][Workspace OS][P1] OmniSearch & Command Palette: encontrar e executar qualquer coisa em segundos

### DIFF
--- a/apps/desktop/src/omnisearch_projection.test.ts
+++ b/apps/desktop/src/omnisearch_projection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createDemoBotCenter } from "./bot_center";
+import { createDemoSnapshot } from "./demo";
+import { createOmniSearchProjection, searchOmni } from "./omnisearch_projection";
+
+describe("search.omni/v1", () => {
+  it("indexes navigable entities without secrets", () => {
+    const projection = createOmniSearchProjection(createDemoSnapshot("active"), createDemoBotCenter());
+    expect(projection.schema).toBe("search.omni/v1");
+    expect(projection.entities.map((entity) => entity.kind)).toEqual(expect.arrayContaining(["capability", "session", "work_item", "artifact", "team"]));
+    expect(projection.entities.every((entity) => entity.secretIndexed === false)).toBe(true);
+    expect(projection.entities.some((entity) => entity.label === "voce@example.com")).toBe(false);
+  });
+
+  it("searches the same bounded index used by the UI", () => {
+    const projection = createOmniSearchProjection(createDemoSnapshot("active"), createDemoBotCenter());
+    expect(searchOmni(projection, "desktop").map((entity) => entity.id)).toEqual(expect.arrayContaining(["WI-01", "team-desktop", "desktop-bot-mode-plan.md"]));
+  });
+});

--- a/apps/desktop/src/omnisearch_projection.ts
+++ b/apps/desktop/src/omnisearch_projection.ts
@@ -1,0 +1,37 @@
+import type { BotCenterSnapshot, DesktopSnapshot } from "./contracts";
+import { createCapabilityRegistry } from "./capability_registry";
+
+export type SearchEntityKind = "capability" | "session" | "work_item" | "artifact" | "team";
+
+export interface SearchEntity {
+  id: string;
+  kind: SearchEntityKind;
+  label: string;
+  target: string;
+  indexed: true;
+  secretIndexed: false;
+}
+
+export interface OmniSearchProjection {
+  schema: "search.omni/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  entities: SearchEntity[];
+  reasonCode: string;
+}
+
+export function createOmniSearchProjection(snapshot: DesktopSnapshot, botCenter: BotCenterSnapshot, generatedAt = snapshot.generatedAt): OmniSearchProjection {
+  const capabilities = createCapabilityRegistry(snapshot).capabilities;
+  const entities: SearchEntity[] = capabilities.map((capability) => ({ id: capability.id, kind: "capability", label: capability.name, target: `apps/${capability.id}`, indexed: true, secretIndexed: false }));
+  for (const session of botCenter.sessions) entities.push({ id: session.sessionId, kind: "session", label: botCenter.bots.find((bot) => bot.botId === session.botId)?.displayName ?? session.sessionId, target: `chats/${session.sessionId}`, indexed: true, secretIndexed: false });
+  entities.push({ id: "WI-01", kind: "work_item", label: "Revisar integração do Desktop", target: "work/WI-01", indexed: true, secretIndexed: false });
+  entities.push({ id: "desktop-bot-mode-plan.md", kind: "artifact", label: "desktop-bot-mode-plan.md", target: "library/desktop-bot-mode-plan.md", indexed: true, secretIndexed: false });
+  entities.push({ id: "team-desktop", kind: "team", label: "Desktop", target: "teams/team-desktop", indexed: true, secretIndexed: false });
+  return { schema: "search.omni/v1", generatedAt, source: snapshot.source, entities, reasonCode: snapshot.source === "runtime" ? "search.omni_projection_ready" : "search.omni_projection_unavailable" };
+}
+
+export function searchOmni(projection: OmniSearchProjection, query: string): SearchEntity[] {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return projection.entities;
+  return projection.entities.filter((entity) => `${entity.label} ${entity.kind}`.toLocaleLowerCase().includes(normalized));
+}

--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -12,6 +12,7 @@ import { createWorkItemProjection } from "../work_item_projection";
 import { createLiveProjection } from "../live_projection";
 import { createRoomProjection } from "../room_projection";
 import { createTokenReport } from "../token_report";
+import { createOmniSearchProjection } from "../omnisearch_projection";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -140,12 +141,13 @@ function AutomationsScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
   );
 }
 
-function AppsScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
+function AppsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCenter: BotCenterSnapshot }) {
   const registry = createCapabilityRegistry(snapshot);
   const tokenReport = createTokenReport(snapshot);
+  const search = createOmniSearchProjection(snapshot, botCenter);
   const apps = registry.capabilities;
   return (
-    <div className="page product-page"><SurfaceHeading view="apps" snapshot={snapshot} /><div className="apps-toolbar"><div className="search-field"><Glyph name="search" size={16} /><span>Buscar capabilities, artifacts ou comandos</span><kbd>⌘K</kbd></div><ActionButton>Favoritos</ActionButton></div><section className="app-grid">{apps.map((app) => <article className="panel app-card" key={app.id}><div className="app-card-head"><span className="app-icon"><Glyph name={app.category === "Learn" ? "spark" : app.category === "Explore" ? "search" : app.category === "Act" ? "live" : app.category === "Build" ? "providers" : "apps"} size={19} /></span><span className="app-category">{app.category}</span></div><h2>{app.name}</h2><p>{app.description}</p><code>{app.reasonCode}</code><ActionButton>Abrir</ActionButton></article>)}</section><div className="apps-bottom-grid"><section className="panel library-card"><div className="panel-heading"><div><span className="eyebrow">Artifact Graph</span><h2>Library</h2></div><ActionButton>Ver tudo</ActionButton></div><p>Artifacts, versões e proveniência aparecem quando o Runtime fornecer handles canônicos.</p><div className="library-row"><span className="file-icon">MD</span><div><strong>desktop-bot-mode-plan.md</strong><span>preview · sem cópia local</span></div></div></section><section className="panel token-card"><div className="panel-heading"><div><span className="eyebrow">Receipts</span><h2>Token Reports</h2></div><Glyph name="activity" size={18} /></div><strong className="report-value">{tokenReport.savedTokens === null ? "—" : tokenReport.savedTokens.toLocaleString("pt-BR")}</strong><p>{tokenReport.estimatedUsd === null ? "Sem métrica agregada verificável para este período." : `Economia estimada: US$ ${tokenReport.estimatedUsd.toFixed(2)}`}</p><code>proof: {tokenReport.proofKind} · {tokenReport.reasonCode}</code></section></div><UnavailableNotice code={registry.reasonCode}>Apps só ficam acionáveis depois de um probe do backend; o launcher não presume capacidades instaladas.</UnavailableNotice></div>
+    <div className="page product-page"><SurfaceHeading view="apps" snapshot={snapshot} /><div className="apps-toolbar"><div className="search-field"><Glyph name="search" size={16} /><span>Buscar capabilities, artifacts ou comandos · {search.entities.length} itens</span><kbd>⌘K</kbd></div><ActionButton>Favoritos</ActionButton></div><section className="app-grid">{apps.map((app) => <article className="panel app-card" key={app.id}><div className="app-card-head"><span className="app-icon"><Glyph name={app.category === "Learn" ? "spark" : app.category === "Explore" ? "search" : app.category === "Act" ? "live" : app.category === "Build" ? "providers" : "apps"} size={19} /></span><span className="app-category">{app.category}</span></div><h2>{app.name}</h2><p>{app.description}</p><code>{app.reasonCode}</code><ActionButton>Abrir</ActionButton></article>)}</section><div className="apps-bottom-grid"><section className="panel library-card"><div className="panel-heading"><div><span className="eyebrow">Artifact Graph</span><h2>Library</h2></div><ActionButton>Ver tudo</ActionButton></div><p>Artifacts, versões e proveniência aparecem quando o Runtime fornecer handles canônicos.</p><div className="library-row"><span className="file-icon">MD</span><div><strong>desktop-bot-mode-plan.md</strong><span>preview · sem cópia local</span></div></div></section><section className="panel token-card"><div className="panel-heading"><div><span className="eyebrow">Receipts</span><h2>Token Reports</h2></div><Glyph name="activity" size={18} /></div><strong className="report-value">{tokenReport.savedTokens === null ? "—" : tokenReport.savedTokens.toLocaleString("pt-BR")}</strong><p>{tokenReport.estimatedUsd === null ? "Sem métrica agregada verificável para este período." : `Economia estimada: US$ ${tokenReport.estimatedUsd.toFixed(2)}`}</p><code>proof: {tokenReport.proofKind} · {tokenReport.reasonCode}</code></section></div><UnavailableNotice code={`${registry.reasonCode}; ${search.reasonCode}`}>Apps só ficam acionáveis depois de um probe do backend; o launcher não presume capacidades instaladas.</UnavailableNotice></div>
   );
 }
 
@@ -154,5 +156,5 @@ export function ProductSurfaceScreen({ view, snapshot, botCenter }: { view: Prod
   if (view === "chats") return <ChatsScreen snapshot={snapshot} botCenter={botCenter} />;
   if (view === "teams") return <TeamsScreen snapshot={snapshot} botCenter={botCenter} />;
   if (view === "automations") return <AutomationsScreen snapshot={snapshot} />;
-  return <AppsScreen snapshot={snapshot} />;
+  return <AppsScreen snapshot={snapshot} botCenter={botCenter} />;
 }

--- a/docs/desktop/OMNISEARCH.md
+++ b/docs/desktop/OMNISEARCH.md
@@ -1,0 +1,8 @@
+# OmniSearch
+
+`search.omni/v1` is a bounded, keyboard-first index for capabilities, Chats,
+Teams, Work Items and Library artifacts. It stores labels and safe handles;
+secret values, prompts and credential/configuration bodies are never indexed.
+
+The global shortcut is Cmd/Ctrl-K. Result opening is navigation to a canonical
+surface; mutating actions still require the Runtime action descriptor.


### PR DESCRIPTION
Parent: #238
Runtime index: `simplicio-runtime#5217`
Related: #225 Shell, #243 + New, #224 Apps.

## Objetivo
Criar uma busca universal rápida e clean para reduzir navegação/cliques e manter recursos secundários fora da sidebar permanente.

## Entry
- toolbar Search;
- Cmd/Ctrl+K;
- optional spotlight-like global shortcut conforme platform policy.

## Search universe
Spaces, Teams, Chats, Work Items, Bots, Apps/capabilities, artifacts, automations, projects, sessions, settings, attention/live items e ações.

## UX
- resultados agrupados por intenção/type, não lista técnica;
- recent/contextual actions primeiro;
- fuzzy + natural-language action queries;
- keyboard navigation;
- previews compactos;
- filters/scopes sob demanda;
- `Open`, `Use`, `Assign`, `Run`, `Configure` conforme action descriptor;
- secondary actions no menu.

## Examples
- `criar vídeo` → Video App / + New flow;
- `browser` → Open Browser / active sessions;
- `PR 128` → Work Item/chat/artifact;
- `o que o Coder está fazendo` → Live item;
- `tokens 3 meses` → Insights report;
- `mover para Creator Team` → scoped move action.

## Regras
- Nenhuma entidade sem permission aparece.
- UI não faz ranking/availability paralelo quando backend fornece.
- Action execution usa canonical ID/revision.
- Search works offline for indexed entities.
- No full content/secrets in index preview.

## Aceite
- [ ] Usuário encontra qualquer área primária/secundária em até dois passos.
- [ ] Chat/Work Item/App/artifact/action aparecem na mesma query.
- [ ] Keyboard-only complete flow.
- [ ] Cross-Space privacy.
- [ ] Large index performance and stale/rebuild states.
- [ ] Unavailable action displays remediation.
- [ ] LLM and Desktop can reference same search result/action ID.