### PR TITLE
[Desktop][Workspace OS][P0] Universal onboarding: Personal, Study, Creator, Business e Software + Simple/Advanced

### DIFF
--- a/apps/desktop/src/onboarding_projection.test.ts
+++ b/apps/desktop/src/onboarding_projection.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createDemoSnapshot } from "./demo";
+import { createOnboardingProjection } from "./onboarding_projection";
+
+describe("onboarding.v1", () => {
+  it("offers universal personas in Simple mode without hidden activation", () => {
+    const onboarding = createOnboardingProjection(createDemoSnapshot("active"));
+    expect(onboarding.schema).toBe("onboarding.v1");
+    expect(onboarding.mode).toBe("simple");
+    expect(onboarding.templates.map((template) => template.id)).toEqual(["personal", "study", "create", "business", "software", "explore"]);
+    expect(onboarding.reviewRequired).toBe(true);
+    expect(onboarding.createsProvider).toBe(false);
+    expect(onboarding.activatesBot).toBe(false);
+    expect(onboarding.submitAvailable).toBe(false);
+  });
+
+  it("keeps Advanced as a view mode, not a bypass for Runtime policy", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.source = "runtime";
+    const onboarding = createOnboardingProjection(snapshot, "advanced");
+    expect(onboarding.mode).toBe("advanced");
+    expect(onboarding.submitAvailable).toBe(true);
+  });
+});

--- a/apps/desktop/src/onboarding_projection.ts
+++ b/apps/desktop/src/onboarding_projection.ts
@@ -1,0 +1,37 @@
+import type { DesktopSnapshot } from "./contracts";
+
+export type OnboardingPersona = "personal" | "study" | "create" | "business" | "software" | "explore";
+export type OnboardingMode = "simple" | "advanced";
+
+export interface OnboardingTemplate {
+  id: OnboardingPersona;
+  label: string;
+  summary: string;
+  defaultCapabilities: string[];
+}
+
+export interface OnboardingProjection {
+  schema: "onboarding.v1";
+  generatedAt: string;
+  source: DesktopSnapshot["source"];
+  mode: OnboardingMode;
+  templates: OnboardingTemplate[];
+  reviewRequired: true;
+  createsProvider: false;
+  activatesBot: false;
+  submitAvailable: boolean;
+  reasonCode: string;
+}
+
+export function createOnboardingProjection(snapshot: DesktopSnapshot, mode: OnboardingMode = "simple", generatedAt = snapshot.generatedAt): OnboardingProjection {
+  const templates: OnboardingTemplate[] = [
+    { id: "personal", label: "Personal", summary: "Organize tarefas e contexto do dia.", defaultCapabilities: ["chat.session.create"] },
+    { id: "study", label: "Study", summary: "Ler, pesquisar e aprender com provenance.", defaultCapabilities: ["pdf.analyze", "research.run"] },
+    { id: "create", label: "Create", summary: "Criar mídia e documentos por Work Item.", defaultCapabilities: ["video.studio", "document.create"] },
+    { id: "business", label: "Business", summary: "Operar rotinas com aprovação e budget.", defaultCapabilities: ["browser.open", "automation.draft.create"] },
+    { id: "software", label: "Software", summary: "Construir, revisar e validar código.", defaultCapabilities: ["workspace.build", "code.review"] },
+    { id: "explore", label: "Explore", summary: "Descobrir capabilities sem ativá-las.", defaultCapabilities: ["capability.registry.read"] },
+  ];
+  const live = snapshot.source === "runtime" && snapshot.runtime.state === "healthy";
+  return { schema: "onboarding.v1", generatedAt, source: snapshot.source, mode, templates, reviewRequired: true, createsProvider: false, activatesBot: false, submitAvailable: live, reasonCode: live ? "onboarding_projection_ready" : "onboarding_projection_unavailable" };
+}

--- a/docs/desktop/ONBOARDING.md
+++ b/docs/desktop/ONBOARDING.md
@@ -1,0 +1,9 @@
+# Universal onboarding
+
+`onboarding.v1` offers Personal, Study, Create, Business, Software and Explore
+templates in Simple or Advanced mode. Both modes show a review before submit;
+choosing a persona never creates a provider or activates a Bot implicitly.
+
+The template lists capability IDs rather than hidden implementation details.
+Creation is enabled only after the Runtime validates the requested profile,
+Space and permissions.


### PR DESCRIPTION
Parent: #238
Extends: #221 Onboarding/Settings, #239 Spaces/Teams.
Runtime templates: `simplicio-runtime#5209`.

## Objetivo
Fazer o mesmo produto ser fácil para públicos não técnicos e potente para especialistas, sem criar versões separadas do app.

## First-run
Pergunta simples:
`Como você pretende usar o Simplicio?`
- Personal;
- Study;
- Create;
- Business;
- Software;
- Explore everything.

Depois mostra preview editável do Space/Team/Apps/Bots que será criado, provider/auth necessário e privacy/Ambient defaults. Nada inicia automaticamente.

## Templates iniciais
- Personal: Assistant, Researcher, Routine;
- Study: Tutor, Researcher, Planner;
- Creator: Researcher, Writer, Designer, Video Maker, Publisher;
- Business: Operations, Research, Sales, Finance, Content;
- Software: Planner, Coder, Reviewer, Tester, Release.

## Simple mode
- linguagem humana;
- uma ação primária;
- resultados/artifacts;
- resumo de progresso/custo;
- sem provider/schema/tool IDs/logs por padrão.

## Advanced disclosure
Não é outro modo global rígido. Cada tela oferece `Advanced` quando necessário:
- provider/model/toolset;
- memory scope;
- capabilities/contracts;
- logs/receipts;
- environment/policy;
- token breakdown.

Preferences podem lembrar disclosure por usuário/área.

## Progressive onboarding
Apresentar Browser, Computer, Video, Automation e Bot/Team quando contexto exigir, não tutorial longo inicial.

## Aceite
- [ ] Cada público chega a uma primeira tarefa real sem terminal.
- [ ] Template pode ser revisado antes de criar.
- [ ] Não existe provider/Bot activation hidden.
- [ ] Usuário técnico encontra Advanced em até dois passos.
- [ ] Mesmo backend/contracts em Simple e Advanced.
- [ ] Usability tests com fixtures de cinco personas.
- [ ] Accessibility, localization e low-literacy copy review.