### PR TITLE
fix: install Codex plugin from sparse marketplace

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -284,7 +284,10 @@ function Install-DetectedHostPlugins {
   $failures = 0
   if (Get-Command codex -CommandType Application -ErrorAction SilentlyContinue) {
     $detected += 1
-    [void](Invoke-NativeHostCommand "codex" @("plugin", "marketplace", "add", $Repo, "--ref", "master"))
+    [void](Invoke-NativeHostCommand "codex" @(
+      "plugin", "marketplace", "add", $Repo, "--ref", "master",
+      "--sparse", ".agents/plugins", "--sparse", "plugins/simplicio"
+    ))
     if (Invoke-NativeHostCommand "codex" @("plugin", "add", "simplicio@simplicio-codex")) {
       Write-Host "  ✓ Codex native plugin installed"
     } else {

--- a/install.sh
+++ b/install.sh
@@ -336,7 +336,8 @@ install_detected_host_plugins() {
   failures=0
   if command -v codex >/dev/null 2>&1; then
     detected=$((detected + 1))
-    codex plugin marketplace add "$REPO" --ref master >/dev/null 2>&1 || true
+    codex plugin marketplace add "$REPO" --ref master \
+      --sparse .agents/plugins --sparse plugins/simplicio >/dev/null 2>&1 || true
     if codex plugin add simplicio@simplicio-codex >/dev/null 2>&1; then
       ok "plugin nativo do Codex instalado"
     else

--- a/tests/test_installer_host_plugins_contract.py
+++ b/tests/test_installer_host_plugins_contract.py
@@ -10,7 +10,8 @@ def test_shell_installs_documented_native_plugins_after_runtime_registration() -
     plugin_install = "install_detected_host_plugins"
 
     assert 'command -v codex' in text
-    assert 'codex plugin marketplace add "$REPO" --ref master' in text
+    assert 'codex plugin marketplace add "$REPO" --ref master \\' in text
+    assert "--sparse .agents/plugins --sparse plugins/simplicio" in text
     assert "codex plugin add simplicio@simplicio-codex" in text
     assert 'command -v claude' in text
     assert 'claude plugin marketplace add "$REPO"' in text
@@ -37,7 +38,8 @@ def test_powershell_installs_documented_native_plugins_after_runtime_registratio
     plugin_install = "Install-DetectedHostPlugins"
 
     assert "Get-Command codex -CommandType Application" in text
-    assert '@("plugin", "marketplace", "add", $Repo, "--ref", "master")' in text
+    assert '"plugin", "marketplace", "add", $Repo, "--ref", "master",' in text
+    assert '"--sparse", ".agents/plugins", "--sparse", "plugins/simplicio"' in text
     assert '@("plugin", "add", "simplicio@simplicio-codex")' in text
     assert "Get-Command claude -CommandType Application" in text
     assert '@("plugin", "marketplace", "add", $Repo)' in text


### PR DESCRIPTION
Limits Codex marketplace checkout to .agents/plugins and plugins/simplicio on Unix and Windows. This preserves native plugin installation while avoiding a full repository-history clone in clean homes. Verified with a real isolated Codex marketplace/add/list flow, 24 local contract tests, shell syntax, and the full v3.8.38 terminal install smoke.