### PR TITLE
[Desktop][Workspace OS][P0] Flagship Apps: Video Studio, Browser, Computer, Research, Files/PDF e Code

### DIFF
--- a/apps/desktop/src/flagship_projection.test.ts
+++ b/apps/desktop/src/flagship_projection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createFlagshipProjection } from "./flagship_projection";
+
+describe("flagship.apps/v1", () => {
+  it("keeps first-party Apps on one capability request/output contract", () => {
+    const projection = createFlagshipProjection(createDemoSnapshot("active"));
+    expect(projection.schema).toBe("flagship.apps/v1");
+    expect(projection.requestSchema).toBe("capability.request/v1");
+    expect(projection.apps.map((app) => app.id)).toEqual(["video", "browser", "computer", "research", "files_pdf", "code_build"]);
+    expect(projection.sharedOutputs).toContain("artifact");
+    expect(projection.apps.every((app) => app.available === false)).toBe(true);
+  });
+});

--- a/apps/desktop/src/flagship_projection.ts
+++ b/apps/desktop/src/flagship_projection.ts
@@ -1,0 +1,42 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export type FlagshipAppId = "video" | "browser" | "computer" | "research" | "files_pdf" | "code_build";
+
+export interface FlagshipApp {
+  id: FlagshipAppId;
+  name: string;
+  capabilityIds: string[];
+  available: boolean;
+  reasonCode: string;
+}
+
+export interface FlagshipProjection {
+  schema: "flagship.apps/v1";
+  requestSchema: "capability.request/v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  apps: FlagshipApp[];
+  sharedOutputs: Array<"chat" | "work_item" | "live" | "artifact" | "token_report">;
+  reasonCode: string;
+}
+
+export function createFlagshipProjection(snapshot: DesktopSnapshot, generatedAt = snapshot.generatedAt): FlagshipProjection {
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  const definitions: Array<Pick<FlagshipApp, "id" | "name" | "capabilityIds">> = [
+    { id: "video", name: "Video Studio", capabilityIds: ["video.studio"] },
+    { id: "browser", name: "Browser", capabilityIds: ["browser.open"] },
+    { id: "computer", name: "Computer", capabilityIds: ["computer.use"] },
+    { id: "research", name: "Research", capabilityIds: ["research.run"] },
+    { id: "files_pdf", name: "Files & PDF", capabilityIds: ["files.read", "pdf.analyze"] },
+    { id: "code_build", name: "Code & Build", capabilityIds: ["workspace.build"] },
+  ];
+  return {
+    schema: "flagship.apps/v1",
+    requestSchema: "capability.request/v1",
+    generatedAt,
+    source: snapshot.source,
+    apps: definitions.map((app) => ({ ...app, available: live, reasonCode: live ? "flagship_capability_verified" : "flagship_capability_unavailable" })),
+    sharedOutputs: ["chat", "work_item", "live", "artifact", "token_report"],
+    reasonCode: live ? "flagship.apps_projection_ready" : "flagship.apps_projection_unavailable",
+  };
+}

--- a/docs/desktop/FLAGSHIP-APPS.md
+++ b/docs/desktop/FLAGSHIP-APPS.md
@@ -1,0 +1,10 @@
+# Flagship Apps
+
+`flagship.apps/v1` lists Video, Browser, Computer, Research, Files/PDF and
+Code/Build as first-party surfaces over the same `capability.request/v1`.
+Requests produce the same Chat, Work Item, Live, artifact and token-report
+identities used elsewhere in Desktop.
+
+Each App is available only after the capability registry probe. The App shell
+does not contain a private agent loop or an unverified Computer/Browser
+backend.


### PR DESCRIPTION
Parent: #238
Extends: #224 Apps, #235 Capability Apps, #243 + New.
Runtime: capability registry `#5161`, Browser/Computer `#5174/#5183/#5215`, Agent API `#5168`.

## Objetivo
Entregar superfícies first-party de alto valor que provem que Apps não é apenas catálogo e que o Simplicio atende criadores, estudantes, empresas e developers.

## 1. Video Studio
Flow: Brief → Research → Script → Storyboard → Generate/Render → Review → Export/Publish.
- format/duration/style/brand inputs;
- Team/Bot assignment;
- scene/progress/artifacts;
- versions/compare/approve;
- video capability unavailable/auth-required honest.

## 2. Browser
- live page/tabs;
- Bot cursor/action state;
- chat/task linkage;
- take control/hand back;
- screenshots/downloads/artifacts/receipts;
- navigation approval/policy.

## 3. Computer
- live computer session;
- active Bot/Work Item/resource lease;
- pause/takeover/handback;
- action timeline and blockers;
- teach workflow entry.

## 4. Research
- sources/query scope;
- parallel research tasks only when requested;
- notes/citations/artifacts;
- compare/synthesize/export;
- browser handoff.

## 5. Files/PDF
- upload/select workspace files;
- summarize/search/Q&A/extract/transform;
- provenance/pages/artifacts;
- use in chat/assign to Team.

## 6. Code/Build
- repo/project context;
- Work Item/task thread;
- edits/diff/tests/diagnostics/evidence;
- review/approval/delivery.

## Shared app shell
Cada App usa same capability/request schema, Work Item, Live, tokens, artifacts, approvals e chat. Nada de Agent loop próprio por App.

## Design
Clean macOS-inspired, one primary flow, technical detail in inspector/Advanced, smooth state transitions, reduced-motion.

## Aceite
- [ ] Cada App inicia pelo + New e Apps em até dois passos.
- [ ] Video produces a real artifact with staged progress.
- [ ] Browser/Computer show real backend or disabled reason.
- [ ] Research preserves sources/provenance.
- [ ] Files/PDF and Code complete real Work Items.
- [ ] Human form request and LLM tool request validate against same schema.
- [ ] Tokens/cost/receipts available per App run.