### PR TITLE
fix: align manual publisher with source policy

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -2,8 +2,10 @@
 
 This repository is the public distribution surface for Simplicio Runtime. It
 does not build source from sibling `simplicio-*` repositories during install.
-The release files committed here and attached to the GitHub Release must be
-the four signed Runtime binaries plus the Desktop artifacts listed for the release.
+Release metadata, signatures, SBOMs, provenance, checksums, manifests, and hooks
+are committed here. Runtime and Desktop executables are staged locally and
+attached to the GitHub Release; the source-tree policy intentionally refuses to
+track executable build products.
 
 ## Required release files
 
@@ -73,7 +75,8 @@ only permitted for an explicitly selected unofficial channel.
 1. Build and sign the artifacts from the intended `simplicio-runtime` main
    commit.
 2. Commit the Runtime metadata and release record into a release branch;
-   keep oversized Desktop artifacts in staging for GitHub Release upload.
+   keep all Runtime and Desktop executables in local staging for GitHub Release
+   upload. Never force-add executable build products to the source tree.
 3. Run `python3 scripts/verify_distribution_consistency.py`,
    `python3 -m unittest discover -s tests -p 'test_verify_ed25519.py'`, and
    the release provenance tests.

--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -319,7 +319,10 @@ def stage_bundle(bundle: Path) -> list[Path]:
     for name in required_release_assets():
         destination = ROOT / name
         shutil.copy2(bundle / name, destination)
-        staged.append(destination)
+        # Executables are immutable GitHub Release assets, not source-tree
+        # files. The repository policy intentionally rejects tracked binaries.
+        if name not in ASSETS:
+            staged.append(destination)
     return staged
 
 

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -116,6 +116,31 @@ def test_public_publisher_stages_versioned_codex_hooks(tmp_path, monkeypatch):
     assert (public / "codex/mcp-route.sh").stat().st_mode & 0o111
 
 
+
+def test_public_publisher_keeps_executables_out_of_the_source_commit(tmp_path, monkeypatch):
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_assets", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    bundle = tmp_path / "bundle"
+    public = tmp_path / "public"
+    bundle.mkdir()
+    public.mkdir()
+    for name in module.required_release_assets():
+        (bundle / name).write_bytes(("fixture:" + name).encode("utf-8"))
+
+    monkeypatch.setattr(module, "ROOT", public)
+    changed = module.stage_bundle(bundle)
+    changed_names = {path.relative_to(public).as_posix() for path in changed}
+
+    assert changed_names == set(module.required_release_assets()) - set(module.ASSETS)
+    assert not (changed_names & set(module.ASSETS))
+    for name in module.required_release_assets():
+        assert (public / name).read_bytes() == (bundle / name).read_bytes()
+
+
 def test_publication_paths_gate_the_executable_codex_hook_contract():
     publisher = (ROOT / "scripts/publish_release_local.py").read_text(encoding="utf-8")
     assert 'shutil.which("pwsh")' in publisher


### PR DESCRIPTION
Keeps Runtime executables in local staging for GitHub Release upload instead of forcing ignored binaries into Git source. Metadata, signatures, SBOMs, provenance, manifest, wrappers, and hooks remain committed. Updates the manual and adds a regression test. Local gates: 20 release tests passed; repository policy passed.