### PR TITLE
docs: record verified Desktop 3.8.39 release evidence

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -4,22 +4,32 @@
 
 ## Purpose
 
-This is the **public distribution repo** for [Simplicio](https://github.com/wesleysimplicio/simplicio), a Rust-based terminal AI coding agent. It contains installers, packages, documentation (15 languages), and release assets.
+This is the **public distribution repo** for [Simplicio](https://github.com/wesleysimplicio/simplicio), a Rust-based terminal AI coding agent. It contains installers, packages, documentation (15 languages), release metadata, and the first-party Desktop source in `apps/desktop`.
 
-**Not the source code.** The Rust runtime source lives in the private [`simplicio-runtime`](https://github.com/wesleysimplicio/simplicio-runtime) repo.
+The Rust Runtime source lives in the private [`simplicio-runtime`](https://github.com/wesleysimplicio/simplicio-runtime) repo. Runtime and Desktop executables are GitHub Release assets, not tracked source files.
 
 ## Runtime snapshot: v3.8.39
 
 ## Current Version: v3.8.39
 
 - **Source:** `simplicio-runtime` main at commit
-  `d91aa04b39ab33c252c628fab6806bf8ea2c39a8` (merged Runtime v3.8.24 release metadata).
-- **Runtime targets:** macOS ARM64, macOS x64, Linux x64, and Windows x64.\n  The canonical target table and release manifest define the asset, checksum,\n  signature, SBOM, and provenance for each Runtime platform.\n- **Desktop assets:** macOS ARM64 DMG and ZIP are published alongside the\n  Runtime release and tracked by exact filename, SHA-256, size, and signing\n  status in `docs/RELEASE_RUNBOOK.md`. The
-  canonical target table and release manifest define the asset, checksum,
-  signature, SBOM, and provenance for each platform.
-- **Release status:** GitHub Release v3.8.24 metadata is published manually, without GitHub Actions. Installers
-  and the update command resolve GitHub's latest release, verify its signed
-  manifest, and fail closed if an artifact signature or checksum is invalid.
+  `d91aa04b39ab33c252c628fab6806bf8ea2c39a8` (Runtime v3.8.39).
+- **Runtime targets:** macOS ARM64, macOS x64, Linux x64, and Windows x64.
+  The canonical target table and release manifest define the asset, checksum,
+  Ed25519 signature, SBOM, and provenance for each Runtime platform.
+- **Desktop assets:** `Simplicio-3.8.39-arm64.dmg` and `.zip` are published
+  alongside the Runtime release, built from public commit
+  `dd7dd0665630fcdd6c9a76d07956d840f80fc0a9`. Exact filenames, SHA-256,
+  sizes, verification evidence, and signing status are recorded in
+  [the release runbook](docs/RELEASE_RUNBOOK.md#published-desktop-v3839).
+- **Release status:** GitHub Release v3.8.39 and `simplicio-installer 3.8.39`
+  on PyPI are published manually, without GitHub Actions. Installers and the
+  update command resolve the release metadata, verify the required Ed25519
+  artifact signatures, and fail closed on an invalid signature or checksum.
+- **Readiness limits:** the macOS ARM64 Desktop package has a valid ad-hoc
+  code signature but no Apple Developer ID signature or notarization;
+  Gatekeeper rejects it. Installed Ambient/Workspace/Agent action contracts
+  and the remaining native-host release-train gates are not declared complete.
 - **Default branch:** master
 - **Release-channel gates:** the installer enforces embedded ecosystem sources,
   the configured update key, SHA256, Ed25519 signatures, and active Google login.
@@ -42,7 +52,9 @@ This is the **public distribution repo** for [Simplicio](https://github.com/wesl
 ├── install.sh / install.ps1  # Installers
 ├── distribution/targets.json # Canonical platform-to-asset mapping
 ├── simplicio-update-manifest.json # Checksums, signatures, provenance
-├── release binaries           # Runtime assets published in GitHub Releases\n└── Desktop DMG/ZIP             # Desktop assets published in GitHub Releases
+├── apps/desktop              # First-party Desktop source
+├── release binaries           # Runtime assets published in GitHub Releases
+└── Desktop DMG/ZIP             # Desktop assets published in GitHub Releases
 ~~~
 
 The current release targets are macOS ARM64, macOS x64 (Intel), Linux x64,

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -42,6 +42,57 @@ are not part of the signed Runtime update manifest because they are consumed
 by the Desktop distribution path. The release record must include their exact
 filename, SHA-256, size, and platform signing/notarization status.
 
+### Published Desktop v3.8.39
+
+The Desktop assets were added manually to the existing public `v3.8.39`
+release after [PR #263](https://github.com/wesleysimplicio/simplicio/pull/263)
+merged. Their source commit is `dd7dd0665630fcdd6c9a76d07956d840f80fc0a9`;
+the already published Runtime tag was not moved and no existing asset was
+overwritten.
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `Simplicio-3.8.39-arm64.dmg` | 33754359 | `5b2c6380d9f5b52ee0371cb3937a4279a806e22dd88f5a80e121e48e7de96735` |
+| `Simplicio-3.8.39-arm64.zip` | 32030285 | `38c73a9c7d6a80a2e370b3ce59d4299fae9f760e440dd406a9d453c6394ca290` |
+
+Both packages and their `.sig`, `.spdx.json`, and `.provenance.json` sidecars
+were downloaded again from GitHub. All eight assets matched the verified
+local files byte-for-byte; Ed25519 signatures, SBOM digests, provenance sizes,
+version, and source commit were checked against the downloaded files.
+
+The bundled `simplicio` must preserve the exact digest of the official
+`simplicio-macos-arm64` release asset:
+`c6dca7c384aaedb0226f6ea93a0dbe259a175f999c070e6c8ef609af519e5130`.
+When repairing the local ad-hoc app signature, sign the outer bundle only.
+Do not use `codesign --force --deep --sign -`: it rewrites the Runtime
+sidecar signature and changes its digest. `--deep` is appropriate for the
+subsequent verification, not for this signing step. Verify the sidecar hash
+before and after signing, then package, hash, and sign the final archives.
+
+Verified locally on macOS ARM64:
+
+- DMG mount, ZIP extraction, and installed app report Desktop `3.8.39`;
+- the bundled Runtime hash matches the official asset in all three locations;
+- `codesign --verify --deep --strict` passes in all three locations;
+- the installed app opens with Runtime `3.8.39`, active account, and working
+  navigation; frontend tests/build, Rust tests, and repository validation pass.
+
+Still open, and not implied by successful publication:
+
+- Apple Developer ID signing and notarization are unavailable. The signature
+  is ad-hoc and `spctl`/Gatekeeper rejects the app. Ed25519 distribution
+  authentication does not replace Apple platform trust.
+- Ambient/Workspace/Agent action contracts are incomplete in the installed
+  path. Today reports `ambient.today_projection_unavailable`; disabled
+  actions are not counted as working workflows.
+- Native installed smoke for Windows, Linux, and macOS Intel, plus composed
+  Loop/Agent/Code N/N-1 release-train gates, are not proven by this host's run.
+- Desktop provenance truthfully records
+  `optimization_profile_receipt_not_supplied`; no optimization result is
+  inferred from a successful build.
+
+### Historical Desktop v3.8.24
+
 For `v3.8.24`:
 
 - `Simplicio-3.8.24-arm64.dmg` — 135,726,628 bytes —


### PR DESCRIPTION
## Resumo

- Corrige as referências antigas a 3.8.24 e as quebras de linha literais em `VERSION.md`.
- Registra o commit de origem, os hashes, os tamanhos e os oito assets do Desktop 3.8.39 publicados manualmente.
- Documenta a verificação do download público, a preservação byte a byte do Runtime embutido e o cuidado com `codesign --deep` na assinatura.
- Mantém explícitos os gates ainda abertos: notarização Apple, ações Ambient/Workspace/Agent e smoke nativo/matriz composta do Release Train.

Não altera binários publicados, manifesto Runtime nem tag existente. Build e publicação foram locais/manuais, sem GitHub Actions.

## Validação local

- `git diff --check` — passou.
- `python3 scripts/repository_policy.py` — árvore de fonte rastreada limpa.
- `simplicio validate` — 256 testes e 30 subtestes passaram.
- DMG/ZIP e seis sidecars baixados novamente do GitHub: oito arquivos idênticos aos verificados localmente; Ed25519, SBOM e proveniência válidos.

Evidência pública: https://github.com/wesleysimplicio/simplicio/releases/tag/v3.8.39

Relacionado a wesleysimplicio/simplicio-runtime#3334, #5156, #5193 e #5208. Este PR não fecha esses épicos nem declara a integração Desktop 100% pronta.
