### PR TITLE
[Desktop][Ambient OS][P0] Suggestion Inbox: revisar, aceitar, adiar e ensinar preferências

### DIFF
--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -14,6 +14,7 @@ import { createRoomProjection } from "../room_projection";
 import { createTokenReport } from "../token_report";
 import { createOmniSearchProjection } from "../omnisearch_projection";
 import { createLibraryProjection } from "../library_projection";
+import { createSuggestionInboxProjection } from "../suggestion_inbox";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -131,13 +132,14 @@ function TeamsScreen({ snapshot, botCenter }: { snapshot: DesktopSnapshot; botCe
 
 function AutomationsScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
   const projection = createAutomationProjection(snapshot);
-  const suggestions = projection.suggestions;
+  const inbox = createSuggestionInboxProjection(snapshot);
+  const suggestions = inbox.suggestions;
   return (
     <div className="page product-page">
       <SurfaceHeading view="automations" snapshot={snapshot} />
       <div className="automation-layout"><section className="panel suggestion-panel"><div className="panel-heading"><div><span className="eyebrow">Inbox</span><h2>Sugestões</h2></div><span className="queue-count">{suggestions.length}</span></div>{suggestions.length ? suggestions.map((item) => <article className="suggestion-card" key={item.id}><span className="suggestion-icon"><Glyph name="spark" size={17} /></span><div><strong>{item.title}</strong><p>{item.description}</p><span>receipt: {item.sourceEventId} · {item.state}</span></div><div className="suggestion-actions"><ActionButton>Aceitar</ActionButton><ActionButton>Descartar</ActionButton></div></article>) : <p className="empty-state">Nenhuma sugestão disponível.</p>}</section><section className="panel studio-panel"><div className="panel-heading"><div><span className="eyebrow">Studio</span><h2>Nova automação</h2></div><Glyph name="automation" size={18} /></div><div className="studio-step"><span>1</span><div><strong>Quando</strong><p>Escolha um evento do Runtime ou uma rotina.</p></div></div><div className="studio-step"><span>2</span><div><strong>Fazer</strong><p>Selecione uma capability e sua política.</p></div></div><div className="studio-step"><span>3</span><div><strong>Revisar</strong><p>Salvar cria apenas um rascunho versionado.</p></div></div><ActionButton>Salvar rascunho</ActionButton></section></div>
       <section className="panel automation-receipts"><div className="panel-heading"><div><span className="eyebrow">Activity Center</span><h2>Recibos recentes</h2></div><ActionButton>Exportar</ActionButton></div><div className="receipt-strip"><span><strong>{snapshot.activity.length}</strong> eventos limitados</span><span><strong>—</strong> automações ativas</span><span><strong>—</strong> ações aguardando você</span></div></section>
-      <UnavailableNotice code={projection.reasonCode}>Triggers, budgets, quiet hours, cancelamento e políticas são autoridade do Runtime; a UI fica sem efeito até a capability ser verificada.</UnavailableNotice>
+      <UnavailableNotice code={`${projection.reasonCode}; ${inbox.reasonCode}`}>Triggers, budgets, quiet hours, cancelamento e políticas são autoridade do Runtime; a UI fica sem efeito até a capability ser verificada.</UnavailableNotice>
     </div>
   );
 }

--- a/apps/desktop/src/suggestion_inbox.test.ts
+++ b/apps/desktop/src/suggestion_inbox.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createSuggestionInboxProjection } from "./suggestion_inbox";
+
+describe("suggestions.inbox/v1", () => {
+  it("keeps suggestions review-only in preview", () => {
+    const inbox = createSuggestionInboxProjection(createDemoSnapshot("active"));
+    expect(inbox.schema).toBe("suggestions.inbox/v1");
+    expect(inbox.suggestions.every((item) => item.state === "review_required")).toBe(true);
+    expect(inbox.actions).toEqual({ accept: false, dismiss: false, snooze: false });
+  });
+});

--- a/apps/desktop/src/suggestion_inbox.ts
+++ b/apps/desktop/src/suggestion_inbox.ts
@@ -1,0 +1,17 @@
+import type { DesktopSnapshot } from "./contracts";
+import { createAutomationProjection, type AutomationSuggestion } from "./automation_projection";
+
+export interface SuggestionInboxProjection {
+  schema: "suggestions.inbox/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  suggestions: AutomationSuggestion[];
+  actions: { accept: boolean; dismiss: boolean; snooze: boolean };
+  reasonCode: string;
+}
+
+export function createSuggestionInboxProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): SuggestionInboxProjection {
+  const automation = createAutomationProjection(snapshot, generatedAt);
+  const live = automation.draftAllowed;
+  return { schema: "suggestions.inbox/v1", generatedAt, source: snapshot.source, suggestions: automation.suggestions, actions: { accept: live, dismiss: live, snooze: live }, reasonCode: live ? "suggestions.inbox_ready" : "suggestions.inbox_unavailable" };
+}

--- a/docs/desktop/SUGGESTION-INBOX.md
+++ b/docs/desktop/SUGGESTION-INBOX.md
@@ -1,0 +1,6 @@
+# Suggestion Inbox
+
+`suggestions.inbox/v1` contains ideas derived from receipts and keeps each one
+in `review_required` until a human reviews it. Accept, dismiss and snooze are
+Runtime actions; a preview cannot create an automation or silently change a
+schedule.


### PR DESCRIPTION
Parent: #226
Runtime engine: `wesleysimplicio/simplicio-runtime#5195`
Runtime policy: `wesleysimplicio/simplicio-runtime#5197`

## Objetivo
Criar uma caixa de entrada clara para propostas proativas, separando sugestão de execução e permitindo feedback granular.

## Lista
- Suggested / awaiting review / snoozed / accepted / dismissed / archived.
- Search/filter por profile, project, Bot, category, risk, impact e date.
- Agrupar sugestões duplicadas/relacionadas.

## Suggestion card/details
- O que foi observado.
- Por que está sendo sugerido.
- Evidence/source links.
- Confidence, impact, urgency, expected cost/time e risk.
- Proposed capability/playbook.
- O que acontecerá se aceitar.
- Required approval/policy and affected destination/files/accounts.

## Ações
- Review plan.
- Accept once.
- Accept and create automation — somente com fluxo explícito de policy.
- Dismiss.
- Snooze.
- Never show this pattern/category.
- Explain why / provide optional feedback.
- Open source/context.

## Regras
- Accept não executa silenciosamente se a ação ainda requer approval.
- `never_show` é persistido no backend e reversível em Settings.
- Frontend não recalcula confidence/ranking.
- Suggestion expired/stale cannot execute without revalidation.

## Aceite
- [ ] Suggestion has evidence and preview before action.
- [ ] Dismiss/snooze/never-show sync across Desktop/CLI/API.
- [ ] Accepting an automation candidate enters Automation Studio with prefilled draft.
- [ ] Stale suggestion is revalidated.
- [ ] Keyboard bulk actions cannot accidentally approve mutable work.
- [ ] E2E proves Suggestions Only has zero mutation.