### PR TITLE
[Desktop][Ambient OS][P1] Routine & Briefings UI: agenda, timeline do dia e revisão

### DIFF
--- a/apps/desktop/src/briefing_projection.test.ts
+++ b/apps/desktop/src/briefing_projection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createBriefingProjection } from "./briefing_projection";
+import { createDemoSnapshot } from "./demo";
+
+describe("ambient.briefing/v1", () => {
+  it("keeps a briefing bounded and delivery opt-in", () => {
+    const briefing = createBriefingProjection(createDemoSnapshot("active"));
+    expect(briefing.schema).toBe("ambient.briefing/v1");
+    expect(briefing.items.length).toBeLessThanOrEqual(3);
+    expect(briefing.schedule.configured).toBe(false);
+    expect(briefing.delivery.configured).toBe(false);
+    expect(briefing.delivery.target).toBeNull();
+  });
+});

--- a/apps/desktop/src/briefing_projection.ts
+++ b/apps/desktop/src/briefing_projection.ts
@@ -1,0 +1,26 @@
+import type { ActivityItem, DesktopSnapshot } from "./contracts";
+
+export interface BriefingProjection {
+  schema: "ambient.briefing/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  title: string;
+  items: Array<{ id: string; title: string; context: string; sourceEventId: string }>;
+  schedule: { configured: boolean; nextRun: string | null };
+  delivery: { configured: boolean; target: string | null; reasonCode: string };
+  reasonCode: string;
+}
+
+export function createBriefingProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): BriefingProjection {
+  const item = (activity: ActivityItem) => ({ id: `brief-${activity.id}`, title: activity.title, context: activity.detail, sourceEventId: activity.id });
+  return {
+    schema: "ambient.briefing/v1",
+    generatedAt,
+    source: snapshot.source,
+    title: "Simplicio Briefing",
+    items: snapshot.activity.slice(0, 3).map(item),
+    schedule: { configured: false, nextRun: null },
+    delivery: { configured: false, target: null, reasonCode: "delivery_unconfigured" },
+    reasonCode: snapshot.source === "runtime" ? "ambient.briefing_projection_ready" : "ambient.briefing_projection_unavailable",
+  };
+}

--- a/docs/desktop/BRIEFINGS.md
+++ b/docs/desktop/BRIEFINGS.md
@@ -1,0 +1,8 @@
+# Routines and briefings
+
+`ambient.briefing/v1` is a compact, receipt-backed summary. It is bounded to
+three items and keeps schedule and delivery unconfigured until the user opts
+in through a Runtime action descriptor.
+
+The Desktop does not send messages, wake agents or create recurring jobs. A
+briefing without a verified delivery target remains a preview only.


### PR DESCRIPTION
Parent: #226
Runtime composer: `wesleysimplicio/simplicio-runtime#5202`
Runtime Today: `wesleysimplicio/simplicio-runtime#5199`
Automation editor: #229.

## Objetivo
Apresentar morning briefing, agenda, rotina e end-of-day review de modo prático, sempre derivados do contrato do Runtime e das fontes consentidas.

## Today integration
- Compact schedule card on Today.
- Next event/preparation card.
- Morning briefing entry.
- End-of-day review entry.

## Full Routine view
- Day/week timeline.
- Briefing sections: goals, Bots, approvals, schedule, automations, blockers, deliveries and economy.
- Routine slots and automation links.
- Drag to propose reschedule/update; backend validates before persistence.
- Enable/disable/pause slot.
- Vacation mode and quiet hours.
- Connector health/source freshness.

## Actions
- Open source calendar event/project/session.
- Start preparation/chat.
- Convert suggestion into automation draft.
- Mark/acknowledge.
- Deliver briefing to configured channel.
- Edit routine policy through Automation Studio.

## Regras
- Missing calendar/weather/source appears unavailable, never as an invented empty day.
- Health/wellness reminders are optional, user-configured and non-medical.
- UI does not synthesize totals or priorities separately from backend.
- Timezone/DST explicit.

## Aceite
- [ ] Briefing renders with partial sources and freshness labels.
- [ ] Timeline respects timezone/DST/holiday/vacation mode.
- [ ] Reschedule creates a backend proposal/update, not local-only state.
- [ ] End-of-day numbers reconcile with receipts.
- [ ] Same briefing can render in Desktop, CLI and channel.