### PR TITLE
release(plugin): bump Simplicio bundle to 0.2.4

### DIFF
--- a/plugins/simplicio/.claude-plugin/plugin.json
+++ b/plugins/simplicio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Verified Simplicio Runtime MCP bootstrap and governed coding skills for Claude Code.",
   "author": {"name": "Wesley Simplicio"},
   "homepage": "https://simpleti.com.br/simplicio/",

--- a/plugins/simplicio/.codex-plugin/plugin.json
+++ b/plugins/simplicio/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Up to 96% token savings. Install and connect the Simplicio Runtime for compact repository context, governed execution, every CLI subcommand, and evidence-backed validation.",
   "author": {
     "name": "Wesley Simplicio",

--- a/plugins/simplicio/gemini-extension.json
+++ b/plugins/simplicio/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Verified Simplicio Runtime MCP bootstrap and governed coding skills for Gemini CLI.",
   "mcpServers": {
     "simplicio-runtime": {

--- a/plugins/simplicio/plugin.json
+++ b/plugins/simplicio/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "simplicio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Governed local-first coding through the verified Simplicio Runtime MCP and portable agent skills.",
   "author": {"name": "Wesley Simplicio", "url": "https://github.com/wesleysimplicio"},
   "homepage": "https://simpleti.com.br/simplicio/",

--- a/tests/unit/test_plugin_marketplace.py
+++ b/tests/unit/test_plugin_marketplace.py
@@ -81,6 +81,17 @@ def test_native_claude_and_gemini_manifests_reuse_the_bootstrap() -> None:
     assert args == ["${extensionPath}/bin/simplicio-mcp-bootstrap.js"]
 
 
+def test_simplicio_plugin_manifests_share_one_version() -> None:
+    manifests = [
+        _load_json("plugins/simplicio/plugin.json"),
+        _load_json("plugins/simplicio/.codex-plugin/plugin.json"),
+        _load_json("plugins/simplicio/.claude-plugin/plugin.json"),
+        _load_json("plugins/simplicio/gemini-extension.json"),
+    ]
+
+    assert {manifest["version"] for manifest in manifests} == {"0.2.4"}
+
+
 def test_host_surface_registry_is_complete_and_honest() -> None:
     registry = _load_json("plugins/simplicio/host-surfaces.json")
     hosts = registry["hosts"]


### PR DESCRIPTION
## Motivo

O conteúdo do plugin público avançou na v3.8.38, mas os manifests continuavam em 0.2.3. Isso podia preservar um cache antigo em clientes que decidem upgrades pela versão declarada.

## Alterações

- alinha os manifests Codex, Claude, Gemini e portátil em 0.2.4;
- adiciona contrato que exige uma única versão entre os quatro hosts.

## Validação

- `8 passed` em `tests/unit/test_plugin_marketplace.py`;
- `simplicio validate`: `256 passed, 30 subtests passed`;
- `repository_policy.py`, `quality_policy.py` e `git diff --check`: PASS.

Publicação e integração seguem manuais, sem GitHub Actions.