### PR TITLE
fix: force-stage only installer source wrappers

### DIFF
--- a/scripts/publish_release_local.py
+++ b/scripts/publish_release_local.py
@@ -33,6 +33,12 @@ CODEX_HOOK_FILES = (
     "codex/mcp-route.ps1",
 )
 LOCAL_STATE_PREFIXES = (".simplicio/", "pypi/simplicio/build/")
+FORCE_TRACKED_RELEASE_PREFIXES = (
+    "npm/simplicio/",
+    "npm/simplicio-installer/",
+    "npm/simplicio-unscoped/",
+    "pypi/simplicio/",
+)
 
 
 class PublishError(RuntimeError):
@@ -139,6 +145,10 @@ def verify_bundle(bundle: Path, tag: str, version: str, source_commit: str) -> d
 def is_ignored_local_state(path: str) -> bool:
     normalized = path.replace("\\", "/")
     return normalized.startswith(LOCAL_STATE_PREFIXES)
+
+def requires_forced_release_staging(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized.startswith(FORCE_TRACKED_RELEASE_PREFIXES)
 
 
 def blocking_tracked_changes() -> list[str]:
@@ -428,7 +438,14 @@ def commit_public(paths: list[Path], tag: str, source_commit: str) -> str:
     relative = sorted({str(path.relative_to(ROOT)) for path in paths})
     branch = "release/" + tag
     run(["git", "switch", "-c", branch])
-    run(["git", "add", "--", *relative])
+    forced = [path for path in relative if requires_forced_release_staging(path)]
+    normal = [path for path in relative if not requires_forced_release_staging(path)]
+    if normal:
+        run(["git", "add", "--", *normal])
+    if forced:
+        # The broad binary-name ignore rules also match these known installer
+        # source directories. Force only this explicit source allowlist.
+        run(["git", "add", "-f", "--", *forced])
     run(["git", "-c", "core.whitespace=cr-at-eol", "diff", "--cached", "--check"])
     run([
         "git", "commit", "-m", "release(public): publish signed Runtime %s" % tag,

--- a/tests/test_release_local_contract.py
+++ b/tests/test_release_local_contract.py
@@ -180,6 +180,34 @@ def test_public_publisher_can_resume_after_an_external_partial_failure():
     assert "already_published_to_pypi" in source
 
 
+
+def test_publication_force_stages_only_known_installer_source_wrappers():
+    script = ROOT / "scripts/publish_release_local.py"
+    spec = importlib.util.spec_from_file_location("publish_release_local_force_paths", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    for path in (
+        "npm/simplicio/package.json",
+        "npm/simplicio-installer/package.json",
+        "npm/simplicio-unscoped/package.json",
+        "pypi/simplicio/pyproject.toml",
+        r"pypi\simplicio\simplicio\__main__.py",
+    ):
+        assert module.requires_forced_release_staging(path)
+
+    for path in (
+        "simplicio-macos-arm64",
+        "simplicio-windows-x64.exe",
+        "simplicio-macos-arm64.sig",
+        "SHA256SUMS",
+        "codex/mcp-route.sh",
+        "scripts/publish_release_local.py",
+    ):
+        assert not module.requires_forced_release_staging(path)
+
+
 def test_public_publisher_builds_wheel_from_clean_source(tmp_path, monkeypatch):
     script = ROOT / "scripts/publish_release_local.py"
     spec = importlib.util.spec_from_file_location("publish_release_local_clean_wheel", script)


### PR DESCRIPTION
The repository's broad simplicio-* ignore rules also match the known npm and PyPI source directories. The manual publisher now force-stages only those four explicit source prefixes; executable release assets remain excluded. Regression coverage verifies that binaries, signatures, checksums, hooks, and scripts never enter the forced allowlist. Local gates: 21 tests and repository policy passed.