### PR TITLE
release(desktop): bundle Runtime v3.8.39

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.38",
+  "version": "3.8.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@simplicio/desktop",
-      "version": "3.8.38",
+      "version": "3.8.39",
       "dependencies": {
         "@tauri-apps/api": "2.11.1",
         "react": "19.2.8",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.38",
+  "version": "3.8.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2807,7 +2807,7 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simplicio-desktop"
-version = "3.8.38"
+version = "3.8.39"
 dependencies = [
  "serde_json",
  "sha2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicio-desktop"
-version = "3.8.38"
+version = "3.8.39"
 description = "Public desktop shell for the Simplicio Runtime"
 authors = ["SimpleTI"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Simplicio",
-  "version": "3.8.38",
+  "version": "3.8.39",
   "identifier": "br.com.simpleti.simplicio",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -55,7 +55,7 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("Automations");
     expect(html).toContain("Apps");
     expect(html).toContain("Configurações");
-    expect(html).toContain("v3.8.38");
+    expect(html).toContain("v3.8.39");
     expect((html.match(/class=\"nav-item/g) ?? []).length).toBe(6);
   });
 

--- a/apps/desktop/src/demo.ts
+++ b/apps/desktop/src/demo.ts
@@ -78,7 +78,7 @@ export function createDemoSnapshot(state: AccessState = "active"): DesktopSnapsh
     },
     runtime: {
       state: "healthy",
-      version: "3.8.38",
+      version: "3.8.39",
       transport: "sidecar",
       lastReceiptAt: generatedAt,
       deterministic: {


### PR DESCRIPTION
## Resumo

- alinha as versões npm, Cargo, Tauri e fixture do Desktop em 3.8.39;
- prepara o bundle manual para carregar o Runtime 3.8.39 exato do manifesto público;
- mantém o Desktop e o Runtime na mesma identidade de release.

## Validação local

- `npm test -- --run`: 32 arquivos / 66 testes;
- `npm run build`: TypeScript + Vite aprovados;
- `cargo test --manifest-path src-tauri/Cargo.toml`: aprovado;
- `npm run tauri -- build --bundles app,dmg`: app e DMG gerados localmente;
- sidecar: `simplicio 3.8.39`, SHA-256 igual ao artefato `macos-arm64` do manifesto público;
- bundle instalado: versão 3.8.39, navegação Today/Chats/Teams/Automations/Apps/Configurações e refresh do Runtime verificados pela interface;
- `simplicio validate`: 256 testes + 30 subtests.

## Assinatura de plataforma

O bundle ad-hoc passa em `codesign --verify --deep --strict`. A notarização Apple continua indisponível neste host porque não há identidade Developer ID nem perfil do `notarytool`; o status será registrado de forma explícita nos ativos, sem alegar Gatekeeper aprovado.
