### PR TITLE
[Desktop][Hermes parity][P1] Workspace UX: file browser, previews, projects, worktrees e profiles

### DIFF
--- a/apps/desktop/src/workspace_resources.test.ts
+++ b/apps/desktop/src/workspace_resources.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createWorkspaceResourcesProjection } from "./workspace_resources";
+
+describe("workspace.resources/v1", () => {
+  it("uses handles and never grants arbitrary filesystem access", () => {
+    const projection = createWorkspaceResourcesProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("workspace.resources/v1");
+    expect(projection.arbitraryFilesystemAccess).toBe(false);
+    expect(projection.resources.every((resource) => resource.pathHandle?.includes("://"))).toBe(true);
+    expect(projection.resources.some((resource) => resource.writable)).toBe(false);
+  });
+});

--- a/apps/desktop/src/workspace_resources.ts
+++ b/apps/desktop/src/workspace_resources.ts
@@ -1,0 +1,35 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export interface WorkspaceResource {
+  id: string;
+  kind: "project" | "worktree" | "file" | "profile";
+  label: string;
+  parentId: string | null;
+  readable: boolean;
+  writable: boolean;
+  pathHandle: string | null;
+  reasonCode: string;
+}
+
+export interface WorkspaceResourcesProjection {
+  schema: "workspace.resources/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  resources: WorkspaceResource[];
+  arbitraryFilesystemAccess: false;
+  reasonCode: string;
+}
+
+export function createWorkspaceResourcesProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): WorkspaceResourcesProjection {
+  return {
+    schema: "workspace.resources/v1",
+    generatedAt,
+    source: snapshot.source,
+    resources: [
+      { id: "project-simplicio", kind: "project", label: "Simplicio", parentId: null, readable: true, writable: false, pathHandle: "project://simplicio", reasonCode: "workspace_handle_preview" },
+      { id: "profile-default", kind: "profile", label: "Personal", parentId: null, readable: true, writable: false, pathHandle: "profile://personal", reasonCode: "workspace_handle_preview" },
+    ],
+    arbitraryFilesystemAccess: false,
+    reasonCode: snapshot.source === "runtime" ? "workspace.resources_projection_ready" : "workspace.resources_projection_unavailable",
+  };
+}

--- a/docs/desktop/WORKSPACE-RESOURCES.md
+++ b/docs/desktop/WORKSPACE-RESOURCES.md
@@ -1,0 +1,8 @@
+# Workspace resources
+
+`workspace.resources/v1` represents projects, worktrees, files and profiles by
+safe handles. The Desktop can render previews and permissions, but it never
+accepts arbitrary filesystem paths or writes directly to disk.
+
+Read/write operations must be action descriptors from the Runtime, scoped to a
+project/worktree/profile and carrying the canonical revision.


### PR DESCRIPTION
Cross-repo parent: `wesleysimplicio/simplicio-runtime#5156`
Runtime dependencies: `#5159`, `#5165`, `#5168`, `#5173`.
Depends on Desktop chat: #218.

## Objetivo
Dar ao Desktop a experiência de workspace do Hermes sem mover ownership de filesystem/projects para o frontend.

## UX
- File browser governado pela Agent API/Runtime.
- Preview de texto/markdown/code/image/HTML e artifacts.
- Diff viewer para efeitos da sessão e alterações staged/unstaged quando backend expuser.
- Project picker e criação/edição de project manifests.
- Multi-folder/multi-repo projects.
- Worktree list/create/status com branch e lifecycle visíveis.
- Profile switcher e indicação clara do profile/session/project ativo.
- Session list scoped por project/workspace.
- Diagnostics LSP associados ao arquivo/turn/tool card.

## Segurança
- Sem acesso arbitrário fora dos roots permitidos.
- Symlink/path traversal tratados no backend; UI respeita reason codes.
- Nenhum write direto do frontend.

## Aceite
- [ ] Abrir projeto, navegar arquivos e iniciar chat já scoped ao project.
- [ ] Criar worktree via backend e abrir nova sessão nela.
- [ ] Diff mostrado corresponde aos receipts/estado real.
- [ ] Troca de profile não cruza sessões/memória.
- [ ] Diagnostics após patch aparecem no arquivo e no tool card correspondente.