### PR TITLE
[Desktop][Workspace OS][P0] Teach Simplicio Recorder: demonstrar processo e criar automação segura

### DIFF
--- a/apps/desktop/src/teach_projection.test.ts
+++ b/apps/desktop/src/teach_projection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createTeachProjection } from "./teach_projection";
+
+describe("teach.recorder/v1", () => {
+  it("requires explicit consent and redacts secret steps", () => {
+    const projection = createTeachProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("teach.recorder/v1");
+    expect(projection.recordingScope).toBe("explicit_steps_only");
+    expect(projection.consentRequired).toBe(true);
+    expect(projection.steps.find((step) => step.kind === "secret")?.redacted).toBe(true);
+    expect(projection.actions.saveDraft).toBe(false);
+  });
+});

--- a/apps/desktop/src/teach_projection.ts
+++ b/apps/desktop/src/teach_projection.ts
@@ -1,0 +1,41 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export type TeachStepKind = "manual" | "secret" | "optional";
+
+export interface TeachStep {
+  id: string;
+  kind: TeachStepKind;
+  label: string;
+  required: boolean;
+  redacted: boolean;
+  status: "not_recorded" | "recorded" | "review_required";
+}
+
+export interface TeachProjection {
+  schema: "teach.recorder/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  recordingScope: "explicit_steps_only";
+  consentRequired: true;
+  steps: TeachStep[];
+  actions: { review: boolean; dryRun: boolean; saveDraft: boolean; repair: boolean };
+  reasonCode: string;
+}
+
+export function createTeachProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): TeachProjection {
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return {
+    schema: "teach.recorder/v1",
+    generatedAt,
+    source: snapshot.source,
+    recordingScope: "explicit_steps_only",
+    consentRequired: true,
+    steps: [
+      { id: "step-1", kind: "manual", label: "Abrir o workspace do projeto", required: true, redacted: false, status: "not_recorded" },
+      { id: "step-2", kind: "secret", label: "Credencial ou token", required: false, redacted: true, status: "not_recorded" },
+      { id: "step-3", kind: "optional", label: "Validar o resultado", required: false, redacted: false, status: "not_recorded" },
+    ],
+    actions: { review: live, dryRun: live, saveDraft: live, repair: live },
+    reasonCode: live ? "teach.recorder_projection_ready" : "teach.recorder_projection_unavailable",
+  };
+}

--- a/docs/desktop/TEACH-RECORDER.md
+++ b/docs/desktop/TEACH-RECORDER.md
@@ -1,0 +1,9 @@
+# Teach Simplicio Recorder
+
+`teach.recorder/v1` records only explicit steps after visible consent. Secret
+steps are represented as redacted placeholders; tokens, passwords and raw
+credential values never enter the recording or review screen.
+
+Review and dry-run happen before saving a draft. Repairing drift or promoting a
+routine is a Runtime action and remains unavailable until the recorder/compiler
+contract is verified.


### PR DESCRIPTION
Parent: #238
Runtime compiler: `simplicio-runtime#5214`
Related: #229 Automation Studio, #222 Computer/Browser, #243 + New.

## Objetivo
Permitir que qualquer usuário ensine uma rotina mostrando como faz, com gravação clara, revisão simples e conversão em automation draft — sem expor detalhes técnicos por padrão.

## Entry points
- `+ New → Teach Simplicio`;
- Browser/Computer toolbar;
- Work Item `Make Routine`;
- Automation Studio.

## Recording UX
- escopo: app/tab/window/Space/Team;
- consent/privacy preview;
- indicador persistente e Stop/Pause;
- step list em tempo real com linguagem humana;
- marcar passo como secret/manual/optional;
- redaction preview;
- nunca gravar silenciosamente.

## Review
Após parar:
- nome e objetivo;
- passos compilados por capability;
- inputs/variáveis detectados;
- preconditions e success checks;
- passos frágeis/unresolved destacados;
- edit/reorder/delete/record again;
- test/dry-run;
- escolher Bot/Team, trigger, mode, budget, approval e delivery;
- Save Draft por padrão.

## Repair
Quando workflow driftar, mostrar passo quebrado, screenshot/context permitido e opções: Re-record step, Choose selector, Manual step, Disable automation.

## Motion
Recording indicator discreto; novos passos fazem fade/slide; compilação usa progress calma; transição shared-layout para Automation Studio. Reduced-motion.

## Aceite
- [ ] Recording nunca começa sem consentimento visível.
- [ ] Secret fields aparecem redigidos.
- [ ] Draft usa capability IDs reais, não apenas coordenadas.
- [ ] Dry-run zero effects.
- [ ] Save não habilita automaticamente ação mutável.
- [ ] Drift/repair funciona com backend fixture.
- [ ] E2E demonstra Browser flow e executa depois de approval.