### PR TITLE
[Desktop][Ambient OS][P1] Tray, native notifications e background presence sem consumo excessivo

### DIFF
--- a/apps/desktop/src/tray_projection.test.ts
+++ b/apps/desktop/src/tray_projection.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createTrayProjection } from "./tray_projection";
+
+describe("desktop.tray/v1", () => {
+  it("shows only attention and never keeps Runtime alive by itself", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.activity[0].status = "attention";
+    const tray = createTrayProjection(snapshot);
+    expect(tray.schema).toBe("desktop.tray/v1");
+    expect(tray.visible).toBe(true);
+    expect(tray.unreadAttentionCount).toBe(1);
+    expect(tray.keepsRuntimeAlive).toBe(false);
+  });
+});

--- a/apps/desktop/src/tray_projection.ts
+++ b/apps/desktop/src/tray_projection.ts
@@ -1,0 +1,30 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export interface TrayProjection {
+  schema: "desktop.tray/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  visible: boolean;
+  label: "Simplicio";
+  activeWorkCount: number;
+  unreadAttentionCount: number;
+  notifications: Array<{ id: string; title: string; reasonCode: string }>;
+  keepsRuntimeAlive: false;
+  reasonCode: string;
+}
+
+export function createTrayProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): TrayProjection {
+  const attention = snapshot.activity.filter((item) => item.status === "attention");
+  return {
+    schema: "desktop.tray/v1",
+    generatedAt,
+    source: snapshot.source,
+    visible: attention.length > 0,
+    label: "Simplicio",
+    activeWorkCount: snapshot.activity.filter((item) => item.status === "running").length,
+    unreadAttentionCount: attention.length,
+    notifications: attention.map((item) => ({ id: item.id, title: item.title, reasonCode: "attention_receipt" })),
+    keepsRuntimeAlive: false,
+    reasonCode: snapshot.source === "runtime" ? "desktop.tray_projection_ready" : "desktop.tray_projection_unavailable",
+  };
+}

--- a/docs/desktop/TRAY-NOTIFICATIONS.md
+++ b/docs/desktop/TRAY-NOTIFICATIONS.md
@@ -1,0 +1,9 @@
+# Tray and native notifications
+
+`desktop.tray/v1` is a contextual projection. It appears for attention or
+active work, links back to the canonical Activity/Live item and does not keep
+the Runtime or an agent alive when the app is idle.
+
+Notification text contains bounded summaries and reason codes, never prompts,
+credentials or raw effect payloads. Native permission and deep-link failures
+remain recoverable/unavailable states.


### PR DESCRIPTION
Parent: #226
Runtime notification policy: `wesleysimplicio/simplicio-runtime#5203`
Runtime wake/sleep: `wesleysimplicio/simplicio-runtime#5200`
Packaging dependency: #223.

## Objetivo
Dar presença ambiental útil quando a janela está fechada, sem manter Agent/provider ativo e sem notificação excessiva.

## Tray states
- Ambient Off
- Sleeping / CPU-first observing
- Working
- Waiting approval/input
- Blocked/error
- Paused/emergency stop

Estado deve vir do backend, com ícones discretos e acessíveis; evitar animação/pulso contínuo que distraia ou consuma recursos.

## Tray menu
- Open Today
- New Chat
- Open Bots
- Pending Approvals
- Pause/Resume Ambient
- Emergency Stop
- Quiet until…
- Runtime/Agent status
- Check update
- Quit

## Native notifications
Categorias e prioridade vêm do Runtime policy. Notification click abre deep-link para item/session/approval/automation.

## Privacidade
- Sensitive preview hidden by default.
- Respect OS do-not-disturb and Runtime quiet hours.
- Per-category settings.
- No full prompt, secret, private path or account data in notification body.

## Background lifecycle
- Close-to-tray is configurable.
- Tray can keep lightweight local observer/API connection, not provider/agents.
- Reconnect and backend restart states.
- Quit cleanly stops owned processes while preserving durable jobs as configured.

## Aceite
- [ ] Tray state matches Runtime wake/sleep/mode.
- [ ] Idle proves zero active agents/provider requests.
- [ ] Notification dedupe/quiet-hours/lock-screen redaction.
- [ ] Deep links navigate to canonical item.
- [ ] Emergency Stop available from tray.
- [ ] macOS/Windows/Linux platform tests for supported behaviors.