### PR TITLE
[Desktop][Ambient OS][P1] Capability Apps & Today Widgets: mini-apps schema-driven para humano e LLM

### DIFF
--- a/apps/desktop/src/widgets_projection.test.ts
+++ b/apps/desktop/src/widgets_projection.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createWidgetsProjection } from "./widgets_projection";
+
+describe("capability.widgets/v1", () => {
+  it("keeps widgets opt-in, read-only and bounded", () => {
+    const widgets = createWidgetsProjection(createDemoSnapshot("active"));
+    expect(widgets.schema).toBe("capability.widgets/v1");
+    expect(widgets.maxPinned).toBe(3);
+    expect(widgets.widgets).toHaveLength(0);
+    expect(widgets.writesAvailable).toBe(false);
+  });
+});

--- a/apps/desktop/src/widgets_projection.ts
+++ b/apps/desktop/src/widgets_projection.ts
@@ -1,0 +1,32 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export interface WidgetProjection {
+  id: string;
+  kind: "today" | "tokens" | "activity" | "live" | "library";
+  title: string;
+  pinned: boolean;
+  readonly: true;
+  source: "runtime" | "preview";
+}
+
+export interface WidgetsProjection {
+  schema: "capability.widgets/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  maxPinned: 3;
+  widgets: WidgetProjection[];
+  writesAvailable: boolean;
+  reasonCode: string;
+}
+
+export function createWidgetsProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): WidgetsProjection {
+  return {
+    schema: "capability.widgets/v1",
+    generatedAt,
+    source: snapshot.source,
+    maxPinned: 3,
+    widgets: [],
+    writesAvailable: snapshot.source === "runtime" && snapshot.runtime.state === "healthy",
+    reasonCode: snapshot.source === "runtime" ? "capability.widgets_projection_ready" : "capability.widgets_projection_unavailable",
+  };
+}

--- a/docs/desktop/CAPABILITY-WIDGETS.md
+++ b/docs/desktop/CAPABILITY-WIDGETS.md
@@ -1,0 +1,9 @@
+# Capability Apps and Today widgets
+
+`capability.widgets/v1` keeps optional Today widgets separate from the default
+clean surface. A user may pin at most three read-only widgets; the default is
+empty. Widget configuration is a Runtime operation and never changes
+priorities, starts work or creates a second dashboard authority.
+
+Apps remain the canonical entry point for capability detail. Each widget links
+back to the same projection (Today, Activity, Token Reports, Live or Library).


### PR DESCRIPTION
Parents: #224 Capability Center, #226 Ambient OS
Runtime registry: `wesleysimplicio/simplicio-runtime#5161`
Agent API: `wesleysimplicio/simplicio-runtime#5168`

## Objetivo
Fazer as capabilities funcionarem como os “apps” do Agentic OS: a mesma capability que a LLM descobre e chama pode oferecer ao usuário uma interface prática, sem criar implementação paralela.

## UI descriptor
Capability manifest pode referenciar `capability.ui/v1` com:
- supported surfaces
- trusted renderer type
- input form schema/defaults/validation
- result/artifact renderers
- actions and deep links
- status/health presentation
- approval preview fields
- widget sizes/data contract
- refresh/realtime policy

## Renderer types first-party
- form/action
- table/list
- key-value/status
- markdown/document
- file/diff/code
- chart/metric
- timeline
- image/media
- browser/computer preview
- approval
- logs/receipts/evidence

Não permitir HTML/JS arbitrário não confiável dentro do app. Plugin UI futura deve usar sandbox/permission model explícito.

## Capability Apps
- `Open` from Capability Center creates a focused capability workspace.
- Form generated from schema and backed by real validation.
- Run/configure/install/authorize actions use same capability ID/contracts as LLM.
- Recent executions, artifacts and receipts.

## Today Widgets
- User can pin a safe read-only projection or shortcut to Today.
- Widgets show source freshness and status.
- Mutating action still opens review/approval; widget never silently executes.
- Layout has constrained sizes, not free-form window chaos.

## LLM integration
- `Use in chat` passes capability handle/intent, not full schema unless selected.
- Tool call highlights the corresponding capability app and execution state.
- Human changes to form/action map to same public request schema.

## Aceite
- [ ] Read-only, mutating, auth-required, plugin/MCP and unavailable fixtures render correctly.
- [ ] Same request generated by form and LLM validates against same schema.
- [ ] Pinned widget survives restart/profile scope.
- [ ] Unknown renderer/schema degrades safely.
- [ ] No untrusted arbitrary code execution.
- [ ] E2E opens capability, runs action, shows artifact/receipt and pins widget.