### PR TITLE
[Desktop][Workspace OS][P0] Installed E2E: multi-chat, Team, Work Item, Live, Video, Browser e Teach Simplicio

### DIFF
--- a/apps/desktop/e2e/workspace.spec.ts
+++ b/apps/desktop/e2e/workspace.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("workspace conformance keeps the five primary surfaces discoverable", async ({ page }) => {
+  await page.goto("/?state=active&view=today");
+  for (const [label, heading] of [["Today", "Today"], ["Chats", "Chats"], ["Teams", "Teams"], ["Automations", "Automations"], ["Apps", "Apps"]] as const) {
+    await page.getByRole("button", { name: label }).click();
+    await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+  }
+  await expect(page.getByRole("button", { name: /Novo/ })).toBeDisabled();
+  await expect(page.getByRole("button", { name: /Buscar/ })).toBeDisabled();
+});
+
+test("workspace conformance exposes unavailable capabilities honestly", async ({ page }) => {
+  await page.goto("/?state=active&view=apps");
+  await expect(page.getByText("capability.registry_unavailable")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Abrir" }).first()).toBeDisabled();
+  await page.getByRole("button", { name: "Chats" }).click();
+  await expect(page.getByText("agent_api_unavailable")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Enviar" })).toBeDisabled();
+});

--- a/docs/desktop/WORKSPACE-E2E.md
+++ b/docs/desktop/WORKSPACE-E2E.md
@@ -1,0 +1,11 @@
+# Workspace conformance E2E
+
+The installed suite covers the canonical route `Today → Chats → Teams →
+Automations → Apps`, then checks disabled `+ New`/Search and unavailable
+capability/session states. The existing contextual suites cover account access,
+Providers, Activity, Memory, Settings, downloads, Bot Center and responsive
+widths.
+
+The suite must run against the packaged Desktop and a real installed Runtime
+fixture. Missing Chrome, packaged artifacts or Runtime contracts are setup
+failures; production mocks are not an acceptable substitute.


### PR DESCRIPTION
Parent: #238
Runtime conformance: `simplicio-runtime#5216`
Depends on: #239, #240, #241, #242, #243, #244, #245, #246, #247, #248 plus #216/#218/#224/#225/#236.

## Objetivo
Provar em app empacotado que a nova experiência é simples, funcional e superior a um roster de Bots/chat demo.

## Personas/journeys
### Personal
Create Personal Space → direct chat → file/calendar action → result.

### Study
Study template → Tutor/Researcher Team → PDF task → sources/artifact.

### Creator
`+ New → Video` → Creator Team → Work Item → Research/Script/Render → review/export.

### Business
Team Room Execute → Browser/Computer task → approval → delivery.

### Software
Team Execute/Review → code/test/reviewer → evidence/PR artifact.

## Cross-cutting
- 10+ chats/tabs, search/resume/split.
- mentions selective activation.
- Live Dock/Mission Control steer/pause/reassign/move/takeover.
- Teach Simplicio recording → automation draft → dry-run → approval → run.
- tokens/cost per session/Work Item/Team.
- Space/Team memory/RBAC isolation.
- reconnect/restart/replay.
- unavailable capability/expired auth/failure/recovery.
- Simple and Advanced disclosure.
- keyboard/screen reader/reduced motion.

## Usability targets
Measure before fixing hard thresholds, but capture:
- clicks/time to first Chat, Team, Video, Browser, Work Item and Live detail;
- success rate without documentation;
- comprehension of Discuss/Execute/Review and Ambient modes;
- ability to identify what each Bot is doing;
- visual density/attention tests.

## Assertions
- No production mock/placeholder.
- Same IDs/revisions/receipts as Runtime.
- No hidden provider/agent fan-out.
- Every visible action real or disabled with reason.
- Motion does not create stale/false state.
- Sensitive data absent from screenshots/logs.

## Definition of Done
- [ ] Packaged targets in supported release matrix.
- [ ] All persona journeys pass.
- [ ] Runtime #5216 passes against same versions.
- [ ] Usability report and motion/performance baselines attached.
- [ ] #238 remains open until this is green.