### PR TITLE
[Desktop][Ambient OS][P0] Ambient Controls: modos, policies, budgets, privacy e emergency stop

### DIFF
--- a/apps/desktop/src/ambient_controls.test.ts
+++ b/apps/desktop/src/ambient_controls.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createAmbientControlsProjection } from "./ambient_controls";
+import { createDemoSnapshot } from "./demo";
+
+describe("ambient.controls/v1", () => {
+  it("defaults to Suggestions Only and keeps the mode list explicit", () => {
+    const controls = createAmbientControlsProjection(createDemoSnapshot("active"));
+    expect(controls.schema).toBe("ambient.controls/v1");
+    expect(controls.mode).toBe("suggestions_only");
+    expect(controls.availableModes).toHaveLength(4);
+    expect(controls.emergencyStop.available).toBe(false);
+    expect(controls.persistInRuntime).toBe(false);
+  });
+});

--- a/apps/desktop/src/ambient_controls.ts
+++ b/apps/desktop/src/ambient_controls.ts
@@ -1,0 +1,28 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export type AmbientMode = "off" | "suggestions_only" | "ask_before_acting" | "autonomous_within_policy";
+
+export interface AmbientControlsProjection {
+  schema: "ambient.controls/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  mode: AmbientMode;
+  availableModes: AmbientMode[];
+  emergencyStop: { available: boolean; reasonCode: string };
+  persistInRuntime: boolean;
+  reasonCode: string;
+}
+
+export function createAmbientControlsProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): AmbientControlsProjection {
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return {
+    schema: "ambient.controls/v1",
+    generatedAt,
+    source: snapshot.source,
+    mode: "suggestions_only",
+    availableModes: ["off", "suggestions_only", "ask_before_acting", "autonomous_within_policy"],
+    emergencyStop: { available: live, reasonCode: live ? "emergency_stop_verified" : "emergency_stop_unavailable" },
+    persistInRuntime: live,
+    reasonCode: live ? "ambient.controls_ready" : "ambient.controls_unavailable",
+  };
+}

--- a/docs/desktop/AMBIENT-CONTROLS.md
+++ b/docs/desktop/AMBIENT-CONTROLS.md
@@ -1,0 +1,8 @@
+# Ambient controls and privacy
+
+`ambient.controls/v1` exposes Off, Suggestions Only, Ask Before Acting and
+Autonomous Within Policy. The safe default is Suggestions Only. Mode changes,
+privacy settings and Emergency Stop are Runtime actions and persist there,
+never in a parallel Desktop scheduler.
+
+Preview mode shows the state but keeps controls unavailable with a reason code.


### PR DESCRIPTION
Parent: #226
Runtime policy: `wesleysimplicio/simplicio-runtime#5197`
Runtime resource governor: `wesleysimplicio/simplicio-runtime#5200`
Runtime consent/privacy: `wesleysimplicio/simplicio-runtime#5201`
Runtime security: `wesleysimplicio/simplicio-runtime#5164`

## Objetivo
Criar controles inequívocos e sempre acessíveis para o usuário governar a proatividade.

## Global control
No top bar e Settings:
- Off
- Suggestions Only
- Ask Before Acting
- Autonomous Within Policy

Troca de modo mostra impacto em linguagem simples antes de salvar. Autonomous nunca é um toggle cego.

## Policy UI
- Scope: profile, project, Bot, automation, capability and destination.
- Allowed read/write/external actions.
- Cost/token/time/concurrency/network budgets.
- Schedule/quiet hours/weekend/vacation/focus behavior.
- Approval lifetime and conditions.
- Notification preferences.
- Per-capability overrides via Capability Center.

## Safety controls
- Pause Ambient globally.
- Pause selected Bot/project/automation.
- Emergency Stop persistent and visually prominent.
- View active work before stop.
- Cancel/reconcile status.
- Restore/resume requires explicit action.

## Privacy controls
- Event history opt-in.
- Pattern learning consent.
- Calendar/email/computer/remote LLM permissions.
- Inspect inferred patterns.
- Correct/remove/forget/export.
- Data retention/TTL.

## UX safeguards
- Confirm only genuinely consequential mode/policy changes.
- Never hide Autonomous state in a submenu.
- Always show current mode in top bar and tray tooltip/menu.
- Unknown/stale policy shows degraded/ask state.

## Aceite
- [ ] Off/Suggestions/Ask/Autonomous states match Runtime exactly.
- [ ] Budget/scope policy preview is understandable and has advanced JSON/details.
- [ ] Emergency Stop works from any primary screen and tray.
- [ ] Revoked consent immediately changes available controls/state.
- [ ] Forget/export flows are tested.
- [ ] No frontend-only security toggle.