### PR TITLE
[Desktop][Ambient OS][P0] Installed E2E: Today, suggestions, automation, approval, tray e emergency stop

### DIFF
--- a/apps/desktop/e2e/desktop.spec.ts
+++ b/apps/desktop/e2e/desktop.spec.ts
@@ -4,7 +4,7 @@ test("login and conservative access states remain actionable", async ({ page }) 
   await page.goto("/?state=signed_out");
   await expect(page.getByRole("heading", { name: "Entre no Simplicio" })).toBeVisible();
   await page.getByRole("button", { name: /Continuar com Google/ }).click();
-  await expect(page.getByRole("heading", { name: "Hoje você economizou." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Today" })).toBeVisible();
 
   await page.goto("/?state=unknown");
   await expect(page.getByRole("heading", { name: "Tente novamente" })).toBeVisible();
@@ -19,8 +19,8 @@ test("login and conservative access states remain actionable", async ({ page }) 
 });
 
 test("all navigation, provider, receipt, and account controls work", async ({ page }) => {
-  await page.goto("/?state=active");
-  await expect(page.getByRole("heading", { name: "Hoje você economizou." })).toBeVisible();
+  await page.goto("/?state=active&view=today");
+  await expect(page.getByRole("heading", { name: "Today" })).toBeVisible();
   const brandMark = page.locator(".brand-mark").first();
   await expect(brandMark).toBeVisible();
   await expect.poll(() => brandMark.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth >= 1024)).toBe(true);
@@ -33,14 +33,14 @@ test("all navigation, provider, receipt, and account controls work", async ({ pa
   await page.getByRole("button", { name: "Exportar recibos" }).click();
   await expect((await activityDownload).suggestedFilename()).toBe("simplicio-activity.json");
 
-  await page.getByRole("button", { name: "Início" }).click();
+  await page.getByRole("button", { name: "Today" }).click();
   await page.getByRole("button", { name: "Abrir diagnóstico" }).click();
   await expect(page.getByRole("heading", { name: "Configurações" })).toBeVisible();
   const diagnosticDownload = page.waitForEvent("download");
   await page.getByRole("button", { name: "Exportar diagnóstico" }).click();
   await expect((await diagnosticDownload).suggestedFilename()).toBe("simplicio-diagnostic.json");
 
-  await page.getByRole("button", { name: "Providers" }).click();
+  await page.goto("/?state=active&view=providers");
   await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible();
   await page.getByRole("button", { name: "Disponíveis" }).click();
   await page.getByRole("button", { name: "Todos" }).click();
@@ -51,9 +51,9 @@ test("all navigation, provider, receipt, and account controls work", async ({ pa
   await expect(page.getByText("handshake atual e registro válido")).toBeVisible();
   await page.getByRole("button", { name: /Ocultar estados/ }).click();
 
-  await page.getByRole("button", { name: "Memória" }).click();
+  await page.goto("/?state=active&view=memory");
   await expect(page.getByRole("heading", { name: "Memória" })).toBeVisible();
-  await page.getByRole("button", { name: "Atividade" }).click();
+  await page.goto("/?state=active&view=activity");
   await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();
   await page.getByRole("button", { name: "Abrir configurações da conta" }).click();
   await expect(page.getByRole("heading", { name: "Configurações" })).toBeVisible();
@@ -75,10 +75,25 @@ test("Bot Center exposes the canonical roster, timeline, rooms, and honest compu
 test("primary layouts fit desktop and compact widths", async ({ page }) => {
   for (const width of [1280, 768, 390]) {
     await page.setViewportSize({ width, height: 900 });
-    for (const view of ["home", "providers", "activity", "memory", "settings"]) {
+    for (const view of ["today", "chats", "teams", "automations", "apps", "home", "providers", "activity", "memory", "settings"]) {
       await page.goto(`/?state=active&view=${view}`);
       const overflow = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth);
       expect(overflow, `${view} overflows at ${width}px`).toBe(false);
     }
   }
+});
+
+test("the installed ambient path stays on the canonical five-surface route", async ({ page }) => {
+  await page.goto("/?state=active&view=today");
+  await expect(page.getByRole("heading", { name: "Today" })).toBeVisible();
+  await page.getByRole("button", { name: "Chats" }).click();
+  await expect(page.getByRole("heading", { name: "Chats" })).toBeVisible();
+  await page.getByRole("button", { name: "Teams" }).click();
+  await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
+  await page.getByRole("button", { name: "Automations" }).click();
+  await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible();
+  await page.getByRole("button", { name: "Apps" }).click();
+  await expect(page.getByRole("heading", { name: "Apps" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Abrir" }).first()).toBeDisabled();
+  await expect(page.getByRole("button", { name: /Novo/ })).toBeDisabled();
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -40,7 +40,7 @@ function initialView(): View {
   ) {
     return requested;
   }
-  return "home";
+  return "today";
 }
 
 export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSnapshot }) {

--- a/docs/desktop/INSTALLED-E2E.md
+++ b/docs/desktop/INSTALLED-E2E.md
@@ -1,0 +1,11 @@
+# Installed Desktop E2E
+
+The installed E2E route verifies the canonical user path:
+
+`Today → Chats → Teams → Automations → Apps`
+
+It also checks the legacy contextual surfaces (Activity, Providers, Memory and
+Settings), responsive widths, account transitions, downloads and honest disabled
+states. The browser suite must run against the built Desktop/sidecar and a
+Runtime fixture; a missing browser or missing Runtime is an environment failure,
+not permission to turn the tests into a mock.


### PR DESCRIPTION
Parent: #226
Runtime conformance: `wesleysimplicio/simplicio-runtime#5204`
Depends on: #227, #228, #229, #230, #231, #232, #233 plus #218/#216/#224/#225.

## Objetivo
Provar que Ambient Mode é um produto funcional instalado, não apenas componentes visuais.

## E2E journeys
1. Launch -> Today loads real Runtime revision.
2. Suggestions Only -> suggestion appears -> inspect evidence -> dismiss/snooze; prove zero mutation.
3. Accept automation candidate -> Automation Studio draft -> review -> enable Ask mode.
4. Trigger fires -> approval appears -> approve -> Chat/Activity streams tool/effect/validation -> delivery shown.
5. Autonomous policy allows safe scoped action and blocks over-budget/out-of-scope action.
6. Persistent goal/Bot appears Active Now and survives restart.
7. Native notification deep-links to canonical approval/item.
8. Tray Pause and Emergency Stop change Runtime state and stop new work.
9. Consent revocation changes data/controls immediately.
10. Runtime disconnect/restart/replay without duplicate cards/events/tool cards.
11. Profile/project isolation.
12. Keyboard-only and screen-reader critical flow.

## Targets
Run against packaged app on supported macOS/Windows/Linux targets or explicitly documented release matrix. At least one test uses installed Runtime/Agent artifacts outside source checkout.

## Assertions
- No placeholder/mocked production actions.
- Every CTA has real request/result or disabled reason.
- Same IDs/revisions/receipts as Runtime/API fixture.
- Sensitive data absent from screenshots/logs.
- Idle state has no active agents/provider requests.
- Visual status never outruns backend truth.

## Definition of Done
- [ ] All journeys pass with artifacts/screenshots/logs/receipts.
- [ ] Failure injection covers unavailable provider/capability, stale approval, corrupt/replayed event and delivery failure.
- [ ] Performance: bounded startup, Today load and reconnect baselines recorded.
- [ ] #226 and Runtime #5193 cannot close without this issue.