### PR TITLE
[Desktop][Hermes parity][P1] Onboarding/Settings: providers, models, tools, skills, auth e secrets write-only

### DIFF
--- a/apps/desktop/src/settings_projection.test.ts
+++ b/apps/desktop/src/settings_projection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createSettingsProjection } from "./settings_projection";
+
+describe("settings.projection/v1", () => {
+  it("keeps providers and registries separate from secret bodies", () => {
+    const projection = createSettingsProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("settings.projection/v1");
+    expect(projection.providers.length).toBeGreaterThan(0);
+    expect(projection.secretPolicy).toEqual({ bodiesVisible: false, writeOnly: true, rawExport: false });
+    expect(JSON.stringify(projection)).not.toContain("voce@example.com");
+  });
+
+  it("requires Runtime authority for model/tool/skill enablement", () => {
+    const snapshot = createDemoSnapshot("active");
+    expect(createSettingsProjection(snapshot).models[0].selectable).toBe(false);
+    snapshot.source = "runtime";
+    expect(createSettingsProjection(snapshot).models[0].selectable).toBe(true);
+  });
+});

--- a/apps/desktop/src/settings_projection.ts
+++ b/apps/desktop/src/settings_projection.ts
@@ -1,0 +1,28 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export interface SettingsProjection {
+  schema: "settings.projection/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  providers: Array<{ id: string; name: string; state: string; availableActions: string[] }>;
+  models: Array<{ id: string; label: string; selectable: boolean; reasonCode: string }>;
+  tools: Array<{ id: string; label: string; enabled: boolean; reasonCode: string }>;
+  skills: Array<{ id: string; label: string; enabled: boolean; reasonCode: string }>;
+  secretPolicy: { bodiesVisible: false; writeOnly: true; rawExport: false };
+  reasonCode: string;
+}
+
+export function createSettingsProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): SettingsProjection {
+  const runtime = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return {
+    schema: "settings.projection/v1",
+    generatedAt,
+    source: snapshot.source,
+    providers: snapshot.providers.slice(0, 32).map((provider) => ({ id: provider.id, name: provider.name, state: provider.state, availableActions: provider.availableActions })),
+    models: [{ id: "model-runtime-default", label: "Modelo fornecido pelo Runtime", selectable: runtime, reasonCode: runtime ? "model_probe_verified" : "model_probe_unavailable" }],
+    tools: [{ id: "tool-runtime-registry", label: "Registry de tools", enabled: runtime, reasonCode: runtime ? "tool_probe_verified" : "tool_probe_unavailable" }],
+    skills: [{ id: "skill-runtime-registry", label: "Registry de skills", enabled: runtime, reasonCode: runtime ? "skill_probe_verified" : "skill_probe_unavailable" }],
+    secretPolicy: { bodiesVisible: false, writeOnly: true, rawExport: false },
+    reasonCode: runtime ? "settings.projection_ready" : "settings.projection_unavailable",
+  };
+}

--- a/docs/desktop/SETTINGS-CONTRACT.md
+++ b/docs/desktop/SETTINGS-CONTRACT.md
@@ -1,0 +1,8 @@
+# Settings and onboarding projection
+
+`settings.projection/v1` groups providers, models, tools and skills while
+keeping authentication and secrets write-only. The Desktop can show state and
+remediation, but never exposes secret bodies or exports raw credentials.
+
+Selecting a provider/model/tool/skill is a Runtime action descriptor. Unknown
+or stale registry entries are read-only until a fresh probe succeeds.


### PR DESCRIPTION
Cross-repo parent: `wesleysimplicio/simplicio-runtime#5156`
Runtime dependencies: `#5158`, `#5161`, `#5164`, `#5165`, `#5168`, `#5171`, `#5178`.

## Objetivo
Permitir que um usuário instale o Desktop e chegue ao primeiro chat funcional sem editar arquivos de configuração ou conhecer comandos internos.

## Fluxos
- Welcome/setup wizard.
- Login/auth first-party quando aplicável.
- Provider picker -> model picker pesquisável.
- Custom OpenAI-compatible endpoint.
- Toolset/tool configuration baseada em capability registry.
- Skills/plugins browse/install/enable/disable.
- Profile/project inicial.
- Voice/browser/gateway opcionais com probe real.
- Doctor/status final com remediation hints.

## Secrets
- Campos write-only.
- Nunca reexibir token completo recebido do backend.
- Mostrar apenas provider/status/source/redacted fingerprint quando permitido.

## Regras
- Não salvar configuração paralela no Desktop se o backend é authority.
- `ready` só quando capability probe confirmar.
- Safe mode deve ser acionável para diagnóstico sem custom plugins/hooks/MCP.

## Aceite
- [ ] Clean install -> setup -> primeiro chat sem terminal.
- [ ] Provider sem credencial não aparece pronto.
- [ ] Troca de modelo/profile reflete imediatamente na sessão conforme política.
- [ ] Secret não aparece em logs, local storage, telemetry ou screenshots de debug automatizadas.