### PR TITLE
Desktop: referencias e relatorios automaticos verificados [skip ci]

### DIFF
--- a/apps/desktop/e2e/access-account-recovery.spec.ts
+++ b/apps/desktop/e2e/access-account-recovery.spec.ts
@@ -5,14 +5,25 @@ type LockedState = "inactive" | "unknown";
 type RecoveryTestWindow = Window & {
   __accessRecoveryCalls: string[];
   __accessFinishLogout?: () => void;
+  __accessFinishLogin?: () => void;
 };
 
-async function mockAccountRecovery(page: Page, state: LockedState, options: { failLogout?: boolean; failSnapshot?: boolean } = {}) {
+async function mockAccountRecovery(page: Page, state: LockedState, options: {
+  failLogout?: boolean;
+  failSnapshot?: boolean;
+  anonymous?: boolean;
+  failLogin?: boolean;
+  loginRemainsUnknown?: boolean;
+  logoutRemainsUnknown?: boolean;
+} = {}) {
   const snapshot = createDemoSnapshot(state);
   snapshot.source = "runtime";
+  if (options.anonymous) snapshot.access = { ...snapshot.access, identityKnown: false, entitlementKnown: false, displayName: null, email: null, plan: null };
   const signedOut = createDemoSnapshot("signed_out");
   signedOut.source = "runtime";
-  await page.addInitScript(({ snapshot, signedOut, options }) => {
+  const active = createDemoSnapshot("active");
+  active.source = "runtime";
+  await page.addInitScript(({ snapshot, signedOut, active, options }) => {
     const calls: string[] = [];
     Object.assign(window, {
       __accessRecoveryCalls: calls,
@@ -26,8 +37,14 @@ async function mockAccountRecovery(page: Page, state: LockedState, options: { fa
           if (command === "desktop_logout") {
             await new Promise<void>((resolve) => Object.assign(window, { __accessFinishLogout: resolve }));
             if (options.failLogout) throw "logout_unconfirmed";
-            return signedOut;
+            return options.logoutRemainsUnknown ? snapshot : signedOut;
           }
+          if (command === "desktop_login") {
+            await new Promise<void>((resolve) => Object.assign(window, { __accessFinishLogin: resolve }));
+            if (options.failLogin) throw "runtime_oauth_timeout";
+            return options.loginRemainsUnknown ? snapshot : active;
+          }
+          if (command === "refresh_desktop_snapshot") return snapshot;
           // Native menu subscriptions have no account or installation effects.
           if (command === "plugin:event|listen") return 1;
           if (command === "plugin:event|unlisten") return;
@@ -35,7 +52,7 @@ async function mockAccountRecovery(page: Page, state: LockedState, options: { fa
         },
       },
     });
-  }, { snapshot, signedOut, options });
+  }, { snapshot, signedOut, active, options });
 }
 
 async function logoutCalls(page: Page) {
@@ -80,7 +97,8 @@ for (const state of ["inactive", "unknown"] as const) {
     await expect(page.getByRole("button", { name: "Saindo…", exact: true })).toBeDisabled();
     await page.evaluate(() => (window as RecoveryTestWindow).__accessFinishLogout?.());
 
-    await expect(page.getByRole("alert")).toContainText("Não foi possível sair com segurança.");
+    await expect(page.getByRole("alert")).toContainText("A saída da conta não foi confirmada.");
+    await expect(page.getByRole("alert")).not.toContainText("logout_unconfirmed");
     await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible();
     await expect(page.getByRole("button", { name: "Sair da conta", exact: true })).toBeEnabled();
     await expect(page.getByRole("button", { name: "Começar", exact: true })).toHaveCount(0);
@@ -103,4 +121,87 @@ test("a failed initial snapshot can recover through confirmed logout (mocked IPC
   await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toHaveCount(0);
   expect(await logoutCalls(page)).toHaveLength(1);
   await expectNoImplicitEffects(page);
+});
+
+for (const failSnapshot of [false, true]) {
+  test(`${failSnapshot ? "failed snapshot" : "unknown access without identity"} can explicitly log in and reach active setup (mocked IPC)`, async ({ page }) => {
+    await mockAccountRecovery(page, "unknown", { anonymous: true, failSnapshot });
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ative o Simplicio", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Começar", exact: true })).toHaveCount(0);
+    await expectNoImplicitEffects(page);
+
+    await page.getByRole("button", { name: "Entrar ou reconectar", exact: true }).dblclick();
+    const pending = page.getByRole("button", { name: "Aguardando navegador…", exact: true });
+    await expect(pending).toBeDisabled();
+    await expect(pending).toHaveAttribute("aria-busy", "true");
+    await expect(page.getByRole("status")).toContainText("O acesso permanece desconhecido");
+    await expect(page.getByRole("button", { name: "Aguarde…", exact: true })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Sair da conta", exact: true })).toBeDisabled();
+    await page.getByRole("button", { name: "Abrir diagnóstico", exact: true }).click();
+    await expect(page.getByText("Estado de acesso desconhecido", { exact: true })).toBeVisible();
+    const pendingCalls = await page.evaluate(() => (window as RecoveryTestWindow).__accessRecoveryCalls);
+    expect(pendingCalls.filter((command) => command === "desktop_login")).toHaveLength(1);
+    expect(pendingCalls).not.toContain("refresh_desktop_snapshot");
+    expect(pendingCalls).not.toContain("desktop_logout");
+
+    await page.evaluate(() => (window as RecoveryTestWindow).__accessFinishLogin?.());
+    await expect(page.getByRole("heading", { name: "Um bom começo.", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Configurar Simplicio", exact: true })).toBeEnabled();
+    await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    const calls = await page.evaluate(() => (window as RecoveryTestWindow).__accessRecoveryCalls);
+    expect(calls.filter((command) => command === "desktop_login")).toHaveLength(1);
+    for (const command of ["desktop_logout", "desktop_open_subscription", "desktop_plan_integrations", "desktop_repair_providers"]) {
+      expect(calls).not.toContain(command);
+    }
+  });
+}
+
+for (const failLogin of [false, true]) {
+  test(`${failLogin ? "failed" : "unverified"} login keeps unknown access gated without assuming active or inactive (mocked IPC)`, async ({ page }) => {
+    await mockAccountRecovery(page, "unknown", { anonymous: true, failLogin, loginRemainsUnknown: true });
+    await page.goto("/");
+    await page.getByRole("button", { name: "Entrar ou reconectar", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Aguardando navegador…", exact: true })).toBeDisabled();
+    await page.evaluate(() => (window as RecoveryTestWindow).__accessFinishLogin?.());
+    await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Entrar ou reconectar", exact: true })).toBeEnabled();
+    await expect(page.getByRole("heading", { name: "Um bom começo.", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Ative o Simplicio", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Começar", exact: true })).toHaveCount(0);
+    if (failLogin) {
+      await expect(page.getByRole("alert")).toContainText("O resultado final do login não foi confirmado");
+      await expect(page.getByRole("alert")).not.toContainText("runtime_oauth_timeout");
+    }
+    await page.getByRole("button", { name: "Tentar novamente", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Entrar ou reconectar", exact: true })).toBeEnabled();
+    const calls = await page.evaluate(() => (window as RecoveryTestWindow).__accessRecoveryCalls);
+    expect(calls.filter((command) => command === "desktop_login")).toHaveLength(1);
+    expect(calls.filter((command) => command === "refresh_desktop_snapshot")).toHaveLength(1);
+    expect(calls).not.toContain("desktop_logout");
+    expect(calls).not.toContain("desktop_repair_providers");
+  });
+}
+
+test("legacy logout returning unknown still permits a later explicit login (mocked IPC)", async ({ page }) => {
+  await mockAccountRecovery(page, "unknown", { anonymous: true, logoutRemainsUnknown: true });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Sair da conta", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Entrar ou reconectar", exact: true })).toBeDisabled();
+  await page.evaluate(() => (window as RecoveryTestWindow).__accessFinishLogout?.());
+  await expect(page.getByRole("button", { name: "Entrar ou reconectar", exact: true })).toBeEnabled();
+  await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+  await expectNoImplicitEffects(page);
+  await page.getByRole("button", { name: "Entrar ou reconectar", exact: true }).focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("button", { name: "Aguardando navegador…", exact: true })).toBeDisabled();
+  await page.evaluate(() => (window as RecoveryTestWindow).__accessFinishLogin?.());
+  await expect(page.getByRole("heading", { name: "Um bom começo.", exact: true })).toBeVisible();
+  const calls = await page.evaluate(() => (window as RecoveryTestWindow).__accessRecoveryCalls);
+  expect(calls.filter((command) => command === "desktop_logout")).toHaveLength(1);
+  expect(calls.filter((command) => command === "desktop_login")).toHaveLength(1);
+  expect(calls.indexOf("desktop_logout")).toBeLessThan(calls.indexOf("desktop_login"));
+  expect(calls).not.toContain("desktop_repair_providers");
 });

--- a/apps/desktop/e2e/automatic-projects.spec.ts
+++ b/apps/desktop/e2e/automatic-projects.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+async function installBridge(page: Page, delay = 60, partial = false, unavailableRoots: string[] = []) {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot, delay, partial, unavailableRoots }) => {
+    const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
+    Object.assign(window, { __projectCalls: calls, __TAURI_INTERNALS__: { invoke: async (command: string, args: Record<string, unknown> = {}) => {
+      calls.push({ command, args });
+      if (command === "desktop_snapshot") return snapshot;
+      if (command === "desktop_usage_projects") {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return { schema: "simplicio.desktop-project-usage/v1", candidateCount: 2, partial, reasons: partial ? [unavailableRoots.length ? "root_timeout" : "deadline"] : [], unavailableRoots, directoriesVisited: 6,
+          scope: { kind: "conventional_roots_and_configured_repo", maxDepth: 5, maxDirectories: 4000, maxResults: 64, deadlineMs: 2000 },
+          roots: [{ name: "Projetos", path: "/tmp/Projetos" }], projects: [
+            { id: `project-${"a".repeat(64)}`, name: "Material didático", path: "/tmp/Projetos/aulas", evidenceType: "context", lastModifiedEpoch: 1788180001 },
+            { id: `project-${"b".repeat(64)}`, name: "Runtime", path: "/tmp/Projetos/runtime", evidenceType: "both", lastModifiedEpoch: 1788180000 },
+          ] };
+      }
+      if (command === "desktop_token_report") throw "token_ledger_unavailable";
+      if (command === "desktop_context_report") {
+        await new Promise((resolve) => setTimeout(resolve, 90));
+        const savedTokens = args.repoPath === "/tmp/Projetos/aulas" ? 350 : 125;
+        return { schema: "simplicio.desktop-context-report/v1", source: "runtime", scope: "project_history",
+          eventCount: 12, ledgerEventCount: 12, llmSpendEventCount: 0, baselineTokens: 1000, actualTokens: 1000 - savedTokens, savedTokens, netTokens: savedTokens,
+          baselineKind: "mixed", confidence: "low", heuristicEventCount: 10, unlabeledEstimateCount: 1,
+          proof: { measured: 9, estimated: 3, replayed: 0, benchmark: 0, unavailable: 0 }, reportHash: `sha256:${"d".repeat(64)}` };
+      }
+      throw `Unexpected test command: ${command}`;
+    } } });
+  }, { snapshot, delay, partial, unavailableRoots });
+}
+
+test("discovers real-ledger candidates, selects the newest and loads only the selected project", async ({ page }) => {
+  await installBridge(page);
+  await page.goto("/?view=tokens");
+  await expect(page.getByLabel("Pasta do projeto (opcional)")).toHaveValue("/tmp/Projetos/aulas");
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await expect(context.getByTestId("context-metrics")).toContainText("350");
+  const projects = page.getByRole("region", { name: "Pastas com uso do Simplicio" });
+  await expect(projects).toContainText("2 pastas encontradas");
+  await expect(projects).toContainText("Um ledger encontrado é um candidato");
+  await page.getByLabel("Projetos com uso do Simplicio").selectOption(`project-${"b".repeat(64)}`);
+  await expect(page.getByLabel("Pasta do projeto (opcional)")).toHaveValue("/tmp/Projetos/runtime");
+  await expect(context.getByTestId("context-metrics")).toContainText("125");
+  await expect(context.getByTestId("context-metrics")).not.toContainText("350");
+  const calls = await page.evaluate(() => (window as unknown as { __projectCalls: Array<{ command: string; args: Record<string, unknown> }> }).__projectCalls);
+  expect(calls.filter((call) => call.command === "desktop_context_report").map((call) => call.args.repoPath)).toEqual(["/tmp/Projetos/aulas", "/tmp/Projetos/runtime"]);
+  expect(calls.filter((call) => call.command === "desktop_usage_projects")).toHaveLength(1);
+});
+
+test("late discovery does not overwrite a manually entered folder and reports partial scope", async ({ page }) => {
+  await installBridge(page, 800, true);
+  await page.goto("/?view=tokens");
+  await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/minha-escolha");
+  await expect(page.getByRole("region", { name: "Pastas com uso do Simplicio" })).toContainText("Descoberta parcial");
+  await expect(page.getByLabel("Pasta do projeto (opcional)")).toHaveValue("/tmp/minha-escolha");
+  await expect(page.getByTestId("context-metrics")).toHaveCount(0);
+  const contextCalls = await page.evaluate(() => (window as unknown as { __projectCalls: Array<{ command: string }> }).__projectCalls.filter((call) => call.command === "desktop_context_report"));
+  expect(contextCalls).toHaveLength(0);
+});
+
+test("keeps completed projects usable when another root times out", async ({ page }) => {
+  await installBridge(page, 60, true, ["Desktop"]);
+  await page.goto("/?view=tokens");
+  const projects = page.getByRole("region", { name: "Pastas com uso do Simplicio" });
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await expect(projects).toContainText("2 pastas encontradas");
+  await expect(projects).toContainText("Descoberta parcial");
+  await expect(projects).toContainText("Locais não concluídos: Desktop");
+  await expect(context.getByTestId("context-metrics")).toContainText("350");
+  await page.getByLabel("Projetos com uso do Simplicio").selectOption(`project-${"b".repeat(64)}`);
+  await expect(page.getByLabel("Pasta do projeto (opcional)")).toHaveValue("/tmp/Projetos/runtime");
+  await expect(context.getByTestId("context-metrics")).toContainText("125");
+  await expect(projects.getByRole("button", { name: "Escolher outra pasta…" })).toBeEnabled();
+  const calls = await page.evaluate(() => (window as unknown as { __projectCalls: Array<{ command: string; args: Record<string, unknown> }> }).__projectCalls);
+  expect(calls.filter((call) => call.command === "desktop_context_report").map((call) => call.args.repoPath)).toEqual(["/tmp/Projetos/aulas", "/tmp/Projetos/runtime"]);
+  expect(calls.filter((call) => call.command === "desktop_usage_projects")).toHaveLength(1);
+});

--- a/apps/desktop/e2e/context-report.spec.ts
+++ b/apps/desktop/e2e/context-report.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+import type { ContextReport } from "../src/context_report";
+
+async function contextBridge(page: Page, fail = false, reportPatch: Partial<ContextReport> = {}) {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  const report: ContextReport = {
+    schema: "simplicio.desktop-context-report/v1", source: "runtime", scope: "project_history",
+    eventCount: 12, ledgerEventCount: 12, llmSpendEventCount: 0, baselineTokens: 1000, actualTokens: 650, savedTokens: 350, netTokens: 350,
+    baselineKind: "mixed", confidence: "low", heuristicEventCount: 10, unlabeledEstimateCount: 1,
+    proof: { measured: 9, estimated: 3, replayed: 0, benchmark: 0, unavailable: 0 },
+    reportHash: `sha256:${"c".repeat(64)}`,
+    ...reportPatch,
+  };
+  await page.addInitScript(({ snapshot, report, fail }) => {
+    const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
+    Object.assign(window, { __contextCalls: calls, __TAURI_INTERNALS__: {
+      invoke: async (command: string, args: Record<string, unknown> = {}) => {
+        calls.push({ command, args });
+        if (command === "desktop_snapshot") return snapshot;
+        if (command === "desktop_token_report") throw "token_ledger_unavailable";
+        if (command === "desktop_context_report") {
+          await new Promise((resolve) => setTimeout(resolve, 80));
+          if (fail) throw "context_ledger_invalid";
+          return report;
+        }
+        throw `Unexpected test command: ${command}`;
+      },
+    } });
+  }, { snapshot, report, fail });
+}
+
+function contextMetric(page: Page, label: string) {
+  return page.getByTestId("context-metrics").locator(":scope > div")
+    .filter({ has: page.getByText(label, { exact: true }) }).locator("strong");
+}
+
+async function callsFor(page: Page, command: string) {
+  return page.evaluate((command) => (window as Window & {
+    __contextCalls: Array<{ command: string; args: Record<string, unknown> }>;
+  }).__contextCalls.filter((call) => call.command === command), command);
+}
+
+test("project context savings remain usable when the separate usage ledger is absent", async ({ page }) => {
+  await contextBridge(page);
+  await page.goto("/?view=tokens");
+  await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/context project");
+  await page.getByRole("button", { name: "Consultar economia de contexto", exact: true }).click();
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await expect(context).toContainText("350");
+  await expect(context).toContainText("1.000");
+  await expect(context).toContainText("650");
+  await expect(context).toContainText("12 eventos");
+  await expect(context).toContainText("Evidência mista");
+  await expect(context).toContainText("não é consumo faturado");
+  const calls = await page.evaluate(() => (window as unknown as { __contextCalls: Array<{ command: string; args: Record<string, unknown> }> }).__contextCalls.filter((item) => item.command === "desktop_context_report"));
+  expect(calls).toEqual([{ command: "desktop_context_report", args: { repoPath: "/tmp/context project" } }]);
+  await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/another project");
+  await expect(context.getByTestId("context-metrics")).toHaveCount(0);
+  await expect(context).toContainText("Consulte o histórico desta pasta");
+});
+
+test("an invalid savings ledger is not turned into successful savings or cost", async ({ page }) => {
+  await contextBridge(page, true);
+  await page.goto("/?view=tokens");
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await page.getByRole("button", { name: "Consultar economia de contexto", exact: true }).click();
+  await expect(context.getByRole("alert")).toContainText("integridade");
+  await expect(context.getByTestId("context-metrics")).toHaveCount(0);
+  await expect(context).not.toContainText("R$");
+  await expect(page.getByRole("button", { name: "Consultar economia de contexto", exact: true })).toBeEnabled();
+});
+
+test("negative net context usage is not replaced by positive gross reductions (mocked IPC)", async ({ page }) => {
+  await contextBridge(page, false, { actualTokens: 1100, netTokens: -100 });
+  await page.goto("/?view=tokens");
+  await page.getByRole("button", { name: "Consultar economia de contexto", exact: true }).click();
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await expect(contextMetric(page, "Reduções registradas")).toHaveText("350");
+  await expect(contextMetric(page, "Referência registrada")).toHaveText("1.000");
+  await expect(contextMetric(page, "Com Simplicio")).toHaveText("1.100");
+  await expect(contextMetric(page, "Diferença líquida")).toHaveText("-100");
+  await expect(context).toContainText("Acumulado bruto do Runtime");
+  await expect(context).toContainText("Mais tokens do que a referência");
+  await expect(context).toContainText("Não o trate como economia líquida.");
+  await expect(context).toContainText("não é consumo faturado");
+});
+
+test("mixed LLM spending leaves all context comparisons unavailable without hiding gross reductions (mocked IPC)", async ({ page }) => {
+  await contextBridge(page, false, {
+    eventCount: 10, llmSpendEventCount: 2,
+    baselineTokens: null, actualTokens: null, netTokens: null,
+  });
+  await page.goto("/?view=tokens");
+  await page.getByRole("button", { name: "Consultar economia de contexto", exact: true }).click();
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  await expect(contextMetric(page, "Reduções registradas")).toHaveText("350");
+  for (const label of ["Referência registrada", "Com Simplicio", "Diferença líquida"]) {
+    await expect(contextMetric(page, label)).toHaveText("—");
+  }
+  await expect(context).toContainText("10 eventos de contexto · 12 eventos no histórico.");
+  await expect(context).toContainText("O histórico também tem 2 eventos de uso de LLM.");
+  await expect(context).toContainText("a comparação permanece indisponível");
+  await expect(context).toContainText("Classificação informada pelo Runtime para o histórico completo.");
+  await expect(context).not.toContainText("R$");
+});
+
+test("period and session filters do not replace or requery all-project context history (mocked IPC)", async ({ page }) => {
+  await contextBridge(page);
+  await page.goto("/?view=tokens");
+  await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/context-history-fixture");
+  await page.getByRole("button", { name: "Consultar economia de contexto", exact: true }).click();
+  const context = page.getByRole("region", { name: "Economia de contexto", exact: true });
+  const metrics = context.getByTestId("context-metrics").locator("strong");
+  const expectedMetrics = ["350", "1.000", "650", "350"];
+  await expect(metrics).toHaveText(expectedMetrics);
+  await context.getByText("Identificador do relatório", { exact: true }).click();
+  const digest = context.locator(".context-digest code");
+  await expect(digest).toHaveText(`sha256:${"c".repeat(64)}`);
+
+  await page.getByRole("combobox", { name: "Período", exact: true }).selectOption("7d");
+  await expect(metrics).toHaveText(expectedMetrics);
+  await page.getByLabel("Sessão (opcional)").fill("session-fixture");
+  await expect(metrics).toHaveText(expectedMetrics);
+  await page.getByRole("combobox", { name: "Período", exact: true }).selectOption("custom");
+  await page.getByRole("textbox", { name: "Início", exact: true }).fill("2026-08-01T00:00");
+  await page.getByRole("textbox", { name: "Fim (exclusivo)", exact: true }).fill("2026-08-02T00:00");
+  await expect(metrics).toHaveText(expectedMetrics);
+  const usageCalls = (await callsFor(page, "desktop_token_report")).length;
+  await page.getByRole("button", { name: "Consultar uso", exact: true }).click();
+  await expect.poll(async () => (await callsFor(page, "desktop_token_report")).length).toBe(usageCalls + 1);
+  await expect(page.getByRole("button", { name: "Consultar uso", exact: true })).toBeEnabled();
+  expect((await callsFor(page, "desktop_token_report")).at(-1)).toMatchObject({
+    args: { request: {
+      repoPath: "/tmp/context-history-fixture", sessionId: "session-fixture",
+      fromEpoch: expect.any(Number), toEpoch: expect.any(Number),
+    } },
+  });
+  await expect(metrics).toHaveText(expectedMetrics);
+  await expect(digest).toHaveText(`sha256:${"c".repeat(64)}`);
+  await expect(context).toContainText("Todo o histórico da pasta acima.");
+  await expect(context).toContainText("Os filtros de período e sessão se aplicam apenas ao uso registrado.");
+  expect(await callsFor(page, "desktop_context_report")).toEqual([
+    { command: "desktop_context_report", args: { repoPath: "/tmp/context-history-fixture" } },
+  ]);
+});

--- a/apps/desktop/e2e/desktop-updates.spec.ts
+++ b/apps/desktop/e2e/desktop-updates.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 import { createDemoSnapshot } from "../src/demo";
 import { DESKTOP_RELEASES_API, DESKTOP_RELEASES_URL, DESKTOP_UPDATE_EVENT } from "../src/desktop_updates";
 
@@ -8,22 +8,25 @@ type UpdatesWindow = Window & {
   __updatesListeners: () => number;
   __updatesResolveOpen: (index: number) => void;
   __updatesRejectOpen: (index: number) => void;
+  __updatesResolveVersion: () => void;
 };
 
-async function mockUpdates(page: Page) {
+async function mockUpdates(page: Page, options: { holdVersion?: boolean; version?: string; notes?: string } = {}) {
   const snapshot = createDemoSnapshot("active");
   snapshot.source = "runtime";
   await page.clock.install();
-  await page.addInitScript(({ snapshot, eventName }) => {
+  await page.addInitScript(({ snapshot, eventName, options }) => {
     let sequence = 0;
     const callbacks = new Map<number, (event: unknown) => void>();
     const listeners = new Map<number, { event: string; handler: number }>();
     const openers: Array<{ resolve: () => void; reject: () => void }> = [];
     const calls: UpdatesWindow["__updatesCalls"] = [];
+    const versions: Array<(version: string) => void> = [];
+    let holdVersion = options.holdVersion;
     Object.assign(window, {
       isTauri: true,
       __updatesCalls: calls,
-      __updatesListeners: () => listeners.size,
+      __updatesListeners: () => [...listeners.values()].filter((entry) => entry.event === eventName).length,
       __updatesMenu: () => {
         for (const [id, entry] of listeners) {
           if (entry.event === eventName) callbacks.get(entry.handler)?.({ event: eventName, id, payload: null });
@@ -31,6 +34,7 @@ async function mockUpdates(page: Page) {
       },
       __updatesResolveOpen: (index: number) => openers[index].resolve(),
       __updatesRejectOpen: (index: number) => openers[index].reject(),
+      __updatesResolveVersion: () => { holdVersion = false; for (const resolve of versions) resolve(options.version ?? "3.8.39"); },
       __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: (_event: string, id: number) => listeners.delete(id) },
       __TAURI_INTERNALS__: {
         transformCallback: (callback: (event: unknown) => void) => { const id = ++sequence; callbacks.set(id, callback); return id; },
@@ -42,7 +46,7 @@ async function mockUpdates(page: Page) {
             return id;
           }
           if (command === "plugin:event|unlisten") return;
-          if (command === "plugin:app|version") return "3.8.39";
+          if (command === "plugin:app|version") return holdVersion ? new Promise<string>((resolve) => versions.push(resolve)) : options.version ?? "3.8.39";
           if (command === "desktop_update_target") return { platform: "macos", arch: "arm64" };
           if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
           if (command === "desktop_open_releases") return new Promise<void>((resolve, reject) => openers.push({ resolve, reject: () => reject(new Error("mock opener failed")) }));
@@ -50,11 +54,12 @@ async function mockUpdates(page: Page) {
         },
       },
     });
-  }, { snapshot, eventName: DESKTOP_UPDATE_EVENT });
+  }, { snapshot, eventName: DESKTOP_UPDATE_EVENT, options });
   const name = "Simplicio-3.8.40-arm64.dmg";
   await page.route((url) => url.href === DESKTOP_RELEASES_API, (route) => route.fulfill({
     status: 200, headers: { "content-type": "application/json", "access-control-allow-origin": "*" },
     body: JSON.stringify([{ tag_name: "v3.8.40", draft: false, prerelease: false, html_url: `${DESKTOP_RELEASES_URL}/tag/v3.8.40`,
+      published_at: "2026-08-31T01:34:29Z", body: options.notes ?? "Melhorias no login e nas integrações do Desktop.",
       assets: [{ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` }],
     }]),
   }));
@@ -75,7 +80,7 @@ test("pending release opener times out honestly and ignores late completion afte
   await mockUpdates(page);
   await showUpdates(page);
   await expect(page.getByRole("dialog")).toContainText("Versão deste aplicativo: 3.8.39");
-  const subscriptions = await page.evaluate(() => (window as UpdatesWindow).__updatesCalls.filter((entry) => entry.command === "plugin:event|listen"));
+  const subscriptions = await page.evaluate((eventName) => (window as UpdatesWindow).__updatesCalls.filter((entry) => entry.command === "plugin:event|listen" && entry.args.event === eventName), DESKTOP_UPDATE_EVENT);
   expect(subscriptions.every((entry) => JSON.stringify(entry.args.target) === JSON.stringify({ kind: "AnyLabel", label: "main" }))).toBe(true);
   await page.getByRole("button", { name: "Ver releases oficiais", exact: true }).dblclick();
   await expect(page.getByRole("button", { name: "Abrindo…", exact: true })).toBeDisabled();
@@ -110,5 +115,109 @@ test("closing a pending opener preserves uncertainty on reopen and ignores its l
   await page.clock.fastForward(8_001);
   await expect(page.getByRole("alert")).toContainText("Uma nova tentativa só será feita se você clicar novamente.");
   expect(await openerCalls(page)).toEqual([{ command: "desktop_open_releases", args: {} }]);
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "available");
+});
+
+test("shows a white manual-update dialog and public release notes only as inert text (mocked IPC/metadata)", async ({ page }, testInfo) => {
+  const requests: string[] = [];
+  page.on("request", (request) => requests.push(request.url()));
+  const notes = "## Mudanças\n<img src='https://untrusted.invalid/pixel' onerror='alert(1)'>\n[Download](javascript:alert(1))\n<script>alert(1)</script>";
+  await mockUpdates(page, { notes });
+  await showUpdates(page);
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toHaveCSS("background-color", "rgb(255, 255, 255)");
+  await expect(dialog).toContainText("Download e instalação manuais");
+  await expect(dialog).toContainText("Localize a release v3.8.40 e o pacote acima");
+  await expect(dialog).toContainText("97,7 KiB");
+  await expect(dialog.locator("time")).toHaveAttribute("datetime", "2026-08-31T01:34:29Z");
+  await expect(dialog.locator("time")).toHaveText("31/08/2026");
+  await page.screenshot({ path: testInfo.outputPath("updates-available.png") });
+  await dialog.locator("summary").click();
+  await expect(dialog.locator("pre")).toHaveText(notes);
+  await expect(dialog.locator("a, script, iframe")).toHaveCount(0);
+  await expect(dialog.locator("img")).toHaveCount(1);
+  await expect(page.getByRole("progressbar")).toHaveCount(0);
+  expect(requests.filter((url) => url === DESKTOP_RELEASES_API)).toHaveLength(1);
+  expect(requests.some((url) => url.includes("untrusted.invalid") || url.includes("/releases/download/"))).toBe(false);
+  expect(await openerCalls(page)).toHaveLength(0);
+  await expect(page.getByRole("button", { name: "Ver releases oficiais", exact: true })).toBeInViewport({ ratio: 1 });
+  await page.screenshot({ path: testInfo.outputPath("updates-notes-escaped.png") });
+});
+
+test("keeps real progress cancelable, traps focus and ignores a late local identity response (mocked IPC)", async ({ page }, testInfo) => {
+  const requests: string[] = [];
+  page.on("request", (request) => { if (request.url() === DESKTOP_RELEASES_API) requests.push(request.url()); });
+  await mockUpdates(page, { holdVersion: true });
+  const origin = page.getByRole("button").first();
+  await origin.focus();
+  await page.evaluate(() => { (window as UpdatesWindow).__updatesMenu(); (window as UpdatesWindow).__updatesMenu(); });
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toHaveAttribute("data-update-state", "checking");
+  await expect(dialog.locator("[data-update-stage]")).toHaveAttribute("data-update-stage", "identity");
+  await expect(dialog).toContainText("O instalador não está sendo baixado.");
+  await expect(page.getByRole("progressbar", { name: "Progresso da consulta de atualização" })).not.toHaveAttribute("value", /.*/);
+  await expect(page.getByRole("button", { name: "Fechar atualizações", exact: true })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Cancelar consulta", exact: true })).toBeFocused();
+  await page.keyboard.press("Shift+Tab");
+  await expect(page.getByRole("button", { name: "Fechar atualizações", exact: true })).toBeFocused();
+  const versionCalls = await page.evaluate(() => (window as UpdatesWindow).__updatesCalls.filter((entry) => entry.command === "plugin:app|version"));
+  expect(versionCalls).toHaveLength(1);
+  await page.screenshot({ path: testInfo.outputPath("updates-checking.png") });
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(origin).toBeFocused();
+  await page.evaluate(() => (window as UpdatesWindow).__updatesResolveVersion());
+  await page.clock.fastForward(1);
+  await expect(dialog).toHaveCount(0);
+  expect(requests).toHaveLength(0);
+  await showUpdates(page);
+  expect(requests).toHaveLength(1);
+});
+
+test("a stalled metadata request times out without fake success or automatic retries (mocked IPC/metadata)", async ({ page }) => {
+  await mockUpdates(page);
+  const held: Route[] = [];
+  const matchesApi = (url: URL) => url.href === DESKTOP_RELEASES_API;
+  const hold = (route: Route) => { held.push(route); };
+  await page.route(matchesApi, hold);
+  await page.evaluate(() => (window as UpdatesWindow).__updatesMenu());
+  await expect(page.getByRole("dialog").locator("[data-update-stage]")).toHaveAttribute("data-update-stage", "requesting");
+  await expect.poll(() => held.length).toBe(1);
+  await page.clock.fastForward(15_001);
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "error");
+  await expect(page.getByRole("dialog")).toContainText("A consulta excedeu o tempo limite");
+  await expect(page.getByRole("progressbar")).toHaveCount(0);
+  await page.clock.fastForward(20_000);
+  expect(held).toHaveLength(1);
+  expect(await openerCalls(page)).toHaveLength(0);
+  await page.unroute(matchesApi, hold);
+  // The browser may already have canceled the held route. Either way it cannot update the UI.
+  await held[0].fulfill({ status: 200, headers: { "content-type": "application/json", "access-control-allow-origin": "*" }, body: "[]" }).catch(() => undefined);
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "error");
+  await page.getByRole("button", { name: "Verificar novamente", exact: true }).click();
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "available");
+});
+
+test("an invalid installed version stays unknown without querying release metadata (mocked IPC)", async ({ page }) => {
+  const requests: string[] = [];
+  page.on("request", (request) => { if (request.url() === DESKTOP_RELEASES_API) requests.push(request.url()); });
+  await mockUpdates(page, { version: "latest" });
+  await page.evaluate(() => (window as UpdatesWindow).__updatesMenu());
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "error");
+  await expect(page.getByRole("dialog")).toContainText("O aplicativo não informou uma versão válida");
+  await expect(page.getByRole("dialog")).not.toContainText("Simplicio está atualizado");
+  expect(requests).toHaveLength(0);
+});
+
+test("offline checks remain unknown and only retry after the user reconnects and clicks (mocked IPC)", async ({ page, context }) => {
+  await mockUpdates(page);
+  await context.setOffline(true);
+  await page.evaluate(() => (window as UpdatesWindow).__updatesMenu());
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "offline");
+  await expect(page.getByRole("dialog")).toContainText("Sem conexão de rede");
+  await context.setOffline(false);
+  await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "offline");
+  await page.getByRole("button", { name: "Verificar novamente", exact: true }).click();
   await expect(page.getByRole("dialog")).toHaveAttribute("data-update-state", "available");
 });

--- a/apps/desktop/e2e/desktop.spec.ts
+++ b/apps/desktop/e2e/desktop.spec.ts
@@ -89,7 +89,7 @@ test("primary layouts fit desktop and compact widths", async ({ page }) => {
 });
 
 test("legacy capability previews stay bounded and do not promise unavailable actions", async ({ page }) => {
-  for (const [view, label] of [["today", "Today"], ["chats", "Chats"], ["teams", "Teams"], ["automations", "Automations"], ["apps", "Apps"]]) {
+  for (const [view, label] of [["today", "Hoje"], ["chats", "Conversas"], ["teams", "Equipes"], ["automations", "Automações"], ["apps", "Aplicativos"]]) {
     await page.goto("/?state=active&view=" + view);
     await expect(page.getByRole("heading", { name: label, level: 1 })).toBeVisible();
   }

--- a/apps/desktop/e2e/integration-preflight-recovery.spec.ts
+++ b/apps/desktop/e2e/integration-preflight-recovery.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+type PreflightWindow = Window & {
+  __preflightCalls: string[];
+  __preflightDigests: unknown[];
+};
+
+async function preparePreflightFailure(page: Page) {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot }) => {
+    const calls: string[] = [];
+    const digests: unknown[] = [];
+    let reviews = 0;
+    let applied = false;
+    Object.assign(window, {
+      isTauri: true,
+      __preflightCalls: calls,
+      __preflightDigests: digests,
+      __TAURI_INTERNALS__: {
+        transformCallback: () => 1,
+        unregisterCallback: () => undefined,
+        metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          calls.push(command);
+          if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+          if (command === "desktop_plan_integrations") {
+            reviews += 1;
+            return {
+              schema: "simplicio.desktop-integration-plan/v1", source: "runtime",
+              planDigest: "sha256:" + (reviews === 1 ? "a" : "b").repeat(64),
+              changes: [{ label: "codex", exists: applied, changed: !applied }],
+            };
+          }
+          if (command === "desktop_repair_providers") {
+            digests.push(args.planDigest);
+            // Native preflight failed before starting the installer, for example on a query timeout.
+            if (digests.length === 1) throw "integration_preflight_unavailable";
+            if (args.planDigest !== "sha256:" + "b".repeat(64)) throw "integration_plan_changed_review_again";
+            applied = true;
+            return snapshot;
+          }
+          if (command === "plugin:event|listen") return 1;
+          if (command === "plugin:event|unlisten") return;
+          throw "unexpected_preflight_recovery_command";
+        },
+      },
+    });
+  }, { snapshot });
+}
+
+async function calls(page: Page, command: string) {
+  return page.evaluate((command) => (window as PreflightWindow).__preflightCalls.filter((item) => item === command).length, command);
+}
+
+async function digests(page: Page) {
+  return page.evaluate(() => (window as PreflightWindow).__preflightDigests);
+}
+
+for (const view of ["setup", "providers"] as const) {
+  test(`${view} requires a new plan and consent after preflight failure, without automatic installation (mocked IPC)`, async ({ page }) => {
+    await preparePreflightFailure(page);
+    await page.goto(`/?view=${view}`);
+    const setup = view === "setup";
+    const surface = setup ? page.getByRole("main") : page.getByRole("region", { name: "Configuração do MCP", exact: true });
+    const review = page.getByRole("button", { name: setup ? "Configurar Simplicio" : "Revisar configuração MCP", exact: true });
+    const apply = page.getByRole("button", { name: setup ? "Instalar e conectar" : "Aplicar configuração MCP", exact: true });
+    const consent = surface.getByRole("checkbox", { name: /Autorizo o Runtime/ });
+
+    await review.click();
+    await expect(consent).not.toBeChecked();
+    await expect(apply).toBeDisabled();
+    await consent.check();
+    await apply.click();
+    await expect(page.getByRole("alert")).toContainText("O instalador não foi iniciado");
+    await expect(page.getByRole("alert")).not.toContainText("alterações parciais");
+    if (setup) await expect(page.getByRole("heading", { name: "Não foi possível concluir.", exact: true })).toBeVisible();
+    await expect(consent).toHaveCount(0);
+    await expect(apply).toHaveCount(0);
+    expect(await digests(page)).toEqual(["sha256:" + "a".repeat(64)]);
+    expect(await calls(page, "desktop_plan_integrations")).toBe(1);
+
+    if (!setup) {
+      const before = await calls(page, "refresh_desktop_snapshot");
+      await page.getByRole("button", { name: "Verificar", exact: true }).click();
+      await expect.poll(() => calls(page, "refresh_desktop_snapshot")).toBeGreaterThan(before);
+      await expect(page.getByRole("button", { name: "Verificar", exact: true })).toBeEnabled();
+      expect(await digests(page)).toHaveLength(1);
+    }
+    const reviewAgain = page.getByRole("button", { name: setup ? "Revisar novamente" : "Revisar configuração MCP", exact: true });
+    await expect(reviewAgain).toBeEnabled();
+    await reviewAgain.click();
+    await expect(consent).not.toBeChecked();
+    await expect(apply).toBeDisabled();
+    expect(await calls(page, "desktop_plan_integrations")).toBe(2);
+    expect(await digests(page)).toEqual(["sha256:" + "a".repeat(64)]);
+
+    // A separate explicit confirmation submits only the newly reviewed digest.
+    await consent.check();
+    await apply.click();
+    if (setup) {
+      await expect(page.getByRole("heading", { name: "Configuração concluída.", exact: true })).toBeVisible();
+    } else {
+      await expect(surface.getByRole("status")).toContainText("Configuração concluída pelo Runtime");
+    }
+    expect(await digests(page)).toEqual(["sha256:" + "a".repeat(64), "sha256:" + "b".repeat(64)]);
+  });
+}

--- a/apps/desktop/e2e/reference-entry.spec.ts
+++ b/apps/desktop/e2e/reference-entry.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("the two-step entry keeps keyboard focus on its next supported action", async ({ page }, testInfo) => {
+  for (const width of [1280, 390]) {
+    await page.setViewportSize({ width, height: 740 });
+    await page.goto("/?state=signed_out");
+    const start = page.getByRole("button", { name: "Começar", exact: true });
+    await expect(start).toBeFocused();
+    await page.screenshot({ path: testInfo.outputPath(`welcome-${width}.png`) });
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("heading", { name: "Entre no Simplicio" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continuar com Google", exact: true })).toBeFocused();
+    await expect(page.getByRole("textbox")).toHaveCount(0);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath(`login-${width}.png`) });
+    await page.getByRole("button", { name: "Voltar", exact: true }).click();
+    await expect(start).toBeFocused();
+    await expect(page.getByRole("heading", { name: "Um bom começo." })).toHaveCount(0);
+  }
+});

--- a/apps/desktop/e2e/reference-navigation.spec.ts
+++ b/apps/desktop/e2e/reference-navigation.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { REFERENCE_SCREENS } from "../src/reference_screens";
+
+test("every supplied-reference settings destination is searchable and reachable without losing navigation", async ({ page }, testInfo) => {
+  await page.goto("/?view=settings");
+  const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
+  const categories = sidebar.getByRole("navigation", { name: "Categorias de configurações", exact: true });
+  const search = sidebar.getByRole("searchbox", { name: "Buscar configurações", exact: true });
+  for (const screen of REFERENCE_SCREENS) await expect(categories.getByRole("button", { name: screen.label, exact: true })).toHaveCount(1);
+  expect(await page.locator(".sidebar-scroll").evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
+  await expect(sidebar.getByRole("button", { name: "Voltar ao app", exact: true })).toBeInViewport();
+  await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toBeInViewport();
+
+  for (const screen of REFERENCE_SCREENS) {
+    await search.fill(screen.label);
+    await categories.getByRole("button", { name: screen.label, exact: true }).click();
+    await expect(page.getByRole("heading", { name: screen.label, exact: true, level: 1 })).toBeVisible();
+    await expect(categories.getByRole("button", { name: screen.label, exact: true })).toHaveAttribute("aria-current", "page");
+    await expect(categories.getByRole("button", { name: screen.label, exact: true })).toBeInViewport();
+    await expect(search).toHaveValue("");
+  }
+  await expect(sidebar.getByRole("button", { name: "Voltar ao app", exact: true })).toBeInViewport();
+  await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toBeInViewport();
+  await page.screenshot({ path: testInfo.outputPath("reference-settings-navigation.png") });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("reference navigation is discoverable by description and usable in a narrow window", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 740 });
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Simplicio", exact: true, level: 1 })).toBeVisible();
+  await page.keyboard.press("Control+k");
+  const workspaceMenu = page.getByRole("dialog", { name: "Espaço de trabalho", exact: true });
+  await workspaceMenu.getByRole("searchbox").fill("pareamento");
+  const mobile = workspaceMenu.getByRole("button", { name: "Simplicio Mobile", exact: true });
+  await expect(mobile).toBeVisible();
+  await mobile.click();
+  await expect(page.getByRole("heading", { name: "Simplicio Mobile", exact: true, level: 1 })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Expandir barra lateral", exact: true }).click();
+  const settingsMenu = page.getByRole("dialog", { name: "Configurações", exact: true });
+  await settingsMenu.getByRole("searchbox").fill("Privacidade e telemetria");
+  await settingsMenu.getByRole("button", { name: "Privacidade e telemetria", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Privacidade e telemetria", exact: true, level: 1 })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath("reference-narrow-settings.png") });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("the main sidebar exposes the existing automation surface", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("navigation", { name: "Navegação principal", exact: true }).getByRole("button", { name: "Automações", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Automações", exact: true, level: 1 })).toBeVisible();
+});

--- a/apps/desktop/e2e/reference-project-dialog.spec.ts
+++ b/apps/desktop/e2e/reference-project-dialog.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+type ReferenceFolderWindow = Window & {
+  __referenceFolderCalls: string[];
+  __finishReferenceFolder?: (path: string | null) => void;
+};
+
+test("choosing a native folder fills a reviewable path without adding a project implicitly (mocked IPC)", async ({ page }, testInfo) => {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  const project = { id: "project-" + "d".repeat(64), name: "didaticos", path: "/tmp/didaticos" };
+  await page.addInitScript(({ snapshot, project }) => {
+    Object.assign(window, { __TAURI_INTERNALS__: {
+      invoke: async (command: string) => {
+        if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+        if (command === "plugin:dialog|open") return project.path;
+        if (command === "desktop_validate_project") return project;
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:event|unlisten") return;
+        throw "unexpected_reference_project_command";
+      },
+    } });
+  }, { snapshot, project });
+  await page.goto("/?view=home");
+  await page.getByRole("button", { name: "Adicionar projeto", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Adicionar projeto", exact: true });
+  const choose = dialog.getByRole("button", { name: "Escolher pasta…", exact: true });
+  await expect(choose).toBeFocused();
+  await choose.click();
+  await expect(page.getByLabel("Caminho da pasta")).toHaveValue("/tmp/didaticos");
+  await expect(page.getByLabel("Caminho da pasta")).toBeFocused();
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole("button", { name: "Abrir projeto didaticos", exact: true })).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath("folder-review.png") });
+  await dialog.getByRole("button", { name: "Adicionar projeto", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "didaticos", exact: true })).toBeVisible();
+});
+
+test("canceling the system picker preserves the typed path and restores focus without validation (mocked IPC)", async ({ page }) => {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot }) => {
+    const calls: string[] = [];
+    Object.assign(window, { __referenceFolderCalls: calls, __TAURI_INTERNALS__: {
+      invoke: async (command: string) => {
+        calls.push(command);
+        if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+        if (command === "plugin:dialog|open") return new Promise<string | null>((resolve) => {
+          (window as ReferenceFolderWindow).__finishReferenceFolder = resolve;
+        });
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:event|unlisten") return;
+        throw "unexpected_reference_folder_command";
+      },
+    } });
+  }, { snapshot });
+  await page.goto("/?view=home");
+  const add = page.getByRole("button", { name: "Adicionar projeto", exact: true });
+  await add.click();
+  const dialog = page.getByRole("dialog", { name: "Adicionar projeto", exact: true });
+  await page.getByLabel("Caminho da pasta").fill("/tmp/rascunho");
+  await dialog.getByRole("button", { name: "Escolher pasta…", exact: true }).click();
+  await expect(dialog.getByRole("button", { name: "Escolhendo pasta…", exact: true })).toBeDisabled();
+  await expect(dialog.getByRole("button", { name: "Cancelar", exact: true })).toBeDisabled();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeVisible();
+  await page.evaluate(() => (window as ReferenceFolderWindow).__finishReferenceFolder?.(null));
+  await expect(dialog.getByRole("button", { name: "Escolher pasta…", exact: true })).toBeFocused();
+  await expect(page.getByLabel("Caminho da pasta")).toHaveValue("/tmp/rascunho");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  const calls = await page.evaluate(() => (window as ReferenceFolderWindow).__referenceFolderCalls);
+  expect(calls.filter((call) => call === "plugin:dialog|open")).toHaveLength(1);
+  expect(calls).not.toContain("desktop_validate_project");
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(add).toBeFocused();
+});
+
+test("manual path errors stay actionable and are cleared when the path changes", async ({ page }) => {
+  await page.goto("/");
+  const add = page.getByRole("button", { name: "Adicionar projeto", exact: true });
+  await add.click();
+  const path = page.getByLabel("Caminho da pasta");
+  await path.fill("/tmp/didaticos");
+  await page.getByRole("dialog").getByRole("button", { name: "Adicionar projeto", exact: true }).click();
+  await expect(path).toHaveAttribute("aria-invalid", "true");
+  await expect(path).toHaveAttribute("aria-describedby", /project-path-error/);
+  await expect(path).toBeFocused();
+  await expect(page.getByRole("alert")).toContainText("demonstração no navegador não acessa seus arquivos");
+  await path.fill("/tmp/outro-projeto");
+  await expect(path).toHaveAttribute("aria-invalid", "false");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await page.getByRole("button", { name: "Cancelar", exact: true }).click();
+  await expect(add).toBeFocused();
+});

--- a/apps/desktop/e2e/reference-settings.spec.ts
+++ b/apps/desktop/e2e/reference-settings.spec.ts
@@ -1,0 +1,210 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+import type { DesktopSnapshot } from "../src/contracts";
+
+type SettingsTestWindow = Window & {
+  __referenceCalls: string[];
+  __referenceCopies: string[];
+  __referenceResolveCopy: (index: number) => void;
+};
+
+const referenceViews = [
+  { id: "computer-use", heading: "Uso do computador" },
+  { id: "voice", heading: "Voz" },
+  { id: "mobile", heading: "Simplicio Mobile" },
+  { id: "plugins", heading: "Plugins" },
+  { id: "permissions", heading: "Permissões do sistema" },
+];
+
+async function mockReadonlyRuntime(page: Page, snapshot: DesktopSnapshot) {
+  await page.addInitScript((snapshot) => {
+    let callbackId = 0;
+    const calls: string[] = [];
+    Object.assign(window, {
+      isTauri: true,
+      __referenceCalls: calls,
+      __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: () => {} },
+      __TAURI_INTERNALS__: {
+        transformCallback: () => ++callbackId,
+        invoke: async (command: string) => {
+          calls.push(command);
+          if (command === "plugin:event|listen") return ++callbackId;
+          if (command === "plugin:event|unlisten") return;
+          if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+          throw new Error("Unexpected readonly settings IPC: " + command);
+        },
+      },
+    });
+  }, snapshot);
+}
+
+function runtimeFixture() {
+  const snapshot = structuredClone(createDemoSnapshot("active"));
+  snapshot.source = "runtime";
+  if (snapshot.botCenter) snapshot.botCenter.source = "runtime";
+  return snapshot;
+}
+
+async function mockClipboard(page: Page) {
+  await page.addInitScript(() => {
+    const copies: string[] = [];
+    const pending: Array<() => void> = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          copies.push(text);
+          return new Promise<void>((resolve) => pending.push(resolve));
+        },
+      },
+    });
+    Object.assign(window, {
+      __referenceCopies: copies,
+      __referenceResolveCopy: (index: number) => pending[index](),
+    });
+  });
+}
+
+test("reference capability surfaces are white, distinct, and honest about unavailable effects (preview)", async ({ page }, testInfo) => {
+  const unexpected: string[] = [];
+  page.on("request", (request) => {
+    if (!/^https?:\/\/127\.0\.0\.1:\d+\//.test(request.url())) unexpected.push(request.url());
+  });
+  for (const view of referenceViews) {
+    await page.goto("/?view=" + view.id);
+    const panel = page.locator(".reference-settings-page");
+    await expect(panel.getByRole("heading", { name: view.heading, exact: true, level: 1 })).toBeVisible();
+    await expect(panel).toHaveCSS("background-color", "rgb(255, 255, 255)");
+    await expect(panel).toContainText("Prévia visual.");
+    expect(await panel.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath("reference-" + view.id + "-white.png") });
+  }
+  await expect(page.getByRole("button", { name: "Solicitar microfone", exact: true })).toBeDisabled();
+  await page.goto("/?view=voice");
+  await expect(page.getByRole("switch", { name: "Ativar ditado por voz", exact: true })).toBeDisabled();
+  await expect(page.getByRole("combobox", { name: "Modelo de voz", exact: true })).toBeDisabled();
+  await page.goto("/?view=mobile");
+  await expect(page.getByRole("button", { name: "Gerar QR code", exact: true })).toBeDisabled();
+  await expect(page.locator(".ref-pairing-empty")).toContainText("Nenhum código emitido");
+  await expect(page.locator(".ref-pairing-empty img, .ref-pairing-empty canvas")).toHaveCount(0);
+  expect(unexpected).toEqual([]);
+});
+
+test("reference settings preserve readable controls in a narrow white window (preview)", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 740 });
+  for (const view of referenceViews) {
+    await page.goto("/?view=" + view.id);
+    const panel = page.locator(".reference-settings-page");
+    await expect(panel.getByRole("heading", { name: view.heading, exact: true, level: 1 })).toBeVisible();
+    await expect(panel).toHaveCSS("background-color", "rgb(255, 255, 255)");
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+    expect(await panel.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath("reference-" + view.id + "-narrow.png") });
+  }
+});
+
+test("plugin catalog search and evidence tabs work without pretending packages are installed (preview)", async ({ page }) => {
+  await page.goto("/?view=plugins");
+  const panel = page.locator(".reference-settings-page");
+  const search = panel.getByRole("searchbox", { name: "Buscar plugins e skills", exact: true });
+  await expect(panel.locator(".ref-plugin-card")).toHaveCount(5);
+  await search.fill("hermes");
+  await expect(panel.locator(".ref-plugin-card")).toHaveCount(1);
+  await expect(panel.getByRole("heading", { name: "Simplicio Hermes", exact: true })).toBeVisible();
+  await expect(panel.getByRole("button", { name: "Instalar Simplicio Hermes", exact: true })).toBeDisabled();
+  await search.fill("pacote-que-nao-existe");
+  await expect(panel.getByRole("heading", { name: "Nenhum resultado neste filtro", exact: true })).toBeVisible();
+  await panel.getByRole("button", { name: "Limpar busca", exact: true }).click();
+  await expect(search).toHaveValue("");
+  await panel.getByRole("button", { name: "Skills informadas", exact: true }).click();
+  await expect(panel.getByRole("button", { name: "Skills informadas", exact: true })).toHaveAttribute("aria-pressed", "true");
+  await expect(panel.getByRole("heading", { name: "Nenhuma skill informada nesta consulta", exact: true })).toBeVisible();
+  await panel.getByRole("button", { name: "Catálogo público", exact: true }).click();
+  await expect(panel.locator(".ref-plugin-card")).toHaveCount(5);
+  await panel.getByRole("button", { name: "Revisar plano MCP", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Integrações MCP", exact: true, level: 1 })).toBeVisible();
+});
+
+test("read-only evidence is escaped and refresh never dispatches unsupported setup actions (mocked IPC)", async ({ page }) => {
+  const snapshot = runtimeFixture();
+  const malicious = '<img src="https://example.test/secret" onerror="alert(1)">';
+  snapshot.access.email = "private-person@example.test";
+  snapshot.providers[0].detail = "private-configuration-body";
+  snapshot.botCenter!.bots[0].displayName = malicious;
+  snapshot.botCenter!.bots[0].skills = ["Skill de teste", malicious];
+  snapshot.botCenter!.computer.available = true;
+  await mockReadonlyRuntime(page, snapshot);
+  const external: string[] = [];
+  page.on("request", (request) => { if (request.url().startsWith("https://example.test/")) external.push(request.url()); });
+  await page.goto("/?view=orchestration");
+  const panel = page.locator(".reference-settings-page");
+  await expect(panel.getByText(malicious, { exact: true })).toBeVisible();
+  await expect(panel.locator("img, iframe, script")).toHaveCount(0);
+  await expect(panel).not.toContainText("private-person@example.test");
+  await expect(panel).not.toContainText("private-configuration-body");
+  const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
+  await sidebar.getByRole("button", { name: "Plugins", exact: true }).click();
+  await panel.getByRole("button", { name: "Skills informadas", exact: true }).click();
+  await expect(panel.getByText("Skill de teste", { exact: true })).toBeVisible();
+  await expect(panel.getByText(malicious, { exact: true })).toBeVisible();
+  await sidebar.getByRole("button", { name: "Permissões do sistema", exact: true }).click();
+  await expect(panel.getByRole("button", { name: "Solicitar microfone", exact: true })).toBeDisabled();
+  await panel.getByRole("button", { name: "Solicitar microfone", exact: true }).evaluate((button) => (button as HTMLButtonElement).click());
+  await panel.getByRole("button", { name: "Atualizar consulta do Runtime", exact: true }).click();
+  await expect.poll(() => page.evaluate(() => (window as SettingsTestWindow).__referenceCalls.filter((command) => command === "refresh_desktop_snapshot").length)).toBe(1);
+  const calls = await page.evaluate(() => (window as SettingsTestWindow).__referenceCalls);
+  expect(calls.every((command) => ["desktop_snapshot", "refresh_desktop_snapshot", "plugin:event|listen", "plugin:event|unlisten"].includes(command))).toBe(true);
+  expect(external).toEqual([]);
+});
+
+test("command copy has a finite wait, no automatic retry, and no late success claim (mocked clipboard)", async ({ page }) => {
+  await page.clock.install();
+  await mockClipboard(page);
+  await page.goto("/?view=quick-commands");
+  const button = page.getByRole("button", { name: "Copiar Versão do Runtime", exact: true });
+  await button.click();
+  await expect(button).toBeDisabled();
+  await button.evaluate((element) => (element as HTMLButtonElement).click());
+  expect(await page.evaluate(() => (window as SettingsTestWindow).__referenceCopies)).toEqual(["simplicio version"]);
+  await page.clock.fastForward(4001);
+  await expect(page.getByRole("status").filter({ hasText: "Não foi possível confirmar a cópia." })).toBeVisible();
+  await expect(button).toBeEnabled();
+  await page.clock.fastForward(4001);
+  expect(await page.evaluate(() => (window as SettingsTestWindow).__referenceCopies)).toHaveLength(1);
+  await button.click();
+  await page.evaluate(() => (window as SettingsTestWindow).__referenceResolveCopy(0));
+  await expect(button).toHaveText("Copiando…");
+  await expect(button).toBeDisabled();
+  await page.evaluate(() => (window as SettingsTestWindow).__referenceResolveCopy(1));
+  await expect(button).toHaveText("Copiado");
+  await expect(page.getByRole("status").filter({ hasText: "Comando copiado. Nenhum comando foi executado." })).toBeVisible();
+});
+
+test("leaving a pending copy ignores its completion and does not carry a spinner into the next visit", async ({ page }) => {
+  await mockClipboard(page);
+  await page.goto("/?view=quick-commands");
+  const copy = page.getByRole("button", { name: "Copiar Versão do Runtime", exact: true });
+  await copy.click();
+  await expect(copy).toBeDisabled();
+  const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
+  await sidebar.getByRole("button", { name: "Voz", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Voz", exact: true, level: 1 })).toBeVisible();
+  await page.evaluate(() => (window as SettingsTestWindow).__referenceResolveCopy(0));
+  await expect(page.locator(".reference-settings-page")).not.toContainText("Copiado");
+  await sidebar.getByRole("button", { name: "Comandos rápidos", exact: true }).click();
+  await expect(copy).toBeEnabled();
+  await expect(copy).toHaveText("Copiar");
+  expect(await page.evaluate(() => (window as SettingsTestWindow).__referenceCopies)).toHaveLength(1);
+});
+
+test("task source details are keyboard-operable without saving a fake connection preference", async ({ page }) => {
+  await page.goto("/?view=task-sources");
+  const summary = page.locator(".ref-source-details summary").filter({ hasText: "Linear" });
+  await summary.focus();
+  await page.keyboard.press("Enter");
+  const details = page.locator(".ref-source-details").filter({ has: page.locator("summary").filter({ hasText: "Linear" }) });
+  await expect(details).toHaveAttribute("open", "");
+  await expect(details.getByRole("switch", { name: "Mostrar tarefas de Linear", exact: true })).toBeDisabled();
+  await details.getByRole("button", { name: "Ver conexão do serviço", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Integrações de serviços", exact: true, level: 1 })).toBeVisible();
+});

--- a/apps/desktop/e2e/reference-setup-recovery.spec.ts
+++ b/apps/desktop/e2e/reference-setup-recovery.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+type RecoveryWindow = Window & { __referenceRecoveryCalls: string[] };
+
+async function prepareRecovery(page: Page, failure: string) {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot, failure }) => {
+    const calls: string[] = [];
+    Object.assign(window, { __referenceRecoveryCalls: calls, __TAURI_INTERNALS__: {
+      invoke: async (command: string) => {
+        calls.push(command);
+        if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+        if (command === "desktop_plan_integrations") return {
+          schema: "simplicio.desktop-integration-plan/v1", source: "runtime",
+          planDigest: "sha256:" + "a".repeat(64),
+          changes: [{ label: "codex", exists: false, changed: true }],
+        };
+        if (command === "desktop_repair_providers") {
+          if (failure === "verification_failed") return snapshot;
+          throw failure;
+        }
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:event|unlisten") return;
+        throw "unexpected_reference_recovery_command";
+      },
+    } });
+  }, { snapshot, failure });
+  await page.goto("/?view=setup");
+  await page.getByRole("button", { name: "Configurar Simplicio", exact: true }).click();
+  await page.getByRole("checkbox", { name: /Autorizo o Runtime/ }).check();
+  await page.getByRole("button", { name: "Instalar e conectar", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Não foi possível concluir.", exact: true })).toBeVisible();
+}
+
+async function count(page: Page, command: string) {
+  return page.evaluate((command) => (window as RecoveryWindow).__referenceRecoveryCalls.filter((call) => call === command).length, command);
+}
+
+for (const failure of ["integration_install_timeout", "integration_install_busy", "integration_install_applied_snapshot_unavailable", "verification_failed"]) {
+  test(`${failure} stays read-only across Setup, Providers and diagnostic refresh (mocked IPC)`, async ({ page }) => {
+    await prepareRecovery(page, failure);
+    await expect(page.getByRole("button", { name: "Revisar novamente", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Instalar e conectar", exact: true })).toHaveCount(0);
+    const confirmedReceipt = failure === "integration_install_applied_snapshot_unavailable" || failure === "verification_failed";
+    await expect(page.getByRole("progressbar")).toHaveAttribute("value", confirmedReceipt ? "3" : "2");
+    const diagnostic = page.getByRole("button", { name: confirmedReceipt ? "Atualizar diagnóstico" : "Abrir diagnóstico", exact: true });
+    await expect(diagnostic).toBeEnabled();
+    expect(await count(page, "desktop_repair_providers")).toBe(1);
+    const plans = await count(page, "desktop_plan_integrations");
+    await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+    await page.getByRole("button", { name: "Integrações MCP", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Integrações MCP", exact: true })).toBeVisible();
+    const integration = page.getByRole("region", { name: "Configuração do MCP", exact: true });
+    await expect(integration.getByRole("button", { name: "Revisar configuração MCP", exact: true })).toBeDisabled();
+    await expect(integration.getByRole("button", { name: "Aplicar configuração MCP", exact: true })).toHaveCount(0);
+    await expect(integration.getByRole("checkbox", { name: /Autorizo o Runtime/ })).toHaveCount(0);
+    const refreshes = await count(page, "refresh_desktop_snapshot");
+    await page.getByRole("button", { name: "Verificar", exact: true }).click();
+    await expect.poll(() => count(page, "refresh_desktop_snapshot")).toBeGreaterThan(refreshes);
+    await expect(page.getByRole("button", { name: "Verificar", exact: true })).toBeEnabled();
+    await expect(integration.getByRole("button", { name: "Revisar configuração MCP", exact: true })).toBeDisabled();
+    const diagnosticRefreshes = await count(page, "refresh_desktop_snapshot");
+    await integration.getByRole("button", { name: "Atualizar diagnóstico", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Runtime e diagnóstico", exact: true })).toBeVisible();
+    await expect.poll(() => count(page, "refresh_desktop_snapshot")).toBeGreaterThan(diagnosticRefreshes);
+    await page.getByRole("button", { name: "Integrações MCP", exact: true }).click();
+    await expect(integration.getByRole("button", { name: "Revisar configuração MCP", exact: true })).toBeDisabled();
+    await expect(integration.getByRole("button", { name: "Aplicar configuração MCP", exact: true })).toHaveCount(0);
+    expect(await count(page, "desktop_plan_integrations")).toBe(plans);
+    await page.getByRole("button", { name: "Instalação guiada", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Configurar Simplicio", exact: true })).toBeDisabled();
+    await expect(page.getByRole("button", { name: confirmedReceipt ? "Atualizar diagnóstico" : "Abrir diagnóstico", exact: true })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Agora não", exact: true })).toBeEnabled();
+    await expect(page.getByRole("alert")).toBeVisible();
+    expect(await count(page, "desktop_plan_integrations")).toBe(plans);
+    expect(await count(page, "desktop_repair_providers")).toBe(1);
+  });
+}
+
+for (const failure of ["integration_plan_changed_review_again", "integration_install_not_started"]) {
+  test(`${failure} requires fresh plans and new consent across Setup and Providers (mocked IPC)`, async ({ page }) => {
+    await prepareRecovery(page, failure);
+    await page.getByRole("button", { name: "Revisar novamente", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Tudo pronto para revisar.", exact: true })).toBeVisible();
+    await expect(page.getByRole("checkbox", { name: /Autorizo o Runtime/ })).not.toBeChecked();
+    await expect(page.getByRole("button", { name: "Instalar e conectar", exact: true })).toBeDisabled();
+    expect(await count(page, "desktop_repair_providers")).toBe(1);
+    expect(await count(page, "desktop_plan_integrations")).toBe(2);
+    await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+    await page.getByRole("button", { name: "Integrações MCP", exact: true }).click();
+    const integration = page.getByRole("region", { name: "Configuração do MCP", exact: true });
+    await expect(integration.getByRole("button", { name: "Revisar configuração MCP", exact: true })).toBeEnabled();
+    await integration.getByRole("button", { name: "Revisar configuração MCP", exact: true }).click();
+    await expect(integration.getByRole("checkbox", { name: /Autorizo o Runtime/ })).not.toBeChecked();
+    await expect(integration.getByRole("button", { name: "Aplicar configuração MCP", exact: true })).toBeDisabled();
+    expect(await count(page, "desktop_plan_integrations")).toBe(3);
+    expect(await count(page, "desktop_repair_providers")).toBe(1);
+    await page.getByRole("button", { name: "Instalação guiada", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Configurar Simplicio", exact: true })).toBeEnabled();
+    await page.getByRole("button", { name: "Configurar Simplicio", exact: true }).click();
+    await expect(page.getByRole("checkbox", { name: /Autorizo o Runtime/ })).not.toBeChecked();
+    await expect(page.getByRole("button", { name: "Instalar e conectar", exact: true })).toBeDisabled();
+    expect(await count(page, "desktop_plan_integrations")).toBe(4);
+    expect(await count(page, "desktop_repair_providers")).toBe(1);
+  });
+}

--- a/apps/desktop/e2e/reference-setup.spec.ts
+++ b/apps/desktop/e2e/reference-setup.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+type ReferenceSetupWindow = Window & {
+  __referenceApplyCount: number;
+  __completeReferenceApply?: () => void;
+};
+
+test("guided setup keeps progress and consent-controlled actions visible in a short window (mocked IPC)", async ({ page }, testInfo) => {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot }) => {
+    let applied = false;
+    Object.assign(window, { __referenceApplyCount: 0, __TAURI_INTERNALS__: {
+      invoke: async (command: string) => {
+        if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+        if (command === "desktop_plan_integrations") return {
+          schema: "simplicio.desktop-integration-plan/v1", source: "runtime",
+          planDigest: "sha256:" + (applied ? "b" : "a").repeat(64),
+          changes: Array.from({ length: 32 }, (_, index) => ({
+            label: "client-" + String(index + 1).padStart(2, "0"), exists: applied, changed: !applied,
+          })),
+        };
+        if (command === "desktop_repair_providers") {
+          const current = window as ReferenceSetupWindow;
+          current.__referenceApplyCount++;
+          await new Promise<void>((resolve) => { current.__completeReferenceApply = resolve; });
+          applied = true;
+          return snapshot;
+        }
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:event|unlisten") return;
+        throw "unexpected_reference_setup_command";
+      },
+    } });
+  }, { snapshot });
+  await page.setViewportSize({ width: 960, height: 600 });
+  await page.goto("/?view=setup");
+  await page.getByRole("button", { name: "Configurar Simplicio", exact: true }).click();
+  const apply = page.getByRole("button", { name: "Instalar e conectar", exact: true });
+  const progress = page.getByRole("progressbar");
+  await expect(apply).toBeInViewport();
+  await expect(progress).toBeInViewport();
+  await expect(apply).toBeDisabled();
+  await expect(page.getByRole("heading", { name: "Tudo pronto para revisar." })).toBeFocused();
+  expect(await page.evaluate(() => (window as ReferenceSetupWindow).__referenceApplyCount)).toBe(0);
+  await page.screenshot({ path: testInfo.outputPath("setup-review.png") });
+
+  const review = page.getByRole("button", { name: "Revisar destinos", exact: true });
+  await expect(review).toBeInViewport();
+  await review.click();
+  await expect(page.getByRole("heading", { name: "O que será configurado", exact: true })).toBeInViewport();
+  await expect(page.getByRole("heading", { name: "O que será configurado", exact: true })).toBeFocused();
+  await expect(page.getByRole("checkbox", { name: /Autorizo o Runtime/ })).not.toBeChecked();
+  await expect(apply).toBeDisabled();
+  expect(await page.evaluate(() => (window as ReferenceSetupWindow).__referenceApplyCount)).toBe(0);
+  await page.getByRole("checkbox", { name: /Autorizo o Runtime/ }).check();
+  await expect(progress).toBeInViewport();
+  await expect(apply).toBeInViewport();
+  await apply.click();
+  await expect(page.getByRole("heading", { name: "Configurando o Simplicio…" })).toBeVisible();
+  await expect(progress).toHaveAttribute("value", "2");
+  await expect(page.getByRole("button", { name: "Voltar ao app", exact: true })).toBeDisabled();
+  const details = page.getByRole("button", { name: "Mostrar detalhes", exact: true });
+  await expect(details).toBeInViewport();
+  await details.click();
+  await expect(page.getByRole("region", { name: "Detalhes da configuração", exact: true })).toBeInViewport();
+  await expect(progress).toBeInViewport();
+  await page.screenshot({ path: testInfo.outputPath("setup-running.png") });
+
+  await page.evaluate(() => (window as ReferenceSetupWindow).__completeReferenceApply?.());
+  await expect(page.getByRole("heading", { name: "Configuração concluída." })).toBeFocused();
+  await expect(progress).toHaveAttribute("value", "4");
+  await expect(page.getByRole("button", { name: "Abrir Simplicio", exact: true })).toBeInViewport();
+  expect(await page.evaluate(() => (window as ReferenceSetupWindow).__referenceApplyCount)).toBe(1);
+});

--- a/apps/desktop/e2e/reference-shell.spec.ts
+++ b/apps/desktop/e2e/reference-shell.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+test("narrow navigation overlays the workspace and keeps keyboard focus inside until dismissed", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 740 });
+  await page.goto("/");
+  await expect(page.getByRole("contentinfo", { name: "Estado do Simplicio", exact: true }).getByText("Demonstração", { exact: true })).toBeVisible();
+  const content = page.getByRole("main");
+  const initialWidth = (await content.boundingBox())?.width;
+  expect(initialWidth).toBeGreaterThan(300);
+  const expand = page.getByRole("button", { name: "Expandir barra lateral", exact: true });
+  await expand.click();
+  await expect.poll(async () => (await content.boundingBox())?.width).toBe(initialWidth);
+  const drawer = page.getByRole("dialog", { name: "Espaço de trabalho", exact: true });
+  await expect(drawer).toHaveAttribute("aria-modal", "true");
+  await expect(drawer.getByText("Simplicio", { exact: true })).toBeVisible();
+  await expect(drawer.getByText("Atividade", { exact: true })).toBeVisible();
+  await expect(drawer.getByRole("searchbox")).toBeFocused();
+  await expect(page.locator(".workspace")).toHaveAttribute("inert", "");
+  await page.screenshot({ path: testInfo.outputPath("narrow-navigation.png") });
+
+  await drawer.getByRole("button", { name: "Início do Simplicio", exact: true }).focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(drawer.getByRole("button", { name: "Ver atalhos", exact: true })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(drawer.getByRole("button", { name: "Início do Simplicio", exact: true })).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(drawer).toHaveCount(0);
+  await expect(expand).toBeFocused();
+  await expect(page.locator(".workspace")).not.toHaveAttribute("inert", "");
+
+  await page.keyboard.press("Control+k");
+  const search = drawer.getByRole("searchbox");
+  await expect(search).toBeFocused();
+  await search.fill("Atividade");
+  await search.press("ArrowDown");
+  await expect(drawer.getByRole("button", { name: "Atividade", exact: true })).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(drawer).toHaveCount(0);
+  await expect(content.getByRole("heading", { name: "Atividade", exact: true })).toBeVisible();
+  await expect(content).toBeFocused();
+
+  await expand.click();
+  await page.getByRole("button", { name: "Fechar navegação", exact: true }).click({ position: { x: 374, y: 240 } });
+  await expect(drawer).toHaveCount(0);
+  await expect(expand).toBeFocused();
+
+  await expand.click();
+  await drawer.getByRole("button", { name: "Adicionar projeto à lista", exact: true }).click();
+  await expect(drawer).toHaveCount(0);
+  const projectDialog = page.getByRole("dialog", { name: "Adicionar projeto", exact: true });
+  await expect(projectDialog.getByRole("button", { name: "Escolher pasta…", exact: true })).toBeFocused();
+  await projectDialog.getByRole("button", { name: "Cancelar", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Adicionar projeto à lista", exact: true })).toBeFocused();
+});
+
+test("the workbench supports skipping navigation and collapses safely when resized", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Simplicio", exact: true, level: 1 })).toBeVisible();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("link", { name: "Ir para o conteúdo", exact: true })).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("main")).toBeFocused();
+
+  await page.setViewportSize({ width: 768, height: 700 });
+  await expect(page.getByRole("complementary", { name: "Espaço de trabalho" }).getByText("Atividade", { exact: true })).toBeVisible();
+  await page.setViewportSize({ width: 720, height: 700 });
+  await expect(page.getByRole("button", { name: "Expandir barra lateral", exact: true })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await page.keyboard.press("Control+k");
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("complementary", { name: "Espaço de trabalho" })).toBeVisible();
+  await expect(page.locator(".workspace")).not.toHaveAttribute("inert", "");
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("the status bar separates configuration records from confirmed MCP connections (mocked IPC)", async ({ page }) => {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  snapshot.providers = snapshot.providers.slice(0, 2).map((provider) => ({
+    ...provider, state: "connected", installState: "installed", registrationState: "registered",
+    handshakeState: "unverified", freshness: "current",
+  }));
+  await page.addInitScript((snapshot) => {
+    Object.assign(window, { __TAURI_INTERNALS__: { invoke: async (command: string) => {
+      if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+      if (command === "plugin:event|listen") return 1;
+      if (command === "plugin:event|unlisten") return;
+      throw "unexpected_reference_status_command";
+    } } });
+  }, snapshot);
+  await page.goto("/");
+  const status = page.getByRole("contentinfo", { name: "Estado do Simplicio", exact: true });
+  await expect(status).toContainText("0 MCP confirmados");
+  await expect(status).toContainText("2 registros detectados");
+  await expect(status).not.toContainText("MCP ativos");
+  const connection = status.getByRole("button", { name: /0 MCP confirmados/ });
+  await expect(connection).toHaveAttribute("title", /não prova que o cliente está desconectado/);
+  await connection.click();
+  await expect(page.getByRole("heading", { name: "Integrações MCP", exact: true })).toBeVisible();
+});

--- a/apps/desktop/e2e/runtime-integration.spec.ts
+++ b/apps/desktop/e2e/runtime-integration.spec.ts
@@ -161,7 +161,8 @@ test("guided setup follows reviewed Runtime operations without fake progress or 
   await expect(page.getByRole("heading", { name: "Configurando o Simplicio…" })).toBeVisible();
   await expect(page.getByRole("progressbar")).toHaveAttribute("value", "2");
   await expect(page.getByRole("button", { name: "Voltar ao app" })).toBeDisabled();
-  await expect(page.getByRole("status")).toContainText("não oferece cancelamento seguro");
+  await expect(page.getByRole("status")).toContainText("Instalar e registrar o MCP");
+  await expect(page.getByText(/Esta operação não oferece cancelamento seguro depois de iniciada/)).toBeVisible();
   await page.getByRole("button", { name: "Mostrar detalhes" }).click();
   await expect(page.getByRole("region", { name: "Detalhes da configuração" })).toContainText(`sha256:${"a".repeat(64)}`);
   await page.screenshot({ path: testInfo.outputPath("setup-progress.png"), fullPage: true });
@@ -206,8 +207,10 @@ test("a failed final verification cannot turn an applied plan into a success scr
   await page.getByRole("button", { name: "Instalar e conectar" }).click();
   await expect(page.getByRole("alert")).toContainText("o plano foi aplicado, mas a verificação final falhou", { ignoreCase: true });
   await expect(page.getByRole("progressbar")).toHaveAttribute("value", "3");
-  await page.getByRole("button", { name: "Abrir diagnóstico" }).click();
+  await expect(page.getByRole("button", { name: "Revisar novamente" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Atualizar diagnóstico" }).click();
   await expect(page.getByRole("heading", { name: "Runtime e diagnóstico", exact: true })).toBeVisible();
+  expect(await calls(page, "desktop_repair_providers")).toHaveLength(1);
 });
 
 test("login never bypasses inactive or unknown entitlement into guided installation (mocked IPC)", async ({ browser, baseURL }) => {

--- a/apps/desktop/e2e/setup-post-apply-verification.spec.ts
+++ b/apps/desktop/e2e/setup-post-apply-verification.spec.ts
@@ -97,12 +97,8 @@ for (const state of ["pending", "absent", "missing", "duplicate", "wrong-source"
     await expect(page.getByRole("region", { name: "Detalhes da configuração", exact: true })).toContainText("Conferência dos destinos: ainda não confirmada.");
     expect(await commandCount(page, "desktop_repair_providers")).toBe(1);
     expect(await commandCount(page, "desktop_plan_integrations")).toBe(2);
-    if (state === "pending" || state === "stable-pending") {
-      await page.getByRole("button", { name: "Revisar novamente", exact: true }).click();
-      await expect(page.getByRole("checkbox", { name: /Autorizo o Runtime/ })).not.toBeChecked();
-      await expect(page.getByRole("button", { name: "Instalar e conectar", exact: true })).toBeDisabled();
-      expect(await commandCount(page, "desktop_repair_providers")).toBe(1);
-    }
+    await expect(page.getByRole("button", { name: "Revisar novamente", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Atualizar diagnóstico", exact: true })).toBeEnabled();
   });
 }
 

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.8.39",
       "dependencies": {
         "@tauri-apps/api": "2.11.1",
+        "@tauri-apps/plugin-dialog": "2.7.3",
         "react": "19.2.8",
         "react-dom": "19.2.8"
       },
@@ -551,6 +552,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.3.tgz",
+      "integrity": "sha512-CRgE+7TP4tvq9MjBU6f04NLTFIqVMLKHk3hAqlhil00ngK9ACTrXPH3oHpKMProxILodd3YjBoKbMwSI4IEcfA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@types/chai": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "2.11.1",
+    "@tauri-apps/plugin-dialog": "2.7.3",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2028,6 +2028,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2508,6 +2509,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,6 +2838,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
 ]
 
 [[package]]
@@ -3171,6 +3197,64 @@ dependencies = [
  "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4165,6 +4249,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4196,11 +4289,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4234,6 +4344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,6 +4360,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4258,10 +4380,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4276,6 +4410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4426,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4300,6 +4446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,6 +4462,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,3 +16,4 @@ tauri-build = { version = "2.6.3", features = [] }
 serde_json = "1"
 sha2 = "0.10"
 tauri = { version = "2.11.5", features = [] }
+tauri-plugin-dialog = "=2.7.3"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Capability mínima da janela principal do Simplicio Desktop",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "dialog:allow-open"]
 }

--- a/apps/desktop/src-tauri/src/auth_access.rs
+++ b/apps/desktop/src-tauri/src/auth_access.rs
@@ -1,0 +1,253 @@
+//! Fresh, auth-only access guard for read-only Desktop queries.
+//! The caller owns process deadlines; this does not supervise filesystem scans.
+use serde_json::Value;
+
+const UNVERIFIED: &str = "desktop_access_unverified";
+const AUTH_STATUS_ARGS: [&str; 3] = ["auth", "status", "--json"];
+
+/// Query once per invocation. No snapshot fallback, cached permit, or retry.
+pub fn require_fresh(query: impl FnOnce(&[&str]) -> Result<Value, String>) -> Result<(), String> {
+    let status = query(&AUTH_STATUS_ARGS).map_err(safe_query_failure)?;
+    require_explicit_active(&status)
+}
+
+fn require_explicit_active(status: &Value) -> Result<(), String> {
+    // The public legacy fixture establishes this positive contract only.
+    // Unknown/negative states are not evidence of an inactive subscription:
+    // without a documented negative auth-status payload, keep them unverified.
+    if status.get("ok").and_then(Value::as_bool) != Some(true)
+        || status.pointer("/identity/status").and_then(Value::as_str) != Some("active")
+        || status
+            .pointer("/entitlement/status")
+            .and_then(Value::as_str)
+            != Some("active")
+        || status
+            .pointer("/entitlement/active")
+            .and_then(Value::as_bool)
+            != Some(true)
+        || status.get("error").is_some_and(|error| !error.is_null())
+    {
+        return Err(UNVERIFIED.into());
+    }
+    Ok(())
+}
+
+fn safe_query_failure(error: String) -> String {
+    // Exact query-lane codes from lib.rs::runtime_failure_code(ProcessFailure).
+    // Never allow an arbitrary runtime_* prefix, suffix, stderr, or account data.
+    match error.as_str() {
+        "runtime_not_started"
+        | "runtime_query_timeout"
+        | "runtime_stdout_limit"
+        | "runtime_stderr_limit"
+        | "runtime_output_unavailable"
+        | "runtime_process_cleanup_unconfirmed" => error,
+        _ => UNVERIFIED.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::cell::Cell;
+
+    fn active() -> Value {
+        json!({
+            "ok": true,
+            "identity": { "status": "active" },
+            "entitlement": { "status": "active", "active": true }
+        })
+    }
+
+    fn check(status: Value) -> Result<(), String> {
+        require_fresh(|args| {
+            assert_eq!(args, ["auth", "status", "--json"]);
+            Ok(status)
+        })
+    }
+
+    #[test]
+    fn accepts_only_explicit_active_with_one_fixed_read_only_query() {
+        let calls = Cell::new(0);
+        assert_eq!(
+            require_fresh(|args| {
+                calls.set(calls.get() + 1);
+                assert_eq!(args, ["auth", "status", "--json"]);
+                Ok(active())
+            }),
+            Ok(())
+        );
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn rejects_missing_fields_and_nonobject_payloads() {
+        for payload in [
+            Value::Null,
+            json!({}),
+            json!([]),
+            json!(true),
+            json!("active"),
+        ] {
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+        for key in ["ok", "identity", "entitlement"] {
+            let mut payload = active();
+            payload.as_object_mut().unwrap().remove(key);
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+        for (parent, key) in [
+            ("identity", "status"),
+            ("entitlement", "status"),
+            ("entitlement", "active"),
+        ] {
+            let mut payload = active();
+            payload[parent].as_object_mut().unwrap().remove(key);
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_types_without_coercion() {
+        for (pointer, wrong) in [
+            ("/ok", json!("true")),
+            ("/ok", json!(1)),
+            ("/identity", json!("active")),
+            ("/identity/status", json!(true)),
+            ("/identity/status", json!(["active"])),
+            ("/entitlement", json!([])),
+            ("/entitlement/status", json!(true)),
+            ("/entitlement/status", json!({"active": true})),
+            ("/entitlement/active", json!("true")),
+            ("/entitlement/active", json!(1)),
+        ] {
+            let mut payload = active();
+            *payload.pointer_mut(pointer).unwrap() = wrong;
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+        for pointer in [
+            "/ok",
+            "/identity/status",
+            "/entitlement/status",
+            "/entitlement/active",
+        ] {
+            let mut payload = active();
+            *payload.pointer_mut(pointer).unwrap() = Value::Null;
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+    }
+
+    #[test]
+    fn unknown_status_cannot_be_promoted_by_an_active_flag() {
+        for status in ["unknown", "error", "unavailable", "", "ACTIVE", "active "] {
+            let mut identity = active();
+            identity["identity"]["status"] = json!(status);
+            assert_eq!(check(identity), Err(UNVERIFIED.into()));
+            for flag in [false, true] {
+                let mut entitlement = active();
+                entitlement["entitlement"]["status"] = json!(status);
+                entitlement["entitlement"]["active"] = json!(flag);
+                assert_eq!(check(entitlement), Err(UNVERIFIED.into()));
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_contradictory_success_and_error_states() {
+        let mut inactive_flag = active();
+        inactive_flag["entitlement"]["active"] = json!(false);
+        assert_eq!(check(inactive_flag), Err(UNVERIFIED.into()));
+        let mut unsuccessful = active();
+        unsuccessful["ok"] = json!(false);
+        assert_eq!(check(unsuccessful), Err(UNVERIFIED.into()));
+        let mut with_error = active();
+        with_error["error"] = json!({"message": "private diagnostic, not UI text"});
+        assert_eq!(check(with_error), Err(UNVERIFIED.into()));
+    }
+
+    #[test]
+    fn undocumented_negative_statuses_remain_unverified_not_subscription_denials() {
+        for status in ["revoked", "expired", "signed_out", "inactive", "denied"] {
+            let mut payload = active();
+            payload["identity"]["status"] = json!(status);
+            payload["entitlement"]["status"] = json!(status);
+            payload["entitlement"]["active"] = json!(false);
+            assert_eq!(check(payload), Err(UNVERIFIED.into()));
+        }
+    }
+
+    #[test]
+    fn preserves_only_exact_safe_query_process_failure_codes() {
+        for code in [
+            "runtime_not_started",
+            "runtime_query_timeout",
+            "runtime_stdout_limit",
+            "runtime_stderr_limit",
+            "runtime_output_unavailable",
+            "runtime_process_cleanup_unconfirmed",
+        ] {
+            let calls = Cell::new(0);
+            let result = require_fresh(|args| {
+                calls.set(calls.get() + 1);
+                assert_eq!(args, ["auth", "status", "--json"]);
+                Err(code.into())
+            });
+            assert_eq!(result, Err(code.into()));
+            assert_eq!(calls.get(), 1);
+        }
+    }
+
+    #[test]
+    fn drops_raw_errors_pii_like_text_unknown_prefixes_and_nonquery_codes() {
+        for error in [
+            "",
+            "person@example.test /private/test-path",
+            "runtime_arbitrary_private_detail",
+            "runtime_query_timeout: private diagnostic",
+            "runtime_query_timeout\nprivate diagnostic",
+            " runtime_not_started",
+            "runtime_not_started ",
+            "runtime_oauth_timeout",
+            "runtime_install_timeout",
+            "desktop_access_not_active",
+            "Simplicio Runtime devolveu JSON inválido",
+        ] {
+            assert_eq!(require_fresh(|_| Err(error.into())), Err(UNVERIFIED.into()));
+        }
+    }
+
+    #[test]
+    fn does_not_cache_active_access_across_a_later_revocation() {
+        let mut revoked = active();
+        revoked["identity"]["status"] = json!("revoked");
+        revoked["entitlement"]["active"] = json!(false);
+        let mut responses = [active(), revoked].into_iter();
+        let calls = Cell::new(0);
+        let mut query = |args: &[&str]| {
+            calls.set(calls.get() + 1);
+            assert_eq!(args, ["auth", "status", "--json"]);
+            Ok(responses.next().expect("one fresh response per query"))
+        };
+        assert_eq!(require_fresh(&mut query), Ok(()));
+        assert_eq!(require_fresh(&mut query), Err(UNVERIFIED.into()));
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[test]
+    fn does_not_reuse_success_when_a_later_query_fails() {
+        let mut responses = [Ok(active()), Err("runtime_query_timeout".into())].into_iter();
+        let mut calls = 0;
+        let mut query = |args: &[&str]| {
+            calls += 1;
+            assert_eq!(args, ["auth", "status", "--json"]);
+            responses.next().unwrap()
+        };
+        assert_eq!(require_fresh(&mut query), Ok(()));
+        assert_eq!(
+            require_fresh(&mut query),
+            Err("runtime_query_timeout".into())
+        );
+        assert_eq!(calls, 2);
+    }
+}

--- a/apps/desktop/src-tauri/src/context_report.rs
+++ b/apps/desktop/src-tauri/src/context_report.rs
@@ -1,0 +1,257 @@
+//! Allowlisted context-savings projection. The Runtime, not the Desktop, reads the ledger.
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+const INVALID: &str = "context_report_invalid";
+
+pub fn query_args(repo_path: Option<&str>, default_repo: &Path) -> Result<Vec<String>, String> {
+    let input = repo_path.unwrap_or(default_repo.to_str().ok_or("context_query_invalid")?);
+    let project =
+        crate::local_projects::validate_project(input).map_err(|_| "context_query_invalid")?;
+    let path = project["path"].as_str().ok_or("context_query_invalid")?;
+    let repo = PathBuf::from(path);
+    let ledger = repo.join(".simplicio/ledger/savings-events.jsonl");
+    // A read must not initialize a ledger or follow a ledger symlink outside the selected folder.
+    let resolved = ledger
+        .canonicalize()
+        .map_err(|_| "context_ledger_unavailable")?;
+    if !resolved.is_file() || !resolved.starts_with(&repo) {
+        return Err("context_ledger_unavailable".into());
+    }
+    Ok(vec![
+        "savings".into(),
+        "report".into(),
+        "--repo".into(),
+        path.into(),
+        "--json".into(),
+    ])
+}
+
+fn count(value: &Value) -> Result<u64, String> {
+    value
+        .as_u64()
+        .filter(|n| *n <= MAX_SAFE_INTEGER)
+        .ok_or_else(|| INVALID.into())
+}
+
+pub fn project(value: Value) -> Result<Value, String> {
+    if value["schema"] != "simplicio.savings-report/v1" {
+        return Err(INVALID.into());
+    }
+    if value["ledger"]["status"] != "valid"
+        || value["ledger"]["hash_chain_valid"] != true
+        || value["ledger"]["promotable"] != true
+        || value["ledger"]["corrupt_lines"] != 0
+    {
+        return Err("context_ledger_invalid".into());
+    }
+    let ledger_events = count(&value["ledger"]["total_events"])?;
+    if ledger_events == 0 {
+        return Err("context_ledger_empty".into());
+    }
+    let context_events = count(&value["runtime_saved_total"]["events"])?;
+    let spend_events = count(&value["llm_spend_total"]["events"])?;
+    if context_events.checked_add(spend_events) != Some(ledger_events) {
+        return Err(INVALID.into());
+    }
+    let saved = count(&value["runtime_saved_total"]["saved_tokens"])?;
+    if context_events == 0 && saved != 0 {
+        return Err(INVALID.into());
+    }
+    // Runtime's all-event totals also include llm_spend. They cannot be presented as a
+    // context-only before/after comparison when those events are mixed into this ledger.
+    let comparison = if spend_events == 0 {
+        let baseline = count(&value["without_simplicio"]["paid_tokens"])?;
+        let actual = count(&value["with_simplicio"]["paid_tokens"])?;
+        Some((baseline, actual, baseline as i64 - actual as i64))
+    } else {
+        None
+    };
+
+    let mut proof = json!({"measured":0,"estimated":0,"replayed":0,"benchmark":0,"unavailable":0});
+    let breakdown = value["proof_breakdown"].as_object().ok_or(INVALID)?;
+    if breakdown.len() > 32 {
+        return Err(INVALID.into());
+    }
+    let mut proof_count = 0_u64;
+    for (kind, raw_count) in breakdown {
+        let amount = count(raw_count)?;
+        proof_count = proof_count
+            .checked_add(amount)
+            .filter(|n| *n <= ledger_events)
+            .ok_or(INVALID)?;
+        let key = match kind.as_str() {
+            "measured" => "measured",
+            "estimated" => "estimated",
+            "replayed" => "replayed",
+            "benchmark" | "benchmark-fixture" => "benchmark",
+            _ => "unavailable",
+        };
+        proof[key] = json!(proof[key].as_u64().unwrap_or(0) + amount);
+    }
+    if proof_count != ledger_events {
+        return Err(INVALID.into());
+    }
+    let tokenizers = value["tokenizer_policy"]["by_tokenizer_id"]
+        .as_object()
+        .ok_or(INVALID)?;
+    if tokenizers.len() > 256 {
+        return Err(INVALID.into());
+    }
+    let mut labeled = 0_u64;
+    let mut heuristic = 0_u64;
+    for (id, raw_count) in tokenizers {
+        let amount = count(raw_count)?;
+        labeled = labeled
+            .checked_add(amount)
+            .filter(|n| *n <= ledger_events)
+            .ok_or(INVALID)?;
+        if id.starts_with("heuristic:") {
+            heuristic += amount;
+        }
+    }
+    let unlabeled = count(&value["tokenizer_policy"]["unlabeled_estimated_events_flagged"])?;
+    if labeled.checked_add(unlabeled) != Some(ledger_events) {
+        return Err(INVALID.into());
+    }
+    let baseline_kind = match value["baseline_kind"].as_str() {
+        Some(kind @ ("measured" | "estimated" | "replayed" | "benchmark" | "mixed")) => kind,
+        Some("benchmark-fixture") => "benchmark",
+        _ => "unavailable",
+    };
+    let confidence = match value["confidence"].as_str() {
+        Some(level @ ("low" | "medium" | "high" | "measured")) => level,
+        _ => "unavailable",
+    };
+    let mut report = json!({
+        "schema":"simplicio.desktop-context-report/v1", "source":"runtime", "scope":"project_history",
+        "eventCount":context_events, "ledgerEventCount":ledger_events, "llmSpendEventCount":spend_events,
+        "savedTokens":saved,
+        "baselineTokens":comparison.map(|v|v.0), "actualTokens":comparison.map(|v|v.1),
+        "netTokens":comparison.map(|v|v.2),
+        "baselineKind":baseline_kind, "confidence":confidence,
+        "heuristicEventCount":heuristic, "unlabeledEstimateCount":unlabeled, "proof":proof,
+    });
+    let bytes = serde_json::to_vec(&report).map_err(|_| INVALID)?;
+    report["reportHash"] = json!(format!("sha256:{:x}", Sha256::digest(bytes)));
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Value {
+        json!({
+            "schema":"simplicio.savings-report/v1",
+            "ledger":{"status":"valid","hash_chain_valid":true,"promotable":true,"corrupt_lines":0,"total_events":12},
+            "runtime_saved_total":{"events":12,"saved_tokens":350}, "llm_spend_total":{"events":0},
+            "without_simplicio":{"paid_tokens":1000}, "with_simplicio":{"paid_tokens":650},
+            "baseline_kind":"mixed", "confidence":"low", "proof_breakdown":{"measured":9,"estimated":3},
+            "tokenizer_policy":{"by_tokenizer_id":{"heuristic:chars-div-4":10,"n/a-not-required":1},"unlabeled_estimated_events_flagged":1},
+            "records":[{"prompt":"private prompt","user":"private identity"}], "cost_totals":{"saved":999},
+            "source_artifacts":["/private/ledger"]
+        })
+    }
+
+    #[test]
+    fn projects_only_bounded_metrics_without_records_costs_or_paths() {
+        let report = project(fixture()).unwrap();
+        assert_eq!(report["savedTokens"], 350);
+        assert_eq!(report["netTokens"], 350);
+        assert_eq!(report["heuristicEventCount"], 10);
+        assert_eq!(report["unlabeledEstimateCount"], 1);
+        let body = report.to_string();
+        for private in [
+            "private prompt",
+            "private identity",
+            "/private/ledger",
+            "cost_totals",
+            "records",
+        ] {
+            assert!(!body.contains(private));
+        }
+        let mut changed_private = fixture();
+        changed_private["records"] = json!(["different private content"]);
+        assert_eq!(
+            report["reportHash"],
+            project(changed_private).unwrap()["reportHash"]
+        );
+    }
+
+    #[test]
+    fn mixed_llm_spend_never_masquerades_as_context_comparison() {
+        let mut input = fixture();
+        input["runtime_saved_total"]["events"] = json!(10);
+        input["llm_spend_total"]["events"] = json!(2);
+        let report = project(input).unwrap();
+        assert_eq!(report["eventCount"], 10);
+        assert_eq!(report["savedTokens"], 350);
+        assert!(report["baselineTokens"].is_null());
+        assert!(report["actualTokens"].is_null());
+        assert!(report["netTokens"].is_null());
+    }
+
+    #[test]
+    fn negative_net_is_not_clamped_to_a_positive_savings_claim() {
+        let mut input = fixture();
+        input["with_simplicio"]["paid_tokens"] = json!(1100);
+        let report = project(input).unwrap();
+        assert_eq!(report["netTokens"], -100);
+        assert_eq!(report["savedTokens"], 350); // Runtime's gross sum is distinct from the net comparison.
+    }
+
+    #[test]
+    fn rejects_invalid_ledger_unsafe_numbers_and_inconsistent_counts() {
+        for (pointer, replacement) in [
+            ("/ledger/hash_chain_valid", json!(false)),
+            ("/ledger/corrupt_lines", json!(1)),
+            (
+                "/runtime_saved_total/saved_tokens",
+                json!(MAX_SAFE_INTEGER + 1),
+            ),
+            ("/runtime_saved_total/events", json!(13)),
+            ("/proof_breakdown/estimated", json!(4)),
+            (
+                "/tokenizer_policy/by_tokenizer_id/heuristic:chars-div-4",
+                json!(12),
+            ),
+        ] {
+            let mut input = fixture();
+            *input.pointer_mut(pointer).unwrap() = replacement;
+            assert!(project(input).is_err(), "accepted {pointer}");
+        }
+    }
+
+    #[test]
+    fn query_requires_existing_ledger_and_uses_fixed_arguments() {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let repo = std::env::temp_dir().join(format!("simplicio-context-{suffix}"));
+        std::fs::create_dir_all(&repo).unwrap();
+        assert_eq!(
+            query_args(None, &repo).unwrap_err(),
+            "context_ledger_unavailable"
+        );
+        assert!(!repo.join(".simplicio").exists());
+        let ledger = repo.join(".simplicio/ledger/savings-events.jsonl");
+        std::fs::create_dir_all(ledger.parent().unwrap()).unwrap();
+        std::fs::write(&ledger, b"test fixture only").unwrap();
+        let args = query_args(None, &repo).unwrap();
+        assert_eq!(&args[..3], ["savings", "report", "--repo"]);
+        assert_eq!(args[4], "--json");
+        assert_eq!(
+            PathBuf::from(&args[3]).canonicalize().unwrap(),
+            repo.canonicalize().unwrap()
+        );
+        assert_eq!(
+            query_args(Some("--unsafe"), &repo).unwrap_err(),
+            "context_query_invalid"
+        );
+        std::fs::remove_dir_all(&repo).unwrap();
+    }
+}

--- a/apps/desktop/src-tauri/src/install_result.rs
+++ b/apps/desktop/src-tauri/src/install_result.rs
@@ -9,6 +9,11 @@ pub enum InstallFailure {
     // Command::output may fail while capturing/waiting, not only when spawning.
     // The absence of an output result does not prove there were no effects.
     OutputUnavailable,
+    NotStarted,
+    TimedOut,
+    StderrTooLarge,
+    CleanupUnconfirmed,
+    ReconciliationRequired,
     ExitCode(i32),
     NoExitCode,
     InvalidJson,
@@ -22,6 +27,11 @@ impl InstallFailure {
     pub fn public_code(&self) -> String {
         match self {
             Self::OutputUnavailable => "integration_install_output_unavailable".into(),
+            Self::NotStarted => "integration_install_not_started".into(),
+            Self::TimedOut => "integration_install_timeout".into(),
+            Self::StderrTooLarge => "integration_install_stderr_too_large".into(),
+            Self::CleanupUnconfirmed => "integration_install_cleanup_unconfirmed".into(),
+            Self::ReconciliationRequired => "integration_install_reconciliation_required".into(),
             Self::ExitCode(code) => format!("integration_install_exit_code:{code}"),
             Self::NoExitCode => "integration_install_no_exit_code".into(),
             Self::InvalidJson => "integration_install_invalid_json".into(),
@@ -30,6 +40,42 @@ impl InstallFailure {
             Self::AppliedSnapshotUnavailable => {
                 "integration_install_applied_snapshot_unavailable".into()
             }
+        }
+    }
+}
+
+/// This state survives closing/reopening the dialog, not application restart.
+/// It is not a substitute for a durable Runtime effect-reconciliation receipt.
+pub struct InstallAttempt {
+    reconciliation_required: bool,
+}
+
+impl InstallAttempt {
+    pub const fn new() -> Self {
+        Self {
+            reconciliation_required: false,
+        }
+    }
+
+    pub fn check_ready(&self) -> Result<(), InstallFailure> {
+        if self.reconciliation_required {
+            Err(InstallFailure::ReconciliationRequired)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn begin(&mut self) -> Result<(), InstallFailure> {
+        self.check_ready()?;
+        self.reconciliation_required = true;
+        Ok(())
+    }
+
+    pub fn finish(&mut self, result: &Result<(), InstallFailure>) {
+        // Only a validated applied receipt or proof that no Runtime started
+        // settles this attempt. Exit failure can still mean partially applied.
+        if matches!(result, Ok(()) | Err(InstallFailure::NotStarted)) {
+            self.reconciliation_required = false;
         }
     }
 }
@@ -85,6 +131,51 @@ mod tests {
             Err(InstallFailure::NoExitCode)
         );
         assert_eq!(validate_install_output(Some(0), &stdout), Ok(()));
+    }
+
+    #[test]
+    fn an_ambiguous_install_cannot_be_authorized_again_by_releasing_the_mutex() {
+        let lock = std::sync::Mutex::new(InstallAttempt::new());
+        {
+            let mut attempt = lock.lock().unwrap();
+            attempt.begin().unwrap();
+            attempt.finish(&Err(InstallFailure::TimedOut));
+        }
+        let mut next_dialog = lock.lock().unwrap();
+        assert_eq!(
+            next_dialog.check_ready(),
+            Err(InstallFailure::ReconciliationRequired)
+        );
+        assert_eq!(
+            next_dialog.begin(),
+            Err(InstallFailure::ReconciliationRequired)
+        );
+    }
+
+    #[test]
+    fn only_a_confirmed_receipt_or_proven_no_start_can_settle_an_attempt() {
+        for failure in [
+            InstallFailure::TimedOut,
+            InstallFailure::OutputUnavailable,
+            InstallFailure::ExitCode(1),
+            InstallFailure::NoExitCode,
+            InstallFailure::InvalidJson,
+            InstallFailure::ResponseTooLarge,
+            InstallFailure::StderrTooLarge,
+            InstallFailure::ReceiptUnconfirmed,
+            InstallFailure::CleanupUnconfirmed,
+        ] {
+            let mut attempt = InstallAttempt::new();
+            attempt.begin().unwrap();
+            attempt.finish(&Err(failure));
+            assert_eq!(attempt.begin(), Err(InstallFailure::ReconciliationRequired));
+        }
+        for result in [Ok(()), Err(InstallFailure::NotStarted)] {
+            let mut attempt = InstallAttempt::new();
+            attempt.begin().unwrap();
+            attempt.finish(&result);
+            assert!(attempt.begin().is_ok());
+        }
     }
 
     #[test]
@@ -187,6 +278,23 @@ mod tests {
             (
                 InstallFailure::OutputUnavailable,
                 "integration_install_output_unavailable",
+            ),
+            (
+                InstallFailure::NotStarted,
+                "integration_install_not_started",
+            ),
+            (InstallFailure::TimedOut, "integration_install_timeout"),
+            (
+                InstallFailure::StderrTooLarge,
+                "integration_install_stderr_too_large",
+            ),
+            (
+                InstallFailure::CleanupUnconfirmed,
+                "integration_install_cleanup_unconfirmed",
+            ),
+            (
+                InstallFailure::ReconciliationRequired,
+                "integration_install_reconciliation_required",
             ),
             (
                 InstallFailure::ExitCode(1),

--- a/apps/desktop/src-tauri/src/legacy_snapshot.rs
+++ b/apps/desktop/src-tauri/src/legacy_snapshot.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const STATUS_SCHEMA: &str = "simplicio.status/v1";
 const SAVINGS_SCHEMA: &str = "simplicio.savings-report/v1";
 const INSTALL_SCHEMA: &str = "simplicio.install-plan/v1";
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 pub fn build_legacy_snapshot(
     auth: &Value,
@@ -27,26 +28,16 @@ pub fn build_legacy_snapshot(
             .map_err(|_| "Relógio local inválido".to_string())?
             .as_secs()
     );
-    let identity_active = auth
-        .pointer("/identity/status")
-        .and_then(Value::as_str)
-        == Some("active");
-    let entitlement_status = auth
-        .pointer("/entitlement/status")
-        .and_then(Value::as_str);
-    let entitlement_active = auth
-        .pointer("/entitlement/active")
-        .and_then(Value::as_bool)
-        == Some(true);
-    let access_state = if !identity_active {
-        "signed_out"
-    } else if entitlement_status.is_none() {
-        "unknown"
-    } else if entitlement_active {
-        "active"
-    } else {
-        "inactive"
-    };
+    // Match auth_access's documented positive auth-status contract. The public
+    // snapshot states do not document negative legacy auth-status payloads;
+    // unknown, contradictory or error responses cannot imply a subscription denial.
+    let auth_error = auth.get("error").is_some_and(|error| !error.is_null());
+    let identity_active =
+        !auth_error && auth.pointer("/identity/status").and_then(Value::as_str) == Some("active");
+    let access_active = identity_active
+        && auth.pointer("/entitlement/status").and_then(Value::as_str) == Some("active")
+        && auth.pointer("/entitlement/active").and_then(Value::as_bool) == Some(true);
+    let access_state = if access_active { "active" } else { "unknown" };
 
     let runtime_version = status
         .pointer("/compiled_runtime/binary_version")
@@ -57,17 +48,19 @@ pub fn build_legacy_snapshot(
     } else {
         "healthy"
     };
-    let saved_events = savings
-        .pointer("/runtime_saved_total/events")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let saved_tokens = savings
-        .pointer("/runtime_saved_total/saved_tokens")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let provider_hit_rate = status
-        .pointer("/cache/hit_rate")
-        .and_then(Value::as_f64);
+    let saved_events = savings_count(&savings["runtime_saved_total"]["events"])?;
+    let saved_tokens = savings_count(&savings["runtime_saved_total"]["saved_tokens"])?;
+    if saved_events == 0 && saved_tokens != 0 {
+        return Err("legacy_savings_invalid".into());
+    }
+    // Share integrity, promotability, proof and counter validation with the
+    // context report. A nonzero event count alone is not a valid ledger.
+    let savings_ledger_status = if crate::context_report::project(savings.clone()).is_ok() {
+        "valid"
+    } else {
+        "unavailable"
+    };
+    let provider_hit_rate = status.pointer("/cache/hit_rate").and_then(Value::as_f64);
     let decision_runs = status
         .pointer("/cache/runs_with_decision")
         .and_then(Value::as_u64)
@@ -84,11 +77,9 @@ pub fn build_legacy_snapshot(
         "access": {
             "state": access_state,
             "identityKnown": identity_active,
-            "entitlementKnown": entitlement_status.is_some(),
+            "entitlementKnown": access_active,
             "reasonCode": match access_state {
                 "active" => "legacy_runtime_active",
-                "inactive" => "legacy_runtime_entitlement_inactive",
-                "signed_out" => "legacy_runtime_signed_out",
                 _ => "legacy_runtime_entitlement_unknown",
             },
             "checkedAt": generated_at,
@@ -116,11 +107,15 @@ pub fn build_legacy_snapshot(
             },
         },
         "savings": {
+            // This required compatibility field retains the known raw counter.
+            // savings-report/v1 is all-history, with no monthly bounds. Every
+            // legacy consumer must keep it hidden behind unavailable proof;
+            // the separate context report presents qualified historical totals.
             "monthTokens": saved_tokens,
             "monthPercent": 0,
             "estimatedUsd": Value::Null,
-            "proofKind": if saved_events > 0 { "measured" } else { "unavailable" },
-            "ledgerStatus": if saved_events > 0 { "valid" } else { "unavailable" },
+            "proofKind": "unavailable",
+            "ledgerStatus": savings_ledger_status,
             "eventCount": saved_events,
             "providerCache": {
                 "status": if provider_hit_rate.is_some() { "mixed" } else { "unknown" },
@@ -177,6 +172,13 @@ pub fn build_legacy_snapshot(
     let digest = Sha256::digest(encoded);
     snapshot["snapshotDigest"] = Value::String(format!("sha256:{digest:x}"));
     Ok(snapshot)
+}
+
+fn savings_count(value: &Value) -> Result<u64, String> {
+    value
+        .as_u64()
+        .filter(|count| *count <= MAX_SAFE_INTEGER)
+        .ok_or_else(|| "legacy_savings_invalid".into())
 }
 
 fn providers_from_install(install: &Value) -> Vec<Value> {
@@ -294,5 +296,270 @@ mod tests {
         let (auth, mut status, savings, install) = fixtures();
         status["schema"] = json!("unexpected");
         assert!(build_legacy_snapshot(&auth, &status, &savings, &install).is_err());
+    }
+
+    fn measured_savings() -> Value {
+        // Aggregate-only fixture using the public context_report contract.
+        json!({
+            "schema": SAVINGS_SCHEMA,
+            "ledger": {
+                "status": "valid", "hash_chain_valid": true, "promotable": true,
+                "corrupt_lines": 0, "total_events": 12
+            },
+            "runtime_saved_total": { "events": 12, "saved_tokens": 350 },
+            "llm_spend_total": { "events": 0 },
+            "without_simplicio": { "paid_tokens": 1000 },
+            "with_simplicio": { "paid_tokens": 650 },
+            "baseline_kind": "measured", "confidence": "measured",
+            "proof_breakdown": { "measured": 12 },
+            "tokenizer_policy": {
+                "by_tokenizer_id": { "n/a-not-required": 12 },
+                "unlabeled_estimated_events_flagged": 0
+            }
+        })
+    }
+
+    fn savings_summary(input: &Value) -> Value {
+        let (auth, status, _, install) = fixtures();
+        build_legacy_snapshot(&auth, &status, input, &install).unwrap()["savings"].clone()
+    }
+
+    #[test]
+    fn preserves_historical_totals_without_inventing_monthly_proof() {
+        for (kind, breakdown) in [
+            ("measured", json!({ "measured": 12 })),
+            ("estimated", json!({ "estimated": 12 })),
+            ("replayed", json!({ "replayed": 12 })),
+            ("mixed", json!({ "measured": 9, "estimated": 3 })),
+        ] {
+            let mut input = measured_savings();
+            input["baseline_kind"] = json!(kind);
+            input["proof_breakdown"] = breakdown;
+            let summary = savings_summary(&input);
+            assert_eq!(
+                summary["proofKind"], "unavailable",
+                "promoted {kind} history"
+            );
+            assert_eq!(summary["ledgerStatus"], "valid");
+            assert_eq!(summary["monthTokens"], 350);
+            assert_eq!(summary["eventCount"], 12);
+        }
+    }
+
+    #[test]
+    fn invalid_integrity_or_unpromotable_ledger_never_becomes_measured_or_zero() {
+        for (key, replacement) in [
+            ("status", json!("invalid")),
+            ("hash_chain_valid", json!(false)),
+            ("promotable", json!(false)),
+            ("corrupt_lines", json!(1)),
+            ("total_events", json!(13)),
+        ] {
+            let mut input = measured_savings();
+            input["ledger"][key] = replacement;
+            let summary = savings_summary(&input);
+            assert_eq!(summary["proofKind"], "unavailable", "accepted {key}");
+            assert_eq!(summary["ledgerStatus"], "unavailable");
+            assert_eq!(summary["monthTokens"], 350);
+            assert_eq!(summary["eventCount"], 12);
+        }
+    }
+
+    #[test]
+    fn absent_evidence_is_unavailable_even_with_nonzero_counters() {
+        for key in [
+            "ledger",
+            "proof_breakdown",
+            "tokenizer_policy",
+            "llm_spend_total",
+        ] {
+            let mut input = measured_savings();
+            input.as_object_mut().unwrap().remove(key);
+            let summary = savings_summary(&input);
+            assert_eq!(summary["proofKind"], "unavailable", "accepted {key}");
+            assert_eq!(summary["ledgerStatus"], "unavailable");
+            assert_eq!(summary["monthTokens"], 350);
+            assert_eq!(summary["eventCount"], 12);
+        }
+        let summary = savings_summary(&json!({
+            "schema": SAVINGS_SCHEMA,
+            "runtime_saved_total": { "events": 12, "saved_tokens": 350 }
+        }));
+        assert_eq!(summary["proofKind"], "unavailable");
+        assert_eq!(summary["ledgerStatus"], "unavailable");
+        assert_eq!(summary["monthTokens"], 350);
+    }
+
+    #[test]
+    fn unknown_or_benchmark_proof_and_missing_qualifiers_stay_unavailable() {
+        for (key, replacement) in [
+            ("baseline_kind", Value::Null),
+            ("baseline_kind", json!("future-kind")),
+            ("baseline_kind", json!("benchmark")),
+            ("confidence", Value::Null),
+            ("confidence", json!("future-confidence")),
+            ("proof_breakdown", json!({ "future-proof": 12 })),
+            ("proof_breakdown", json!({ "benchmark-fixture": 12 })),
+        ] {
+            let mut input = measured_savings();
+            input[key] = replacement;
+            let summary = savings_summary(&input);
+            assert_eq!(summary["proofKind"], "unavailable", "accepted {key}");
+            assert_eq!(summary["ledgerStatus"], "valid");
+            assert_eq!(summary["monthTokens"], 350);
+        }
+    }
+
+    #[test]
+    fn heuristic_unlabeled_or_conflicting_proof_does_not_claim_measured_savings() {
+        for (key, replacement) in [
+            ("baseline_kind", json!("estimated")),
+            ("proof_breakdown", json!({ "measured": 9, "estimated": 3 })),
+            (
+                "tokenizer_policy",
+                json!({
+                    "by_tokenizer_id": { "heuristic:chars-div-4": 12 },
+                    "unlabeled_estimated_events_flagged": 0
+                }),
+            ),
+            (
+                "tokenizer_policy",
+                json!({
+                    "by_tokenizer_id": { "n/a-not-required": 11 },
+                    "unlabeled_estimated_events_flagged": 1
+                }),
+            ),
+        ] {
+            let mut input = measured_savings();
+            input[key] = replacement;
+            let summary = savings_summary(&input);
+            assert_eq!(summary["proofKind"], "unavailable");
+            assert_eq!(summary["ledgerStatus"], "valid");
+            assert_eq!(summary["monthTokens"], 350);
+        }
+    }
+
+    #[test]
+    fn gross_net_divergence_and_mixed_llm_spend_do_not_become_unqualified_savings() {
+        for paid_tokens in [900, 1100] {
+            let mut input = measured_savings();
+            input["with_simplicio"]["paid_tokens"] = json!(paid_tokens);
+            let summary = savings_summary(&input);
+            assert_eq!(summary["proofKind"], "unavailable");
+            assert_eq!(summary["ledgerStatus"], "valid");
+            assert_eq!(summary["monthTokens"], 350);
+        }
+        let mut input = measured_savings();
+        input["runtime_saved_total"]["events"] = json!(10);
+        input["llm_spend_total"]["events"] = json!(2);
+        let summary = savings_summary(&input);
+        assert_eq!(summary["proofKind"], "unavailable");
+        assert_eq!(summary["monthTokens"], 350);
+        assert_eq!(summary["eventCount"], 10);
+    }
+
+    #[test]
+    fn missing_invalid_or_unsafe_counters_fail_instead_of_becoming_zero() {
+        let (auth, status, _, install) = fixtures();
+        for key in ["events", "saved_tokens"] {
+            let mut missing = measured_savings();
+            missing["runtime_saved_total"]
+                .as_object_mut()
+                .unwrap()
+                .remove(key);
+            assert!(build_legacy_snapshot(&auth, &status, &missing, &install).is_err());
+            for replacement in [
+                Value::Null,
+                json!(-1),
+                json!(1.5),
+                json!("12"),
+                json!(9_007_199_254_740_992_u64),
+            ] {
+                let mut input = measured_savings();
+                input["runtime_saved_total"][key] = replacement;
+                assert!(build_legacy_snapshot(&auth, &status, &input, &install).is_err());
+            }
+        }
+        let mut contradictory = measured_savings();
+        contradictory["runtime_saved_total"]["events"] = json!(0);
+        assert!(build_legacy_snapshot(&auth, &status, &contradictory, &install).is_err());
+        let (_, _, empty, _) = fixtures();
+        let summary = savings_summary(&empty);
+        assert_eq!(summary["monthTokens"], 0);
+        assert_eq!(summary["eventCount"], 0);
+        assert_eq!(summary["proofKind"], "unavailable");
+    }
+
+    #[test]
+    fn unknown_or_undocumented_auth_states_are_never_subscription_decisions() {
+        let (auth, status, savings, install) = fixtures();
+        for state in [
+            "unknown",
+            "error",
+            "unavailable",
+            "",
+            "ACTIVE",
+            "active ",
+            "revoked",
+            "expired",
+            "signed_out",
+            "inactive",
+            "denied",
+        ] {
+            for flag in [false, true] {
+                let mut input = auth.clone();
+                input["entitlement"]["status"] = json!(state);
+                input["entitlement"]["active"] = json!(flag);
+                let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+                assert_eq!(snapshot["access"]["state"], "unknown");
+                assert_eq!(snapshot["access"]["identityKnown"], true);
+                assert_eq!(snapshot["access"]["entitlementKnown"], false);
+            }
+            let mut input = auth.clone();
+            input["identity"]["status"] = json!(state);
+            let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+            assert_eq!(snapshot["access"]["state"], "unknown");
+            assert_eq!(snapshot["access"]["identityKnown"], false);
+            assert_eq!(snapshot["access"]["entitlementKnown"], false);
+        }
+    }
+
+    #[test]
+    fn contradictory_missing_or_malformed_auth_never_opens_active_access() {
+        let (auth, status, savings, install) = fixtures();
+        for key in ["identity", "entitlement"] {
+            let mut input = auth.clone();
+            input.as_object_mut().unwrap().remove(key);
+            let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+            assert_eq!(snapshot["access"]["state"], "unknown");
+            assert_eq!(snapshot["access"]["entitlementKnown"], false);
+        }
+        for (pointer, replacement) in [
+            ("/entitlement/active", json!(false)),
+            ("/entitlement/active", json!("true")),
+            ("/entitlement/active", Value::Null),
+            ("/entitlement/status", Value::Null),
+            ("/identity/status", Value::Null),
+        ] {
+            let mut input = auth.clone();
+            *input.pointer_mut(pointer).unwrap() = replacement;
+            let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+            assert_eq!(snapshot["access"]["state"], "unknown");
+            assert_eq!(snapshot["access"]["entitlementKnown"], false);
+        }
+        let mut input = auth.clone();
+        input["error"] = json!({ "message": "test-only diagnostic sentinel" });
+        let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+        assert_eq!(snapshot["access"]["state"], "unknown");
+        assert_eq!(snapshot["access"]["identityKnown"], false);
+        assert_eq!(snapshot["access"]["entitlementKnown"], false);
+        assert!(!snapshot
+            .to_string()
+            .contains("test-only diagnostic sentinel"));
+        input["error"] = Value::Null;
+        let snapshot = build_legacy_snapshot(&input, &status, &savings, &install).unwrap();
+        assert_eq!(snapshot["access"]["state"], "active");
+        assert_eq!(snapshot["access"]["identityKnown"], true);
+        assert_eq!(snapshot["access"]["entitlementKnown"], true);
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,25 +1,31 @@
 use serde_json::Value;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, Output};
 use tauri::Manager;
 
+mod auth_access;
+mod context_report;
 mod desktop_queries;
 mod install_result;
 mod legacy_snapshot;
 mod local_projects;
 #[cfg(desktop)]
 mod native_menu;
+mod project_discovery_process;
+mod project_usage;
+mod runtime_process;
 mod snapshot_exports;
 mod supervisor;
 mod token_exports;
 
-static INSTALL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static INSTALL_LOCK: std::sync::Mutex<install_result::InstallAttempt> =
+    std::sync::Mutex::new(install_result::InstallAttempt::new());
 
 #[tauri::command]
 async fn desktop_validate_project(path: String) -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        require_active_access()?;
+        require_read_access()?;
         local_projects::validate_project(&path)
     })
     .await
@@ -59,7 +65,6 @@ const MAX_SNAPSHOT_BYTES: usize = 65_536;
 const SNAPSHOT_ARGS: &[&str] = &["desktop", "snapshot", "--json"];
 const LOGIN_ARGS: &[&str] = &["login", "google", "--json"];
 const LOGOUT_ARGS: &[&str] = &["logout", "--json"];
-const SUBSCRIPTION_ARGS: &[&str] = &["desktop", "subscribe", "--json"];
 const STATUS_ARGS: &[&str] = &["desktop", "status", "--json"];
 const LEGACY_AUTH_ARGS: &[&str] = &["auth", "status", "--json"];
 const LEGACY_STATUS_ARGS: &[&str] = &["status", "--json"];
@@ -112,28 +117,45 @@ fn runtime_candidates() -> Vec<OsString> {
     )
 }
 
-fn run_runtime_output(args: &[&str]) -> Result<Output, String> {
-    for binary in runtime_candidates() {
-        match Command::new(binary)
-            .args(args)
-            .env("SIMPLICIO_DESKTOP_BRIDGE", "1")
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-        {
-            // Once a process starts, capture/wait failure must not replay an action
-            // against a different Runtime candidate: effects may already exist.
-            Ok(child) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|_| "runtime_output_unavailable".into())
-            }
-            Err(_) => continue,
-        }
+fn runtime_capture_limits(args: &[&str]) -> runtime_process::CaptureLimits {
+    if args == INSTALL_ARGS {
+        runtime_process::CaptureLimits::INSTALL
+    } else if args == LOGIN_ARGS {
+        runtime_process::CaptureLimits::OAUTH
+    } else {
+        runtime_process::CaptureLimits::QUERY
     }
+}
 
-    Err("Simplicio Runtime não encontrado".to_string())
+fn run_runtime_capture(args: &[&str]) -> Result<Output, runtime_process::ProcessFailure> {
+    let commands = runtime_candidates().into_iter().map(|binary| {
+        let mut command = Command::new(binary);
+        command.args(args).env("SIMPLICIO_DESKTOP_BRIDGE", "1");
+        command
+    });
+    runtime_process::capture_candidates(commands, runtime_capture_limits(args))
+}
+
+fn runtime_failure_code(args: &[&str], failure: runtime_process::ProcessFailure) -> String {
+    use runtime_process::{ChildState, FailureKind};
+    if failure.child_state == ChildState::Retained {
+        return "runtime_process_cleanup_unconfirmed".into();
+    }
+    match failure.kind {
+        FailureKind::Spawn => "runtime_not_started",
+        FailureKind::Deadline if args == LOGIN_ARGS => "runtime_oauth_timeout",
+        FailureKind::Deadline if args == INSTALL_ARGS => "runtime_install_timeout",
+        FailureKind::Deadline => "runtime_query_timeout",
+        FailureKind::StdoutLimit => "runtime_stdout_limit",
+        FailureKind::StderrLimit => "runtime_stderr_limit",
+        FailureKind::Capture => "runtime_output_unavailable",
+        FailureKind::CleanupPending => "runtime_process_cleanup_unconfirmed",
+    }
+    .into()
+}
+
+fn run_runtime_output(args: &[&str]) -> Result<Output, String> {
+    run_runtime_capture(args).map_err(|failure| runtime_failure_code(args, failure))
 }
 
 fn successful_output(args: &[&str]) -> Result<Output, String> {
@@ -159,11 +181,23 @@ fn run_runtime_action(args: &[&str]) -> Result<(), String> {
     successful_output(args).map(|_| ())
 }
 
-fn repair_provider_integrations() -> Result<(), String> {
-    let output = run_runtime_output(INSTALL_ARGS)
-        .map_err(|_| install_result::InstallFailure::OutputUnavailable.public_code())?;
+fn repair_provider_integrations() -> Result<(), install_result::InstallFailure> {
+    use install_result::InstallFailure;
+    use runtime_process::{ChildState, FailureKind};
+    let output = run_runtime_capture(INSTALL_ARGS).map_err(|failure| {
+        if failure.child_state == ChildState::Retained {
+            return InstallFailure::CleanupUnconfirmed;
+        }
+        match failure.kind {
+            FailureKind::Spawn => InstallFailure::NotStarted,
+            FailureKind::Deadline => InstallFailure::TimedOut,
+            FailureKind::StdoutLimit => InstallFailure::ResponseTooLarge,
+            FailureKind::StderrLimit => InstallFailure::StderrTooLarge,
+            FailureKind::Capture => InstallFailure::OutputUnavailable,
+            FailureKind::CleanupPending => InstallFailure::CleanupUnconfirmed,
+        }
+    })?;
     install_result::validate_install_output(output.status.code(), &output.stdout)
-        .map_err(|failure| failure.public_code())
 }
 
 fn require_active_access() -> Result<(), String> {
@@ -182,11 +216,51 @@ fn integration_plan_from_runtime() -> Result<Value, String> {
     desktop_queries::project_install_plan(run_runtime_json(LEGACY_INSTALL_ARGS)?)
 }
 
+fn require_read_access() -> Result<(), String> {
+    // A fresh Runtime authorization query, not a cached snapshot or installation inventory.
+    auth_access::require_fresh(run_runtime_json)
+}
+
 #[tauri::command]
 async fn desktop_plan_integrations() -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(integration_plan_from_runtime)
         .await
         .map_err(|_| "integration_plan_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_usage_projects() -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        require_read_access()?;
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .ok_or("project_discovery_unavailable")?;
+        let configured = std::env::var_os("SIMPLICIO_DESKTOP_REPO").map(PathBuf::from);
+        let executable = std::env::current_exe().map_err(|_| "project_discovery_unavailable")?;
+        project_discovery_process::discover(&home, configured.as_deref(), &executable)
+    })
+    .await
+    .map_err(|_| "project_discovery_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_context_report(repo_path: Option<String>) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        require_read_access()?;
+        let default_repo = std::env::var_os("SIMPLICIO_DESKTOP_REPO")
+            .or_else(|| std::env::var_os("HOME"))
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .ok_or("context_query_invalid")?;
+        let args = context_report::query_args(repo_path.as_deref(), &default_repo)?;
+        let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+        context_report::project(
+            run_runtime_json(&borrowed).map_err(|_| "context_report_unavailable")?,
+        )
+    })
+    .await
+    .map_err(|_| "context_report_unavailable".to_string())?
 }
 
 #[tauri::command]
@@ -196,7 +270,7 @@ async fn desktop_token_report(
 ) -> Result<Value, String> {
     let reports = reports.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        require_active_access()?;
+        require_read_access()?;
         let default_repo = std::env::var_os("SIMPLICIO_DESKTOP_REPO")
             .or_else(|| std::env::var_os("HOME"))
             .or_else(|| std::env::var_os("USERPROFILE"))
@@ -413,14 +487,23 @@ async fn desktop_logout() -> Result<Value, String> {
 #[tauri::command]
 async fn desktop_repair_providers(plan_digest: String) -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let _guard = INSTALL_LOCK
-            .try_lock()
-            .map_err(|_| "integration_install_busy")?;
-        let plan = integration_plan_from_runtime()?;
+        let mut attempt = INSTALL_LOCK.try_lock().map_err(|error| match error {
+            std::sync::TryLockError::WouldBlock => "integration_install_busy",
+            std::sync::TryLockError::Poisoned(_) => "integration_install_reconciliation_required",
+        })?;
+        attempt
+            .check_ready()
+            .map_err(|failure| failure.public_code())?;
+        // Preflight is read-only: no installer has started before attempt.begin().
+        let plan =
+            integration_plan_from_runtime().map_err(|_| "integration_preflight_unavailable")?;
         if plan["planDigest"].as_str() != Some(plan_digest.as_str()) {
             return Err("integration_plan_changed_review_again".into());
         }
-        repair_provider_integrations()?;
+        attempt.begin().map_err(|failure| failure.public_code())?;
+        let result = repair_provider_integrations();
+        attempt.finish(&result);
+        result.map_err(|failure| failure.public_code())?;
         snapshot_from_runtime()
             .map_err(|_| install_result::InstallFailure::AppliedSnapshotUnavailable.public_code())
     })
@@ -430,11 +513,10 @@ async fn desktop_repair_providers(plan_digest: String) -> Result<Value, String> 
 
 #[tauri::command]
 async fn desktop_open_subscription() -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(|| {
-        run_runtime_action(SUBSCRIPTION_ARGS).or_else(|_| open_subscription_url())
-    })
-    .await
-    .map_err(|_| "Falha interna ao abrir os planos".to_string())?
+    // One fixed navigation, never retry an uncertain Runtime action with a second opener.
+    tauri::async_runtime::spawn_blocking(open_subscription_url)
+        .await
+        .map_err(|_| "Falha interna ao abrir os planos".to_string())?
 }
 
 /// The Desktop owns the transport boundary, not the Bot/Agent authority.
@@ -455,6 +537,7 @@ async fn runtime_status() -> Result<Value, String> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(token_exports::TokenReports::default())
         .setup(|app| {
             #[cfg(desktop)]
@@ -471,6 +554,8 @@ pub fn run() {
             desktop_logout,
             desktop_repair_providers,
             desktop_plan_integrations,
+            desktop_usage_projects,
+            desktop_context_report,
             desktop_token_report,
             desktop_export_token_report,
             desktop_open_subscription,
@@ -481,6 +566,12 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("failed to run Simplicio Desktop");
+}
+
+/// Internal read-only worker entrypoint, checked before initializing the WebView.
+/// Desktop IPC still requires fresh Runtime access before launching a worker.
+pub fn try_project_discovery_worker() -> Option<Result<Value, String>> {
+    project_discovery_process::try_discovery_worker()
 }
 
 #[cfg(test)]
@@ -535,7 +626,6 @@ mod tests {
         assert_eq!(SNAPSHOT_ARGS, ["desktop", "snapshot", "--json"]);
         assert_eq!(LOGIN_ARGS, ["login", "google", "--json"]);
         assert_eq!(LOGOUT_ARGS, ["logout", "--json"]);
-        assert_eq!(SUBSCRIPTION_ARGS, ["desktop", "subscribe", "--json"]);
         assert_eq!(STATUS_ARGS, ["desktop", "status", "--json"]);
         assert_eq!(LEGACY_AUTH_ARGS, ["auth", "status", "--json"]);
         assert_eq!(LEGACY_STATUS_ARGS, ["status", "--json"]);
@@ -549,6 +639,59 @@ mod tests {
         assert_eq!(
             RELEASES_URL,
             "https://github.com/wesleysimplicio/simplicio/releases"
+        );
+    }
+
+    #[test]
+    fn process_deadlines_are_explicit_per_query_oauth_and_install() {
+        use std::time::Duration;
+        assert_eq!(
+            runtime_capture_limits(SNAPSHOT_ARGS).deadline,
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            runtime_capture_limits(LEGACY_INSTALL_ARGS).deadline,
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            runtime_capture_limits(LOGIN_ARGS).deadline,
+            Duration::from_secs(180)
+        );
+        assert_eq!(
+            runtime_capture_limits(INSTALL_ARGS).deadline,
+            Duration::from_secs(300)
+        );
+        assert_eq!(runtime_capture_limits(INSTALL_ARGS).stdout_bytes, 65_536);
+    }
+
+    #[test]
+    fn public_process_errors_are_fixed_codes_and_do_not_infer_auth_state() {
+        use runtime_process::{ChildState, FailureKind, ProcessFailure};
+        let timeout = ProcessFailure {
+            kind: FailureKind::Deadline,
+            child_state: ChildState::Reaped,
+        };
+        assert_eq!(
+            runtime_failure_code(LOGIN_ARGS, timeout),
+            "runtime_oauth_timeout"
+        );
+        assert_eq!(
+            runtime_failure_code(SNAPSHOT_ARGS, timeout),
+            "runtime_query_timeout"
+        );
+        assert_eq!(
+            runtime_failure_code(INSTALL_ARGS, timeout),
+            "runtime_install_timeout"
+        );
+        assert_eq!(
+            runtime_failure_code(
+                INSTALL_ARGS,
+                ProcessFailure {
+                    child_state: ChildState::Retained,
+                    ..timeout
+                }
+            ),
+            "runtime_process_cleanup_unconfirmed"
         );
     }
 

--- a/apps/desktop/src-tauri/src/local_projects.rs
+++ b/apps/desktop/src-tauri/src/local_projects.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 // Inspect resolved path text without relying on the test host's path syntax.
 // A canonical Win32 device prefix is allowed only for an ordinary local drive.
-fn canonical_local_text(path: &str) -> Result<&str, String> {
+pub(crate) fn canonical_local_text(path: &str) -> Result<&str, String> {
     let rendered = path.strip_prefix("\\\\?\\").unwrap_or(path);
     let bytes = rendered.as_bytes();
     let local_drive = bytes.len() >= 3

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,5 +1,23 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if let Some(result) = simplicio_desktop_lib::try_project_discovery_worker() {
+        use std::io::Write;
+        let code = match result {
+            Ok(report) => {
+                let mut output = std::io::stdout().lock();
+                if serde_json::to_writer(&mut output, &report).is_ok()
+                    && output.write_all(b"\n").is_ok()
+                    && output.flush().is_ok()
+                {
+                    0
+                } else {
+                    1
+                }
+            }
+            Err(_) => 2,
+        };
+        std::process::exit(code);
+    }
     simplicio_desktop_lib::run();
 }

--- a/apps/desktop/src-tauri/src/project_discovery_process.rs
+++ b/apps/desktop/src-tauri/src/project_discovery_process.rs
@@ -1,0 +1,1006 @@
+//! Read-only project discovery workers; the Desktop never scans a root itself.
+use crate::project_usage::{self, RootSelection};
+use crate::runtime_process::{self, CaptureLimits, ChildState, FailureKind};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+const WORKER_FLAG: &str = "--simplicio-project-discovery-worker-v1";
+const SCHEMA: &str = "simplicio.desktop-project-usage/v1";
+const QUALIFICATION: &str =
+    "Local ledger markers found; a report query must validate their integrity.";
+const WORKER_LIMITS: CaptureLimits = CaptureLimits {
+    deadline: Duration::from_secs(3),
+    stdout_bytes: 512 * 1024,
+    stderr_bytes: 16 * 1024,
+};
+
+#[derive(Clone, Debug)]
+struct WorkerRequest {
+    home: PathBuf,
+    selection: RootSelection,
+    configured: Option<PathBuf>,
+    directories: usize,
+    entries: usize,
+}
+
+impl WorkerRequest {
+    fn args(&self) -> Vec<OsString> {
+        vec![
+            WORKER_FLAG.into(),
+            self.home.as_os_str().to_owned(),
+            self.selection.key().into(),
+            self.configured
+                .as_ref()
+                .map(|path| path.as_os_str().to_owned())
+                .unwrap_or_default(),
+            self.directories.to_string().into(),
+            self.entries.to_string().into(),
+        ]
+    }
+
+    fn valid(&self) -> bool {
+        bounded_path(&self.home)
+            && self.home.parent().is_some()
+            && (1..=project_usage::MAX_DIRECTORIES).contains(&self.directories)
+            && (1..=project_usage::MAX_ENTRIES).contains(&self.entries)
+            && match self.selection {
+                RootSelection::Configured => self
+                    .configured
+                    .as_ref()
+                    .is_some_and(|path| bounded_path(path)),
+                _ => self.configured.is_none(),
+            }
+    }
+}
+
+/// No filesystem call is made on HOME, roots or project paths here. In
+/// particular, existence checks and canonicalization run only in the child.
+pub fn discover(home: &Path, configured_repo: Option<&Path>, exe: &Path) -> Result<Value, String> {
+    if !bounded_path(exe) {
+        return Err("project_discovery_unavailable".into());
+    }
+    discover_with_launcher(home, configured_repo, |request| {
+        let mut command = Command::new(exe);
+        command.args(request.args());
+        // Never set cwd to a root, override HOME, or start a shell/Tauri child.
+        capture_worker(&mut command, WORKER_LIMITS)
+    })
+}
+
+/// The executable calls this before starting Tauri. Malformed worker arguments
+/// return an error rather than falling through into a second GUI instance.
+pub fn try_discovery_worker() -> Option<Result<Value, String>> {
+    dispatch_worker(std::env::args_os().skip(1))
+}
+
+fn dispatch_worker(mut args: impl Iterator<Item = OsString>) -> Option<Result<Value, String>> {
+    if args.next()? != WORKER_FLAG {
+        return None;
+    }
+    Some((|| {
+        // Five fields after the selector. Take one extra to reject trailing
+        // options without ever accumulating an unbounded argument list.
+        let request = parse_worker_args(args.take(6).collect())?;
+        let report = project_usage::discover_root(
+            &request.home,
+            request.selection,
+            request.configured.as_deref(),
+            request.directories,
+            request.entries,
+        );
+        validate_worker_report(&request, &report)
+            .map_err(|_| "project_discovery_worker_response_invalid".to_string())?;
+        if serde_json::to_vec(&report)
+            .map_err(|_| "project_discovery_worker_response_invalid")?
+            .len()
+            > WORKER_LIMITS.stdout_bytes
+        {
+            return Err("project_discovery_worker_response_too_large".into());
+        }
+        Ok(report)
+    })())
+}
+
+fn parse_worker_args(args: Vec<OsString>) -> Result<WorkerRequest, String> {
+    let invalid = || "project_discovery_worker_request_invalid".to_string();
+    if args.len() != 5 {
+        return Err(invalid());
+    }
+    let selection = args[1]
+        .to_str()
+        .and_then(RootSelection::from_key)
+        .ok_or_else(invalid)?;
+    let parse_budget = |value: &OsString| -> Option<usize> {
+        let value = value.to_str()?;
+        if value.is_empty() || value.len() > 5 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        value.parse().ok()
+    };
+    let request = WorkerRequest {
+        home: PathBuf::from(&args[0]),
+        selection,
+        configured: if args[2].is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(&args[2]))
+        },
+        directories: parse_budget(&args[3]).ok_or_else(invalid)?,
+        entries: parse_budget(&args[4]).ok_or_else(invalid)?,
+    };
+    if !request.valid() {
+        return Err(invalid());
+    }
+    Ok(request)
+}
+
+fn requests(home: &Path, configured: Option<&Path>) -> Result<Vec<WorkerRequest>, String> {
+    if !bounded_path(home) || home.parent().is_none() {
+        return Err("project_discovery_request_invalid".into());
+    }
+    let mut selections = vec![
+        RootSelection::Projetos,
+        RootSelection::Projects,
+        RootSelection::Desktop,
+    ];
+    if configured.is_some() {
+        selections.push(RootSelection::Configured);
+    }
+    let count = selections.len();
+    Ok(selections
+        .into_iter()
+        .enumerate()
+        .map(|(index, selection)| WorkerRequest {
+            home: home.to_path_buf(),
+            selection,
+            configured: if selection == RootSelection::Configured {
+                configured.map(Path::to_path_buf)
+            } else {
+                None
+            },
+            directories: partition(project_usage::MAX_DIRECTORIES, count, index),
+            entries: partition(project_usage::MAX_ENTRIES, count, index),
+        })
+        .collect())
+}
+
+fn partition(total: usize, slots: usize, index: usize) -> usize {
+    total / slots + usize::from(index < total % slots)
+}
+
+fn discover_with_launcher(
+    home: &Path,
+    configured: Option<&Path>,
+    mut launch: impl FnMut(&WorkerRequest) -> Result<Value, WorkerFailure>,
+) -> Result<Value, String> {
+    let mut responses = Vec::new();
+    let mut stopped = None;
+    for request in requests(home, configured)? {
+        let response = if let Some(reason) = stopped {
+            Err(WorkerFailure {
+                reason,
+                cleanup_pending: reason == "root_cleanup_unconfirmed",
+            })
+        } else if !request.valid() {
+            Err(WorkerFailure {
+                reason: "root_request_invalid",
+                cleanup_pending: false,
+            })
+        } else {
+            launch(&request).and_then(|report| {
+                validate_worker_report(&request, &report)?;
+                Ok(report)
+            })
+        };
+        if let Err(failure) = &response {
+            if failure.cleanup_pending {
+                stopped = Some("root_cleanup_unconfirmed");
+            } else if failure.reason == "root_not_started" {
+                // Same executable is unavailable; don't replay three launches.
+                stopped = Some("root_not_started");
+            }
+        }
+        responses.push((request.selection.name(), response));
+    }
+    merge_root_responses(responses)
+}
+
+fn merge_root_responses(
+    responses: Vec<(&'static str, Result<Value, WorkerFailure>)>,
+) -> Result<Value, String> {
+    let slots = responses.len();
+    if !(3..=4).contains(&slots) {
+        return Err("project_discovery_response_invalid".into());
+    }
+    let mut reasons = BTreeSet::new();
+    let mut unavailable = Vec::new();
+    let mut roots = Vec::new();
+    let mut root_paths = BTreeSet::new();
+    let mut ids = BTreeSet::new();
+    let mut projects = BTreeMap::<String, Value>::new();
+    let mut directories = 0_u64;
+    let mut entries = 0_u64;
+    let mut partitions = Vec::new();
+    for (index, (name, response)) in responses.into_iter().enumerate() {
+        partitions.push(json!({"name": name,
+            "maxDirectories": partition(project_usage::MAX_DIRECTORIES, slots, index),
+            "maxEntries": partition(project_usage::MAX_ENTRIES, slots, index)}));
+        let report = match response {
+            Ok(report) => report,
+            Err(failure) => {
+                reasons.insert(failure.reason.to_string());
+                if failure.cleanup_pending {
+                    reasons.insert("root_cleanup_unconfirmed".into());
+                }
+                unavailable.push(name);
+                continue;
+            }
+        };
+        // Only validated worker reports reach this merge. Count incomplete
+        // workers as unknown; never invent how many entries they had read.
+        let worker_roots = report["roots"]
+            .as_array()
+            .ok_or("project_discovery_response_invalid")?;
+        let worker_reasons = report["reasons"]
+            .as_array()
+            .ok_or("project_discovery_response_invalid")?;
+        if worker_roots.is_empty() && !worker_reasons.is_empty() {
+            unavailable.push(name);
+        }
+        for reason in worker_reasons {
+            reasons.insert(
+                reason
+                    .as_str()
+                    .ok_or("project_discovery_response_invalid")?
+                    .to_owned(),
+            );
+        }
+        for root in worker_roots {
+            if root_paths.insert(
+                root["path"]
+                    .as_str()
+                    .ok_or("project_discovery_response_invalid")?
+                    .to_owned(),
+            ) {
+                roots.push(root.clone());
+            }
+        }
+        for id in report["candidateIds"]
+            .as_array()
+            .ok_or("project_discovery_response_invalid")?
+        {
+            ids.insert(
+                id.as_str()
+                    .ok_or("project_discovery_response_invalid")?
+                    .to_owned(),
+            );
+        }
+        directories += report["directoriesVisited"]
+            .as_u64()
+            .ok_or("project_discovery_response_invalid")?;
+        entries += report["entriesVisited"]
+            .as_u64()
+            .ok_or("project_discovery_response_invalid")?;
+        for candidate in report["projects"]
+            .as_array()
+            .ok_or("project_discovery_response_invalid")?
+        {
+            let path = candidate["path"]
+                .as_str()
+                .ok_or("project_discovery_response_invalid")?
+                .to_owned();
+            if let Some(existing) = projects.get_mut(&path) {
+                if existing["evidenceType"] != candidate["evidenceType"] {
+                    existing["evidenceType"] = json!("both");
+                }
+                if candidate["lastModifiedEpoch"].as_u64() > existing["lastModifiedEpoch"].as_u64()
+                {
+                    existing["lastModifiedEpoch"] = candidate["lastModifiedEpoch"].clone();
+                }
+            } else {
+                projects.insert(path, candidate.clone());
+            }
+        }
+    }
+    let mut projects = projects.into_values().collect::<Vec<_>>();
+    projects.sort_by(|left, right| {
+        right["lastModifiedEpoch"]
+            .as_u64()
+            .cmp(&left["lastModifiedEpoch"].as_u64())
+            .then_with(|| left["path"].as_str().cmp(&right["path"].as_str()))
+    });
+    if projects.len() > project_usage::MAX_RESULTS {
+        projects.truncate(project_usage::MAX_RESULTS);
+        reasons.insert("result_limit".into());
+    }
+    if directories > project_usage::MAX_DIRECTORIES as u64
+        || entries > project_usage::MAX_ENTRIES as u64
+        || ids.len() > project_usage::MAX_DIRECTORIES
+    {
+        return Err("project_discovery_response_invalid".into());
+    }
+    Ok(json!({
+        "schema": SCHEMA, "projects": projects, "candidateCount": ids.len(), "roots": roots,
+        "scope": {"kind":"conventional_roots_and_configured_repo", "maxDepth":project_usage::MAX_DEPTH,
+            "maxDirectories":project_usage::MAX_DIRECTORIES, "maxEntries":project_usage::MAX_ENTRIES,
+            "maxResults":project_usage::MAX_RESULTS, "deadlineMs":3000, "deadlineKind":"process_per_root",
+            "cooperativeDeadlineMs":2000, "cleanupGraceMs":500, "maxWorkers":slots,
+            "budgetAllocation":"deterministic_partition_including_missing_roots", "rootBudgets":partitions,
+            "counterScope":"completed_worker_responses", "candidateCountKind":"unique_ids_in_completed_worker_responses",
+            "followsSymlinks":false, "readsProjectFiles":false, "markerPrefixMaxBytes":project_usage::MARKER_PREFIX_BYTES,
+            "excludedDirectoryNames":project_usage::EXCLUDED},
+        "partial":!reasons.is_empty(), "reasons":reasons, "unavailableRoots":unavailable,
+        "directoriesVisited":directories, "entriesVisited":entries, "qualification":QUALIFICATION
+    }))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct WorkerFailure {
+    reason: &'static str,
+    cleanup_pending: bool,
+}
+
+fn capture_worker(command: &mut Command, limits: CaptureLimits) -> Result<Value, WorkerFailure> {
+    let output = runtime_process::capture(command, limits).map_err(|failure| WorkerFailure {
+        reason: match failure.kind {
+            FailureKind::Spawn => "root_not_started",
+            FailureKind::Deadline => "root_timeout",
+            FailureKind::StdoutLimit => "root_response_too_large",
+            FailureKind::StderrLimit => "root_diagnostics_too_large",
+            FailureKind::Capture => "root_capture_failed",
+            FailureKind::CleanupPending => "root_cleanup_unconfirmed",
+        },
+        cleanup_pending: failure.child_state == ChildState::Retained,
+    })?;
+    if !output.status.success() {
+        return Err(WorkerFailure {
+            reason: "root_failed",
+            cleanup_pending: false,
+        });
+    }
+    serde_json::from_slice(&output.stdout).map_err(|_| WorkerFailure {
+        reason: "root_response_invalid",
+        cleanup_pending: false,
+    })
+}
+
+// Lexical checks only. Canonicalizing even a seemingly harmless path here
+// would reintroduce the filesystem hang into the Desktop process.
+fn bounded_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path
+            .to_str()
+            .is_some_and(|text| crate::local_projects::canonical_local_text(text).is_ok())
+}
+
+fn canonical_path(value: &Value) -> Option<&Path> {
+    let text = value.as_str()?;
+    // Worker output is already projected. Never accept a raw device prefix
+    // into the WebView or hash a different spelling than the displayed path.
+    if crate::local_projects::canonical_local_text(text).ok()? != text {
+        return None;
+    }
+    let path = Path::new(text);
+    if !bounded_path(path)
+        || path
+            .components()
+            .any(|part| matches!(part, Component::ParentDir | Component::CurDir))
+    {
+        return None;
+    }
+    let normalized = path.components().collect::<PathBuf>();
+    (normalized.as_os_str() == path.as_os_str()).then_some(path)
+}
+
+fn only_fields(value: &Value, fields: &[&str]) -> bool {
+    value
+        .as_object()
+        .is_some_and(|map| map.keys().all(|key| fields.contains(&key.as_str())))
+}
+
+fn valid_id(id: &str) -> bool {
+    id.len() == 72
+        && id.starts_with("project-")
+        && id.as_bytes()[8..]
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn worker_scope(directories: usize, entries: usize) -> Value {
+    json!({"kind":"conventional_roots_and_configured_repo", "maxDepth":project_usage::MAX_DEPTH,
+        "maxDirectories":directories, "maxEntries":entries, "maxResults":project_usage::MAX_RESULTS,
+        "deadlineMs":2000, "deadlineKind":"cooperative_between_filesystem_calls",
+        "followsSymlinks":false, "readsProjectFiles":false,
+        "markerPrefixMaxBytes":project_usage::MARKER_PREFIX_BYTES, "excludedDirectoryNames":project_usage::EXCLUDED})
+}
+
+fn validate_worker_report(request: &WorkerRequest, report: &Value) -> Result<(), WorkerFailure> {
+    worker_contract(request, report).ok_or(WorkerFailure {
+        reason: "root_response_invalid",
+        cleanup_pending: false,
+    })
+}
+
+fn worker_contract(request: &WorkerRequest, report: &Value) -> Option<()> {
+    const REASONS: &[&str] = &[
+        "directory_limit",
+        "entry_limit",
+        "result_limit",
+        "depth_limit",
+        "deadline",
+        "home_unavailable",
+        "configured_root_rejected",
+        "configured_root_unavailable",
+        "no_accessible_roots",
+        "path_unreadable",
+        "path_not_displayable",
+        "directory_unreadable",
+        "path_changed_or_outside_scope",
+        "symlink_skipped",
+        "marker_not_regular",
+        "marker_unreadable",
+        "marker_header_invalid",
+    ];
+    if !only_fields(
+        report,
+        &[
+            "schema",
+            "projects",
+            "candidateCount",
+            "candidateIds",
+            "roots",
+            "scope",
+            "partial",
+            "reasons",
+            "directoriesVisited",
+            "entriesVisited",
+            "qualification",
+            "canonicalHome",
+        ],
+    ) || report.get("schema")?.as_str()? != SCHEMA
+        || report.get("scope")? != &worker_scope(request.directories, request.entries)
+        || report.get("qualification")?.as_str()? != QUALIFICATION
+    {
+        return None;
+    }
+    let roots = report.get("roots")?.as_array()?;
+    let projects = report.get("projects")?.as_array()?;
+    let candidate_ids = report.get("candidateIds")?.as_array()?;
+    let candidate_count = report.get("candidateCount")?.as_u64()?;
+    let directories = report.get("directoriesVisited")?.as_u64()?;
+    let entries = report.get("entriesVisited")?.as_u64()?;
+    let reasons = report.get("reasons")?.as_array()?;
+    if roots.len() > 1
+        || projects.len() > project_usage::MAX_RESULTS
+        || candidate_ids.len() > request.directories
+        || candidate_count != candidate_ids.len() as u64
+        || candidate_count > directories
+        || directories > request.directories as u64
+        || entries > request.entries as u64
+        || directories > entries + 1
+        || projects.len() > candidate_ids.len()
+        || reasons.len() > REASONS.len()
+        || report.get("partial")?.as_bool()? != !reasons.is_empty()
+    {
+        return None;
+    }
+    let mut seen_reasons = BTreeSet::new();
+    for reason in reasons {
+        let reason = reason.as_str()?;
+        if !REASONS.contains(&reason) || !seen_reasons.insert(reason) {
+            return None;
+        }
+    }
+    let home_value = report.get("canonicalHome")?;
+    let home = if home_value.is_null() {
+        None
+    } else {
+        Some(canonical_path(home_value)?)
+    };
+    if home.is_none() && (!roots.is_empty() || !seen_reasons.contains("home_unavailable")) {
+        return None;
+    }
+    if roots.is_empty() {
+        if directories != 0 || entries != 0 || candidate_count != 0 || !projects.is_empty() {
+            return None;
+        }
+        if request.selection == RootSelection::Configured && reasons.is_empty() {
+            return None;
+        }
+        return Some(());
+    }
+    let root = &roots[0];
+    if !only_fields(root, &["name", "path"])
+        || root.get("name")?.as_str()? != request.selection.name()
+    {
+        return None;
+    }
+    let root_path = canonical_path(root.get("path")?)?;
+    let home = home?;
+    if root_path.parent().is_none() || home.starts_with(root_path) {
+        return None;
+    }
+    if request.selection != RootSelection::Configured
+        && root_path != home.join(request.selection.name())
+    {
+        return None;
+    }
+    let mut ids = BTreeSet::new();
+    for id in candidate_ids {
+        let id = id.as_str()?;
+        if !valid_id(id) || !ids.insert(id) {
+            return None;
+        }
+    }
+    let mut project_ids = BTreeSet::new();
+    for project in projects {
+        if !only_fields(
+            project,
+            &["id", "name", "path", "evidenceType", "lastModifiedEpoch"],
+        ) {
+            return None;
+        }
+        let path = canonical_path(project.get("path")?)?;
+        let path_text = path.to_str()?;
+        let name = project.get("name")?.as_str()?;
+        let id = project.get("id")?.as_str()?;
+        if !path.starts_with(root_path)
+            || path.strip_prefix(root_path).ok()?.components().count() > project_usage::MAX_DEPTH
+            || name.is_empty()
+            || name.len() > project_usage::MAX_NAME_BYTES
+            || name.chars().any(char::is_control)
+            || path.file_name()?.to_str()? != name
+            || !ids.contains(id)
+            || !project_ids.insert(id)
+            || id != format!("project-{:x}", Sha256::digest(path_text.as_bytes()))
+            || !matches!(
+                project.get("evidenceType")?.as_str()?,
+                "context" | "usage" | "both"
+            )
+        {
+            return None;
+        }
+        if let Some(modified) = project.get("lastModifiedEpoch") {
+            if modified.as_u64()? > project_usage::MAX_SAFE_INTEGER {
+                return None;
+            }
+        }
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    fn child_case(case: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command.args([
+            "--exact",
+            "project_discovery_process::tests::discovery_child_fixture",
+            "--nocapture",
+        ]);
+        command.env("SIMPLICIO_DISCOVERY_PROCESS_TEST_CASE", case);
+        command
+    }
+
+    #[test]
+    fn discovery_child_fixture() {
+        let Ok(case) = std::env::var("SIMPLICIO_DISCOVERY_PROCESS_TEST_CASE") else {
+            return;
+        };
+        if case == "blocked-root" {
+            eprintln!("PRIVATE_DISCOVERY_DIAGNOSTIC_SENTINEL");
+            std::thread::sleep(Duration::from_secs(2));
+        } else if case == "stdout-flood" {
+            let block = [b'x'; 16 * 1024];
+            for _ in 0..40 {
+                if std::io::stdout().write_all(&block).is_err() {
+                    break;
+                }
+            }
+        } else if case == "stderr-flood" {
+            let _ = std::io::stderr().write_all(&[b'x'; 32 * 1024]);
+        } else if case == "delayed-invalid" {
+            std::thread::sleep(Duration::from_millis(50));
+            print!("not-json");
+        } else if case == "success-looking-nonzero" {
+            print!("{{\"schema\":\"simplicio.desktop-project-usage/v1\"}}");
+            std::process::exit(7);
+        }
+        std::process::exit(0);
+    }
+
+    #[test]
+    fn a_blocked_root_is_bounded_and_does_not_leak_its_output() {
+        let started = Instant::now();
+        let failure = capture_worker(
+            &mut child_case("blocked-root"),
+            CaptureLimits {
+                deadline: Duration::from_millis(150),
+                stdout_bytes: 512 * 1024,
+                stderr_bytes: 16 * 1024,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(failure.reason, "root_timeout");
+        assert!(!failure.cleanup_pending);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(!format!("{failure:?}").contains("PRIVATE_DISCOVERY_DIAGNOSTIC_SENTINEL"));
+    }
+
+    #[test]
+    fn worker_streams_are_bounded_and_nonzero_exit_precedes_json() {
+        let limits = CaptureLimits {
+            deadline: Duration::from_secs(1),
+            ..WORKER_LIMITS
+        };
+        assert_eq!(
+            capture_worker(&mut child_case("stdout-flood"), limits)
+                .unwrap_err()
+                .reason,
+            "root_response_too_large"
+        );
+        assert_eq!(
+            capture_worker(&mut child_case("stderr-flood"), limits)
+                .unwrap_err()
+                .reason,
+            "root_diagnostics_too_large"
+        );
+        assert_eq!(
+            capture_worker(&mut child_case("delayed-invalid"), limits)
+                .unwrap_err()
+                .reason,
+            "root_response_invalid"
+        );
+        assert_eq!(
+            capture_worker(&mut child_case("success-looking-nonzero"), limits)
+                .unwrap_err()
+                .reason,
+            "root_failed"
+        );
+    }
+
+    #[test]
+    fn completed_projects_survive_a_later_timeout_and_invalid_worker_output() {
+        let limits = CaptureLimits {
+            deadline: Duration::from_millis(150),
+            stdout_bytes: 512 * 1024,
+            stderr_bytes: 16 * 1024,
+        };
+        let completed = json!({
+            "schema": "simplicio.desktop-project-usage/v1",
+            "projects": [{"id": "project-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name":"known-project", "path":"/bounded/Projetos/known-project", "evidenceType":"usage"}],
+            "candidateIds": ["project-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+            "candidateCount":1, "directoriesVisited":2, "entriesVisited":1,
+            "roots":[{"name":"Projetos", "path":"/bounded/Projetos"}],
+            "reasons":[], "partial":false
+        });
+        let response = merge_root_responses(vec![
+            ("Projetos", Ok(completed)),
+            (
+                "Projects",
+                capture_worker(&mut child_case("blocked-root"), limits),
+            ),
+            (
+                "Desktop",
+                capture_worker(&mut child_case("invalid-json"), limits),
+            ),
+        ]);
+        assert!(
+            response.is_ok(),
+            "a failed root discarded earlier completed projects"
+        );
+        let report = response.unwrap();
+        assert_eq!(report["projects"].as_array().unwrap().len(), 1);
+        assert_eq!(report["projects"][0]["name"], "known-project");
+        assert_eq!(report["candidateCount"], 1);
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("root_timeout")));
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("root_response_invalid")));
+        assert_eq!(report["unavailableRoots"], json!(["Projects", "Desktop"]));
+        assert!(!report
+            .to_string()
+            .contains("PRIVATE_DISCOVERY_DIAGNOSTIC_SENTINEL"));
+        assert!(report.get("candidateIds").is_none());
+    }
+
+    fn empty_worker_report(request: &WorkerRequest) -> Value {
+        let home = request.home.to_str().unwrap();
+        let root_path = match request.selection {
+            RootSelection::Configured => request.configured.clone().unwrap(),
+            _ => request.home.join(request.selection.name()),
+        };
+        json!({"schema":SCHEMA, "projects":[], "candidateIds":[], "candidateCount":0,
+            "roots":[{"name":request.selection.name(), "path":root_path.to_str().unwrap()}],
+            "scope":worker_scope(request.directories, request.entries), "partial":false, "reasons":[],
+            "directoriesVisited":1, "entriesVisited":0, "qualification":QUALIFICATION,
+            "canonicalHome":home})
+    }
+
+    fn fixture_home() -> PathBuf {
+        #[cfg(windows)]
+        {
+            PathBuf::from(r"C:\bounded\home")
+        }
+        #[cfg(not(windows))]
+        {
+            PathBuf::from("/bounded/home")
+        }
+    }
+
+    fn report_with_project(request: &WorkerRequest, project: &Path) -> Value {
+        let mut report = empty_worker_report(request);
+        let path = project.to_str().unwrap();
+        let id = format!("project-{:x}", Sha256::digest(path.as_bytes()));
+        report["projects"] = json!([{"id":id, "name":project.file_name().unwrap().to_str().unwrap(),
+            "path":path, "evidenceType":"usage", "lastModifiedEpoch":1234}]);
+        report["candidateIds"] = json!([id]);
+        report["candidateCount"] = json!(1);
+        report["directoriesVisited"] = json!(2);
+        report["entriesVisited"] = json!(1);
+        report
+    }
+
+    #[test]
+    fn parent_partitions_the_global_budget_without_resolving_home() {
+        let home = std::env::temp_dir().join(format!("missing-parent-root-{}", std::process::id()));
+        assert!(!home.exists());
+        let mut seen = Vec::new();
+        let report = discover_with_launcher(&home, None, |request| {
+            seen.push((request.selection, request.directories, request.entries));
+            Err(WorkerFailure {
+                reason: "root_timeout",
+                cleanup_pending: false,
+            })
+        })
+        .unwrap();
+        assert_eq!(seen.len(), 3);
+        assert_eq!(
+            seen.iter().map(|(_, value, _)| value).sum::<usize>(),
+            project_usage::MAX_DIRECTORIES
+        );
+        assert_eq!(
+            seen.iter().map(|(_, _, value)| value).sum::<usize>(),
+            project_usage::MAX_ENTRIES
+        );
+        assert_eq!(
+            report["unavailableRoots"],
+            json!(["Projetos", "Projects", "Desktop"])
+        );
+        assert_eq!(report["projects"], json!([]));
+        assert_eq!(report["partial"], true);
+        assert!(
+            !home.exists(),
+            "the parent created or resolved the absent HOME fixture"
+        );
+    }
+
+    #[test]
+    fn four_workers_share_budgets_and_deduplicate_an_overlapping_configured_root() {
+        let home = fixture_home();
+        let configured = home.join("Projetos");
+        let project = configured.join("known-project");
+        let mut budgets = Vec::new();
+        let report = discover_with_launcher(&home, Some(&configured), |request| {
+            budgets.push((request.directories, request.entries));
+            Ok(
+                if matches!(
+                    request.selection,
+                    RootSelection::Projetos | RootSelection::Configured
+                ) {
+                    report_with_project(request, &project)
+                } else {
+                    empty_worker_report(request)
+                },
+            )
+        })
+        .unwrap();
+        assert_eq!(budgets, vec![(1000, 10_000); 4]);
+        assert_eq!(report["candidateCount"], 1);
+        assert_eq!(report["projects"].as_array().unwrap().len(), 1);
+        assert_eq!(report["roots"].as_array().unwrap().len(), 3);
+        assert_eq!(report["unavailableRoots"], json!([]));
+        assert_eq!(report["partial"], false);
+    }
+
+    #[test]
+    fn worker_arguments_and_reports_fail_closed_before_scanning() {
+        let valid = vec![
+            fixture_home().into_os_string(),
+            OsString::from("projects"),
+            OsString::new(),
+            OsString::from("1333"),
+            OsString::from("13333"),
+        ];
+        let request = parse_worker_args(valid.clone()).unwrap();
+        assert_eq!(request.selection, RootSelection::Projects);
+        let mut extra = valid.clone();
+        extra.push("unexpected".into());
+        assert_eq!(
+            parse_worker_args(extra).unwrap_err(),
+            "project_discovery_worker_request_invalid"
+        );
+        let mut excessive = valid.clone();
+        excessive[3] = "4001".into();
+        assert_eq!(
+            parse_worker_args(excessive).unwrap_err(),
+            "project_discovery_worker_request_invalid"
+        );
+        let mut configured_missing = valid;
+        configured_missing[1] = "configured".into();
+        assert_eq!(
+            parse_worker_args(configured_missing).unwrap_err(),
+            "project_discovery_worker_request_invalid"
+        );
+
+        let mut report = empty_worker_report(&request);
+        report["directoriesVisited"] = json!(request.directories as u64 + 1);
+        assert_eq!(
+            validate_worker_report(&request, &report)
+                .unwrap_err()
+                .reason,
+            "root_response_invalid"
+        );
+        let mut report = empty_worker_report(&request);
+        report["privateUnexpected"] = json!("PRIVATE_WORKER_SENTINEL");
+        assert_eq!(
+            validate_worker_report(&request, &report)
+                .unwrap_err()
+                .reason,
+            "root_response_invalid"
+        );
+        let mut report = report_with_project(&request, &request.home.join("Projects/project"));
+        report["projects"][0]["id"] =
+            json!("project-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_eq!(
+            validate_worker_report(&request, &report)
+                .unwrap_err()
+                .reason,
+            "root_response_invalid"
+        );
+        let mut report = empty_worker_report(&request);
+        report["roots"][0]["path"] = json!(request.home.join("Desktop").to_str().unwrap());
+        assert_eq!(
+            validate_worker_report(&request, &report)
+                .unwrap_err()
+                .reason,
+            "root_response_invalid"
+        );
+    }
+
+    #[test]
+    fn global_results_keep_the_newest_64_across_all_completed_roots() {
+        let home = fixture_home();
+        let mut first = 0_u64;
+        let report = discover_with_launcher(&home, None, |request| {
+            let mut report = empty_worker_report(request);
+            let root = request.home.join(request.selection.name());
+            let projects = (first..first + 30)
+                .map(|index| {
+                    let path = root.join(format!("project-{index:02}"));
+                    let mut project = report_with_project(request, &path)["projects"][0].clone();
+                    project["lastModifiedEpoch"] = json!(index);
+                    project
+                })
+                .collect::<Vec<_>>();
+            report["candidateIds"] = json!(projects
+                .iter()
+                .map(|project| project["id"].clone())
+                .collect::<Vec<_>>());
+            report["projects"] = json!(projects);
+            report["candidateCount"] = json!(30);
+            report["directoriesVisited"] = json!(31);
+            report["entriesVisited"] = json!(30);
+            first += 30;
+            Ok(report)
+        })
+        .unwrap();
+        assert_eq!(report["candidateCount"], 90);
+        assert_eq!(report["projects"].as_array().unwrap().len(), 64);
+        assert_eq!(report["projects"][0]["name"], "project-89");
+        assert_eq!(report["projects"][63]["name"], "project-26");
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("result_limit")));
+    }
+
+    #[test]
+    fn unresolved_cleanup_prevents_starting_other_root_helpers() {
+        let home = fixture_home();
+        let mut launches = 0;
+        let report = discover_with_launcher(&home, None, |_| {
+            launches += 1;
+            Err(WorkerFailure {
+                reason: "root_timeout",
+                cleanup_pending: true,
+            })
+        })
+        .unwrap();
+        assert_eq!(launches, 1);
+        assert_eq!(
+            report["unavailableRoots"],
+            json!(["Projetos", "Projects", "Desktop"])
+        );
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("root_cleanup_unconfirmed")));
+    }
+
+    struct WorkerHome(PathBuf);
+    impl WorkerHome {
+        fn with_project() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let home = std::env::temp_dir().join(format!(
+                "simplicio-worker-home-{}-{nonce}",
+                std::process::id()
+            ));
+            let ledger = home.join("Projects/real-project/.simplicio/ledger");
+            fs::create_dir_all(&ledger).unwrap();
+            fs::write(ledger.join("savings-events.jsonl"), b"{}\n").unwrap();
+            Self(home)
+        }
+    }
+    impl Drop for WorkerHome {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn headless_dispatch_scans_exactly_the_selected_fixture_root() {
+        let home = WorkerHome::with_project();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(home.0.join("Projects"), home.0.join("Desktop")).unwrap();
+        let args = [
+            WORKER_FLAG.into(),
+            home.0.as_os_str().to_owned(),
+            "projects".into(),
+            OsString::new(),
+            "1333".into(),
+            "13333".into(),
+        ];
+        let report = dispatch_worker(args.into_iter()).unwrap().unwrap();
+        assert_eq!(report["projects"].as_array().unwrap().len(), 1);
+        assert_eq!(report["projects"][0]["name"], "real-project");
+        assert_eq!(report["roots"].as_array().unwrap().len(), 1);
+        assert_eq!(report["roots"][0]["name"], "Projects");
+        assert_eq!(report["candidateCount"], 1);
+        assert_eq!(report["partial"], false, "worker probed an unselected root");
+        assert!(report.to_string().len() < WORKER_LIMITS.stdout_bytes);
+        let missing = [
+            WORKER_FLAG.into(),
+            home.0.as_os_str().to_owned(),
+            "projetos".into(),
+            OsString::new(),
+            "1333".into(),
+            "13333".into(),
+        ];
+        let missing = dispatch_worker(missing.into_iter()).unwrap().unwrap();
+        assert_eq!(missing["projects"], json!([]));
+        assert_eq!(missing["roots"], json!([]));
+        assert_eq!(missing["reasons"], json!([]));
+        assert_eq!(missing["partial"], false);
+    }
+}

--- a/apps/desktop/src-tauri/src/project_usage.rs
+++ b/apps/desktop/src-tauri/src/project_usage.rs
@@ -1,0 +1,1058 @@
+//! Candidate discovery from local ledger markers, never proof of usage or billing.
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashSet, VecDeque};
+use std::fs::{self, File, Metadata, OpenOptions};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, UNIX_EPOCH};
+
+pub(crate) const MARKER_PREFIX_BYTES: usize = 512;
+pub(crate) const MAX_NAME_BYTES: usize = 256;
+pub(crate) const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+pub(crate) const MAX_DIRECTORIES: usize = 4000;
+pub(crate) const MAX_ENTRIES: usize = 40_000;
+pub(crate) const MAX_RESULTS: usize = 64;
+pub(crate) const MAX_DEPTH: usize = 5;
+pub(crate) const EXCLUDED: &[&str] = &[
+    ".git",
+    ".simplicio",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "bin",
+    "binaries",
+    "vendor",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".cache",
+    "cache",
+    "caches",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".next",
+    ".turbo",
+    ".tox",
+    ".npm",
+    ".pnpm-store",
+    "coverage",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RootSelection {
+    Projetos,
+    Projects,
+    Desktop,
+    Configured,
+}
+
+impl RootSelection {
+    pub(crate) fn key(self) -> &'static str {
+        match self {
+            Self::Projetos => "projetos",
+            Self::Projects => "projects",
+            Self::Desktop => "desktop",
+            Self::Configured => "configured",
+        }
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Projetos => "Projetos",
+            Self::Projects => "Projects",
+            Self::Desktop => "Desktop",
+            Self::Configured => "Configured repository",
+        }
+    }
+
+    pub(crate) fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "projetos" => Some(Self::Projetos),
+            "projects" => Some(Self::Projects),
+            "desktop" => Some(Self::Desktop),
+            "configured" => Some(Self::Configured),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Limits {
+    depth: usize,
+    directories: usize,
+    entries: usize,
+    results: usize,
+    deadline: Duration,
+}
+const LIMITS: Limits = Limits {
+    depth: MAX_DEPTH,
+    directories: MAX_DIRECTORIES,
+    entries: MAX_ENTRIES,
+    results: MAX_RESULTS,
+    deadline: Duration::from_secs(2),
+};
+
+struct Root {
+    name: &'static str,
+    path: PathBuf,
+}
+
+struct Candidate {
+    path: String,
+    name: String,
+    evidence: &'static str,
+    modified: Option<u64>,
+}
+
+fn display_path_text(path: &str) -> Option<&str> {
+    crate::local_projects::canonical_local_text(path).ok()
+}
+
+impl Candidate {
+    fn id(&self) -> String {
+        format!("project-{:x}", Sha256::digest(self.path.as_bytes()))
+    }
+
+    fn json(&self) -> Value {
+        let mut value = json!({
+            "id": self.id(),
+            "name": self.name, "path": self.path, "evidenceType": self.evidence,
+        });
+        if let Some(epoch) = self.modified {
+            value["lastModifiedEpoch"] = json!(epoch);
+        }
+        value
+    }
+}
+
+/// In-process fixture entry only. Production must use the bounded worker controller.
+#[cfg(test)]
+pub fn discover(home: &Path, configured_repo: Option<&Path>) -> Value {
+    discover_with_limits(home, configured_repo, LIMITS)
+}
+
+#[cfg(test)]
+fn discover_with_limits(home: &Path, configured_repo: Option<&Path>, limits: Limits) -> Value {
+    let started = Instant::now();
+    let mut reasons = BTreeSet::new();
+    let roots = roots(home, configured_repo, &mut reasons);
+    scan_roots(roots, reasons, limits, started)
+}
+
+/// Called only by the headless worker, before Tauri starts. Even resolving HOME
+/// and the selected root can block in the filesystem, so none of this belongs
+/// in the Desktop parent. This worker never probes another conventional root.
+pub(crate) fn discover_root(
+    home: &Path,
+    selection: RootSelection,
+    configured_repo: Option<&Path>,
+    directories: usize,
+    entries: usize,
+) -> Value {
+    let started = Instant::now();
+    let mut reasons = BTreeSet::new();
+    let limits = Limits {
+        directories: directories.min(MAX_DIRECTORIES),
+        entries: entries.min(MAX_ENTRIES),
+        ..LIMITS
+    };
+    let canonical_home = if home.is_absolute() {
+        fs::canonicalize(home)
+            .ok()
+            .filter(|path| path.to_str().and_then(display_path_text).is_some())
+    } else {
+        None
+    };
+    let mut selected = Vec::new();
+    if let Some(canonical_home) = canonical_home.as_ref() {
+        let proposed = match selection {
+            RootSelection::Configured => configured_repo.map(Path::to_path_buf),
+            _ => Some(canonical_home.join(selection.name())),
+        };
+        if let Some(proposed) = proposed {
+            if let Some(path) = directory(&proposed, &mut reasons) {
+                if path.parent().is_none() || canonical_home.starts_with(&path) {
+                    reasons.insert("configured_root_rejected");
+                } else {
+                    selected.push(Root {
+                        name: selection.name(),
+                        path,
+                    });
+                }
+            } else if selection == RootSelection::Configured {
+                reasons.insert("configured_root_unavailable");
+            }
+        } else {
+            reasons.insert("configured_root_rejected");
+        }
+    } else {
+        reasons.insert("home_unavailable");
+    }
+    let mut report = scan_roots(selected, reasons, limits, started);
+    // This is internal worker metadata. The controller removes it from IPC to
+    // the WebView, together with the bounded candidate ID set used for dedup.
+    report["canonicalHome"] = json!(canonical_home
+        .and_then(|path| { path.to_str().and_then(display_path_text).map(str::to_owned) }));
+    report
+}
+
+fn scan_roots(
+    roots: Vec<Root>,
+    mut reasons: BTreeSet<&'static str>,
+    limits: Limits,
+    started: Instant,
+) -> Value {
+    let mut scheduled = HashSet::new();
+    let mut queue = VecDeque::new();
+    for (index, root) in roots.iter().enumerate() {
+        scheduled.insert(root.path.clone());
+        queue.push_back((root.path.clone(), 0, index));
+    }
+    let mut projects: Vec<Candidate> = Vec::new();
+    let mut directories = 0;
+    let mut entries_seen = 0;
+    let mut candidate_ids = BTreeSet::new();
+    'walk: while let Some((path, depth, root_index)) = queue.pop_front() {
+        if expired(started, limits, &mut reasons) {
+            break;
+        }
+        if directories >= limits.directories {
+            reasons.insert("directory_limit");
+            break;
+        }
+        // Recheck queued directories rather than following links added during the walk.
+        let Some(current) = directory(&path, &mut reasons) else {
+            continue;
+        };
+        if current != path || !current.starts_with(&roots[root_index].path) {
+            reasons.insert("path_changed_or_outside_scope");
+            continue;
+        }
+        directories += 1;
+        if let Some(candidate) = candidate(&current, &mut reasons) {
+            candidate_ids.insert(candidate.id());
+            projects.push(candidate);
+            projects.sort_by(|left, right| {
+                right
+                    .modified
+                    .cmp(&left.modified)
+                    .then_with(|| left.path.cmp(&right.path))
+            });
+            if projects.len() > limits.results {
+                projects.truncate(limits.results);
+                reasons.insert("result_limit");
+            }
+        }
+        if expired(started, limits, &mut reasons) {
+            break;
+        }
+        let mut entries = match fs::read_dir(&current) {
+            Ok(entries) => entries,
+            Err(_) => {
+                reasons.insert("directory_unreadable");
+                continue;
+            }
+        };
+        loop {
+            if expired(started, limits, &mut reasons) {
+                break 'walk;
+            }
+            if entries_seen >= limits.entries {
+                reasons.insert("entry_limit");
+                break 'walk;
+            }
+            let Some(entry) = entries.next() else {
+                break;
+            };
+            entries_seen += 1;
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    reasons.insert("directory_unreadable");
+                    continue;
+                }
+            };
+            let name = entry.file_name();
+            if name
+                .to_str()
+                .is_some_and(|name| EXCLUDED.iter().any(|skip| name.eq_ignore_ascii_case(skip)))
+            {
+                continue;
+            }
+            let kind = match entry.file_type() {
+                Ok(kind) => kind,
+                Err(_) => {
+                    reasons.insert("directory_unreadable");
+                    continue;
+                }
+            };
+            if kind.is_symlink() {
+                reasons.insert("symlink_skipped");
+                continue;
+            }
+            if !kind.is_dir() {
+                continue;
+            }
+            if depth >= limits.depth {
+                reasons.insert("depth_limit");
+                continue;
+            }
+            if scheduled.len() >= limits.directories {
+                reasons.insert("directory_limit");
+                continue;
+            }
+            let Some(child) = directory(&entry.path(), &mut reasons) else {
+                continue;
+            };
+            if !child.starts_with(&roots[root_index].path) {
+                reasons.insert("path_changed_or_outside_scope");
+                continue;
+            }
+            if scheduled.insert(child.clone()) {
+                queue.push_back((child, depth + 1, root_index));
+            }
+        }
+    }
+    json!({
+        "schema": "simplicio.desktop-project-usage/v1",
+        "projects": projects.iter().map(Candidate::json).collect::<Vec<_>>(),
+        "candidateCount": candidate_ids.len(),
+        "candidateIds": candidate_ids,
+        "roots": roots.iter().map(|root| json!({"name":root.name,
+            "path":root.path.to_str().and_then(display_path_text)})).collect::<Vec<_>>(),
+        "scope": {"kind": "conventional_roots_and_configured_repo", "maxDepth": limits.depth,
+            "maxDirectories": limits.directories, "maxEntries": limits.entries,
+            "maxResults": limits.results, "deadlineMs": limits.deadline.as_millis() as u64,
+            "deadlineKind": "cooperative_between_filesystem_calls", "followsSymlinks": false,
+            "readsProjectFiles": false, "markerPrefixMaxBytes": MARKER_PREFIX_BYTES,
+            "excludedDirectoryNames": EXCLUDED},
+        "partial": !reasons.is_empty(), "reasons": reasons,
+        "directoriesVisited": directories, "entriesVisited": entries_seen,
+        "qualification": "Local ledger markers found; a report query must validate their integrity."
+    })
+}
+
+fn expired(started: Instant, limits: Limits, reasons: &mut BTreeSet<&'static str>) -> bool {
+    if started.elapsed() >= limits.deadline {
+        reasons.insert("deadline");
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+fn roots(
+    home: &Path,
+    configured_repo: Option<&Path>,
+    reasons: &mut BTreeSet<&'static str>,
+) -> Vec<Root> {
+    let mut roots = Vec::new();
+    let canonical_home = if home.is_absolute() {
+        fs::canonicalize(home).ok()
+    } else {
+        None
+    };
+    if let Some(home) = canonical_home.as_ref() {
+        for name in ["Projetos", "Projects", "Desktop"] {
+            if let Some(path) = directory(&home.join(name), reasons) {
+                if !roots.iter().any(|root: &Root| root.path == path) {
+                    roots.push(Root { name, path });
+                }
+            }
+        }
+    } else {
+        reasons.insert("home_unavailable");
+    }
+    if let Some(configured) = configured_repo {
+        if let Some(path) = directory(configured, reasons) {
+            if path.parent().is_none()
+                || canonical_home
+                    .as_ref()
+                    .is_some_and(|home| home.starts_with(&path))
+            {
+                reasons.insert("configured_root_rejected");
+            } else if !roots.iter().any(|root| root.path == path) {
+                roots.push(Root {
+                    name: "Configured repository",
+                    path,
+                });
+            }
+        } else {
+            reasons.insert("configured_root_unavailable");
+        }
+    }
+    if roots.is_empty() {
+        reasons.insert("no_accessible_roots");
+    }
+    roots
+}
+
+fn metadata(path: &Path, reasons: &mut BTreeSet<&'static str>) -> Option<Metadata> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if is_link(&metadata) {
+                reasons.insert("symlink_skipped");
+                None
+            } else {
+                Some(metadata)
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(_) => {
+            reasons.insert("path_unreadable");
+            None
+        }
+    }
+}
+
+fn directory(path: &Path, reasons: &mut BTreeSet<&'static str>) -> Option<PathBuf> {
+    if !path.is_absolute() || !metadata(path, reasons)?.is_dir() {
+        return None;
+    }
+    let path = match fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => {
+            reasons.insert("path_unreadable");
+            return None;
+        }
+    };
+    if path.to_str().and_then(display_path_text).is_none() {
+        reasons.insert("path_not_displayable");
+        return None;
+    }
+    Some(path)
+}
+
+fn candidate(path: &Path, reasons: &mut BTreeSet<&'static str>) -> Option<Candidate> {
+    let state = path.join(".simplicio");
+    if !metadata(&state, reasons)?.is_dir() {
+        return None;
+    }
+    let ledger = state.join("ledger");
+    let context = if metadata(&ledger, reasons).is_some_and(|entry| entry.is_dir()) {
+        marker(&ledger.join("savings-events.jsonl"), false, reasons)
+    } else {
+        None
+    };
+    // Match token_query_args: usage has its own database, independent of context savings.
+    let usage = marker(&state.join("token-usage.sqlite3"), true, reasons);
+    let evidence = match (context.is_some(), usage.is_some()) {
+        (true, true) => "both",
+        (true, false) => "context",
+        (false, true) => "usage",
+        _ => return None,
+    };
+    let name = path.file_name()?.to_str()?;
+    if name.is_empty() || name.len() > MAX_NAME_BYTES || name.chars().any(char::is_control) {
+        reasons.insert("path_not_displayable");
+        return None;
+    }
+    Some(Candidate {
+        // Keep native PathBufs for every filesystem call; only projected
+        // metadata and its ID use the shared, local-drive display contract.
+        path: display_path_text(path.to_str()?)?.into(),
+        name: name.into(),
+        evidence,
+        modified: context.flatten().max(usage.flatten()),
+    })
+}
+
+fn marker(path: &Path, sqlite: bool, reasons: &mut BTreeSet<&'static str>) -> Option<Option<u64>> {
+    let before = metadata(path, reasons)?;
+    if !before.is_file() {
+        reasons.insert("marker_not_regular");
+        return None;
+    }
+    if before.len() == 0 {
+        return None;
+    }
+    let mut file = match open_marker(path) {
+        Ok(file) => file,
+        Err(_) => {
+            reasons.insert("marker_unreadable");
+            return None;
+        }
+    };
+    let current = match file.metadata() {
+        Ok(current) if current.is_file() && !is_link(&current) => current,
+        _ => {
+            reasons.insert("marker_not_regular");
+            return None;
+        }
+    };
+    let mut prefix = [0u8; MARKER_PREFIX_BYTES];
+    let count = match file.read(if sqlite {
+        &mut prefix[..100]
+    } else {
+        &mut prefix
+    }) {
+        Ok(count) => count,
+        Err(_) => {
+            reasons.insert("marker_unreadable");
+            return None;
+        }
+    };
+    let prefix = &prefix[..count];
+    // Only signature/size checks. Neither JSONL content nor SQLite tables are parsed.
+    let recognizable = if sqlite {
+        current.len() >= 100 && prefix.starts_with(b"SQLite format 3\0")
+    } else {
+        let prefix = prefix.strip_prefix(b"\xef\xbb\xbf").unwrap_or(prefix);
+        current.len() >= 2 && prefix.iter().find(|byte| !byte.is_ascii_whitespace()) == Some(&b'{')
+    };
+    if !recognizable {
+        reasons.insert("marker_header_invalid");
+        return None;
+    }
+    Some(
+        current
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .filter(|epoch| *epoch <= MAX_SAFE_INTEGER),
+    )
+}
+
+fn is_link(metadata: &Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        // WinNT.h FILE_ATTRIBUTE_REPARSE_POINT includes junctions as well as symlinks.
+        if metadata.file_attributes() & 0x0000_0400 != 0 {
+            return true;
+        }
+    }
+    metadata.file_type().is_symlink()
+}
+
+fn open_marker(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Darwin fcntl.h: O_NOFOLLOW | O_NONBLOCK (never wait on a substituted FIFO).
+        options.custom_flags(0x0000_0100 | 0x0000_0004);
+    }
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ))]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Linux asm-generic/fcntl.h, used by the supported Linux targets.
+        options.custom_flags((1 << 17) | (1 << 11));
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // CreateFileW FILE_FLAG_OPEN_REPARSE_POINT, checked again on the opened handle.
+        options.custom_flags(0x0020_0000);
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        windows,
+        all(
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "x86_64")
+        )
+    )))]
+    return Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "project marker platform unsupported",
+    ));
+    options.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn windows_projection_uses_local_drive_text_for_project_root_and_home() {
+        for (canonical, displayed) in [
+            (
+                r"\\?\C:\Users\person\Projects\project",
+                r"C:\Users\person\Projects\project",
+            ),
+            (r"\\?\C:\Users\person\Projects", r"C:\Users\person\Projects"),
+            (r"\\?\C:\Users\person", r"C:\Users\person"),
+        ] {
+            assert_eq!(display_path_text(canonical), Some(displayed));
+        }
+        for rejected in [
+            r"\\?\UNC\server\share\project",
+            r"\\.\C:\project",
+            r"\\?\GLOBALROOT\Device\volume",
+        ] {
+            assert_eq!(display_path_text(rejected), None);
+        }
+        let canonical = r"\\?\C:\Users\person\Projects\project";
+        let project = Candidate {
+            path: display_path_text(canonical).unwrap().into(),
+            name: "project".into(),
+            evidence: "usage",
+            modified: None,
+        }
+        .json();
+        assert_eq!(project["path"], r"C:\Users\person\Projects\project");
+        assert_eq!(
+            project["id"],
+            format!(
+                "project-{:x}",
+                Sha256::digest(r"C:\Users\person\Projects\project".as_bytes())
+            )
+        );
+        assert_ne!(
+            project["id"],
+            format!("project-{:x}", Sha256::digest(canonical.as_bytes()))
+        );
+    }
+
+    struct Home(PathBuf);
+    impl Home {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "simplicio-project-usage-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn context_ledger(&self, relative: &str) -> PathBuf {
+            let project = self.0.join(relative);
+            let ledger = project.join(".simplicio/ledger");
+            fs::create_dir_all(&ledger).unwrap();
+            fs::write(
+                ledger.join("savings-events.jsonl"),
+                b"{\"private_field\":\"PRIVATE_PROJECT_USAGE_SENTINEL\"}\n",
+            )
+            .unwrap();
+            project
+        }
+
+        fn usage_ledger(&self, relative: &str) -> PathBuf {
+            let project = self.0.join(relative);
+            let state = project.join(".simplicio");
+            fs::create_dir_all(&state).unwrap();
+            // SQLite's documented magic and 100-byte header, not a valid ledger database.
+            // Discovery must identify a candidate without claiming its integrity or contents.
+            let mut header = [0u8; 100];
+            header[..16].copy_from_slice(b"SQLite format 3\0");
+            fs::write(state.join("token-usage.sqlite3"), header).unwrap();
+            project
+        }
+    }
+    impl Drop for Home {
+        fn drop(&mut self) {
+            // The fixture owns this exact newly-created directory, never user data.
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn discovers_a_context_ledger_without_exposing_its_contents_or_claiming_usage() {
+        let home = Home::new();
+        let project = home.context_ledger("Projects/customer-material");
+        let marker = project.join(".simplicio/ledger/savings-events.jsonl");
+        let before = fs::metadata(&marker).unwrap().modified().unwrap();
+        let report = discover(&home.0, None);
+        let projects = report["projects"].as_array().unwrap();
+        assert_eq!(
+            projects.len(),
+            1,
+            "a real local ledger marker was not discovered"
+        );
+        assert_eq!(projects[0]["name"], "customer-material");
+        let canonical_project = fs::canonicalize(project).unwrap();
+        assert_eq!(
+            projects[0]["path"],
+            display_path_text(canonical_project.to_str().unwrap()).unwrap()
+        );
+        assert_eq!(projects[0]["evidenceType"], "context");
+        assert!(projects[0]["id"].as_str().unwrap().starts_with("project-"));
+        assert_eq!(projects[0]["id"].as_str().unwrap().len(), 72);
+        assert!(projects[0]["lastModifiedEpoch"].as_u64().is_some());
+        assert_eq!(report["candidateCount"], 1);
+        assert!(report["qualification"]
+            .as_str()
+            .unwrap()
+            .contains("report query must validate"));
+        assert!(!report
+            .to_string()
+            .contains("PRIVATE_PROJECT_USAGE_SENTINEL"));
+        assert!(!report.to_string().contains("private_field"));
+        assert_eq!(fs::metadata(marker).unwrap().modified().unwrap(), before);
+    }
+
+    #[test]
+    fn discovered_project_matches_the_local_project_selector_contract() {
+        let home = Home::new();
+        let project = home.context_ledger("Projects/same-project-in-picker-and-discovery");
+        let selected = crate::local_projects::validate_project(project.to_str().unwrap()).unwrap();
+        let report = discover(&home.0, None);
+        let candidate = &report["projects"][0];
+        assert_eq!(candidate["path"], selected["path"]);
+        assert_eq!(
+            candidate["id"], selected["id"],
+            "discovery and the native selector disagree on project identity"
+        );
+    }
+
+    #[test]
+    fn absent_markers_bookmarks_and_other_home_folders_are_not_reported_as_usage() {
+        let home = Home::new();
+        home.context_ledger("Private/unrelated-folder");
+        fs::create_dir_all(home.0.join("Projects/bookmarked/.simplicio")).unwrap();
+        fs::write(
+            home.0.join("Projects/bookmarked/notes.txt"),
+            b"PRIVATE_NOT_A_LEDGER",
+        )
+        .unwrap();
+        let report = discover(&home.0, None);
+        assert_eq!(report["projects"], json!([]));
+        assert_eq!(report["candidateCount"], 0);
+        assert_eq!(report["roots"].as_array().unwrap().len(), 1);
+        assert_eq!(report["roots"][0]["name"], "Projects");
+        assert_eq!(report["partial"], false);
+        assert!(!report.to_string().contains("unrelated-folder"));
+        assert!(!report.to_string().contains("PRIVATE_NOT_A_LEDGER"));
+    }
+
+    #[test]
+    fn sqlite_magic_classifies_usage_or_both_but_does_not_prove_database_integrity() {
+        let home = Home::new();
+        home.usage_ledger("Projetos/usage-only");
+        home.context_ledger("Desktop/both-markers");
+        home.usage_ledger("Desktop/both-markers");
+        let report = discover(&home.0, None);
+        let projects = report["projects"].as_array().unwrap();
+        assert_eq!(projects.len(), 2);
+        assert_eq!(
+            projects.iter().find(|p| p["name"] == "usage-only").unwrap()["evidenceType"],
+            "usage"
+        );
+        assert_eq!(
+            projects
+                .iter()
+                .find(|p| p["name"] == "both-markers")
+                .unwrap()["evidenceType"],
+            "both"
+        );
+        assert!(projects
+            .iter()
+            .all(|p| p.get("tokens").is_none() && p.get("savings").is_none()));
+        assert_eq!(report["partial"], false);
+    }
+
+    #[test]
+    fn token_ledger_path_is_canonical_even_without_context_ledger() {
+        let home = Home::new();
+        let project = home.usage_ledger("Projects/sqlite-without-context");
+        let database = fs::canonicalize(project.join(".simplicio/token-usage.sqlite3")).unwrap();
+        assert!(!project.join(".simplicio/ledger").exists());
+        let args = crate::desktop_queries::token_query_args(
+            &json!({"timezoneOffsetSeconds": 0}),
+            &project,
+        )
+        .unwrap();
+        assert!(args
+            .windows(2)
+            .any(|pair| { pair[0] == "--db" && Path::new(&pair[1]) == database }));
+        let report = discover(&home.0, None);
+        assert_eq!(
+            report["projects"].as_array().unwrap().len(),
+            1,
+            "discovery missed the canonical token ledger accepted by token_query_args"
+        );
+        assert_eq!(report["projects"][0]["evidenceType"], "usage");
+        let canonical_project = fs::canonicalize(&project).unwrap();
+        assert_eq!(
+            report["projects"][0]["path"],
+            display_path_text(canonical_project.to_str().unwrap()).unwrap()
+        );
+        assert_eq!(report["partial"], false);
+    }
+
+    #[test]
+    fn token_ledger_path_rejects_the_obsolete_nested_location() {
+        let home = Home::new();
+        let project = home.usage_ledger("Projects/obsolete-nested-database");
+        fs::create_dir(project.join(".simplicio/ledger")).unwrap();
+        fs::rename(
+            project.join(".simplicio/token-usage.sqlite3"),
+            project.join(".simplicio/ledger/token-usage.sqlite3"),
+        )
+        .unwrap();
+        assert_eq!(
+            crate::desktop_queries::token_query_args(
+                &json!({"timezoneOffsetSeconds": 0}),
+                &project
+            )
+            .unwrap_err(),
+            "token_ledger_unavailable"
+        );
+        let report = discover(&home.0, None);
+        assert_eq!(
+            report["projects"],
+            json!([]),
+            "discovery must not advertise the obsolete token ledger rejected by report queries"
+        );
+        assert_eq!(report["candidateCount"], 0);
+    }
+
+    #[test]
+    fn empty_non_regular_and_unrecognized_markers_are_not_candidates() {
+        let home = Home::new();
+        let empty = home.context_ledger("Projects/empty");
+        fs::write(empty.join(".simplicio/ledger/savings-events.jsonl"), b"").unwrap();
+        let invalid_json = home.context_ledger("Projects/wrong-json-header");
+        fs::write(
+            invalid_json.join(".simplicio/ledger/savings-events.jsonl"),
+            b"PRIVATE_INVALID_HEADER",
+        )
+        .unwrap();
+        let invalid_sqlite = home.usage_ledger("Projects/wrong-sqlite-header");
+        fs::write(
+            invalid_sqlite.join(".simplicio/token-usage.sqlite3"),
+            [b'x'; 100],
+        )
+        .unwrap();
+        let short_sqlite = home.usage_ledger("Projects/short-sqlite");
+        fs::write(
+            short_sqlite.join(".simplicio/token-usage.sqlite3"),
+            b"SQLite format 3\0",
+        )
+        .unwrap();
+        fs::create_dir_all(
+            home.0
+                .join("Projects/not-a-file/.simplicio/token-usage.sqlite3"),
+        )
+        .unwrap();
+        let report = discover(&home.0, None);
+        assert_eq!(report["projects"], json!([]));
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("marker_header_invalid")));
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("marker_not_regular")));
+        assert!(!report.to_string().contains("PRIVATE_INVALID_HEADER"));
+    }
+
+    #[test]
+    fn generated_trees_are_excluded_but_worktrees_remain_in_scope() {
+        let home = Home::new();
+        for excluded in [
+            ".git",
+            "node_modules",
+            "target",
+            "dist",
+            "bin",
+            "binaries",
+            "build",
+            "vendor",
+            ".venv",
+            "venv",
+            ".cache",
+            "caches",
+            ".simplicio",
+        ] {
+            home.context_ledger(&format!("Projects/{excluded}/excluded-project"));
+        }
+        home.context_ledger("Projects/repository/.worktrees/real-source");
+        let report = discover(&home.0, None);
+        assert_eq!(report["projects"].as_array().unwrap().len(), 1);
+        assert_eq!(report["projects"][0]["name"], "real-source");
+        assert_eq!(report["scope"]["readsProjectFiles"], false);
+        assert_eq!(report["scope"]["followsSymlinks"], false);
+    }
+
+    #[test]
+    fn canonical_roots_are_deduplicated_and_home_is_never_accepted_as_a_scan_root() {
+        let home = Home::new();
+        home.context_ledger("Projects/project");
+        let alias = home.0.join("Projects/../Projects");
+        let report = discover(&home.0, Some(&alias));
+        assert_eq!(report["roots"].as_array().unwrap().len(), 1);
+        assert_eq!(report["candidateCount"], 1);
+        let rejected = discover(&home.0, Some(&home.0));
+        assert!(rejected["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("configured_root_rejected")));
+        assert_eq!(rejected["roots"].as_array().unwrap().len(), 1);
+        assert_ne!(
+            rejected["roots"][0]["path"],
+            fs::canonicalize(&home.0).unwrap().to_str().unwrap()
+        );
+        let configured = home.context_ledger("Explicit/project-outside-conventional-roots");
+        assert_eq!(discover(&home.0, None)["candidateCount"], 1);
+        assert_eq!(discover(&home.0, Some(&configured))["candidateCount"], 2);
+    }
+
+    #[test]
+    fn depth_limit_is_visible_instead_of_claiming_an_exhaustive_inventory() {
+        let home = Home::new();
+        home.context_ledger("Projects/visible");
+        home.context_ledger("Projects/too/deep");
+        let report = discover_with_limits(&home.0, None, Limits { depth: 1, ..LIMITS });
+        assert_eq!(report["projects"].as_array().unwrap().len(), 1);
+        assert_eq!(report["projects"][0]["name"], "visible");
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("depth_limit")));
+    }
+
+    #[test]
+    fn directory_and_entry_budgets_bound_the_frontier_and_flat_file_directories() {
+        let home = Home::new();
+        home.context_ledger("Projects/first");
+        home.context_ledger("Projects/second");
+        let report = discover_with_limits(
+            &home.0,
+            None,
+            Limits {
+                directories: 1,
+                ..LIMITS
+            },
+        );
+        assert_eq!(report["directoriesVisited"], 1);
+        assert_eq!(report["candidateCount"], 0);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("directory_limit")));
+        for index in 0..8 {
+            fs::write(
+                home.0.join(format!("Projects/file-{index}")),
+                b"do not read",
+            )
+            .unwrap();
+        }
+        let report = discover_with_limits(
+            &home.0,
+            None,
+            Limits {
+                entries: 3,
+                ..LIMITS
+            },
+        );
+        assert_eq!(report["entriesVisited"], 3);
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("entry_limit")));
+    }
+
+    #[test]
+    fn elapsed_deadline_returns_partial_without_starting_a_detached_scan() {
+        let home = Home::new();
+        home.context_ledger("Projects/project");
+        let started = Instant::now();
+        let report = discover_with_limits(
+            &home.0,
+            None,
+            Limits {
+                deadline: Duration::ZERO,
+                ..LIMITS
+            },
+        );
+        assert_eq!(report["directoriesVisited"], 0);
+        assert_eq!(report["entriesVisited"], 0);
+        assert_eq!(report["projects"], json!([]));
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("deadline")));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn retains_the_newest_64_candidates_not_the_first_bfs_entries() {
+        let home = Home::new();
+        for index in 0..65 {
+            let project = home.context_ledger(&format!("Projects/project-{index:02}"));
+            OpenOptions::new()
+                .write(true)
+                .open(project.join(".simplicio/ledger/savings-events.jsonl"))
+                .unwrap()
+                .set_modified(UNIX_EPOCH + Duration::from_secs(1_700_000_000 + index))
+                .unwrap();
+        }
+        let report = discover(&home.0, None);
+        let projects = report["projects"].as_array().unwrap();
+        assert_eq!(report["candidateCount"], 65);
+        assert_eq!(projects.len(), 64);
+        assert_eq!(projects[0]["name"], "project-64");
+        assert_eq!(projects[0]["lastModifiedEpoch"], 1_700_000_064u64);
+        assert_eq!(projects[63]["name"], "project-01");
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("result_limit")));
+        let second = discover(&home.0, None);
+        assert_eq!(second["projects"], report["projects"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_follow_project_state_ledger_file_or_root_symlinks() {
+        use std::os::unix::fs::symlink;
+        let home = Home::new();
+        let outside = Home::new();
+        let source = outside.context_ledger("private-outside-project");
+        let projects = home.0.join("Projects");
+        fs::create_dir(&projects).unwrap();
+        symlink(&source, projects.join("linked-project")).unwrap();
+        fs::create_dir(projects.join("linked-state")).unwrap();
+        symlink(
+            source.join(".simplicio"),
+            projects.join("linked-state/.simplicio"),
+        )
+        .unwrap();
+        fs::create_dir_all(projects.join("linked-ledger/.simplicio")).unwrap();
+        symlink(
+            source.join(".simplicio/ledger"),
+            projects.join("linked-ledger/.simplicio/ledger"),
+        )
+        .unwrap();
+        fs::create_dir_all(projects.join("linked-file/.simplicio/ledger")).unwrap();
+        symlink(
+            source.join(".simplicio/ledger/savings-events.jsonl"),
+            projects.join("linked-file/.simplicio/ledger/savings-events.jsonl"),
+        )
+        .unwrap();
+        symlink(&source, home.0.join("Desktop")).unwrap();
+        let report = discover(&home.0, None);
+        assert_eq!(report["projects"], json!([]));
+        assert_eq!(report["roots"].as_array().unwrap().len(), 1);
+        assert_eq!(report["partial"], true);
+        assert!(report["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("symlink_skipped")));
+        assert!(!report.to_string().contains("private-outside-project"));
+    }
+}

--- a/apps/desktop/src-tauri/src/runtime_process.rs
+++ b/apps/desktop/src-tauri/src/runtime_process.rs
@@ -1,0 +1,544 @@
+//! Owned Runtime process boundary. Errors never contain output, arguments, or paths.
+use std::io;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+const CLEANUP_DEADLINE: Duration = Duration::from_millis(500);
+// Only Child handles created by capture are retained here. No PID lookup,
+// process-group signal, external-process termination, or Runtime lock deletion.
+static PENDING_CHILDREN: Mutex<Vec<Child>> = Mutex::new(Vec::new());
+
+#[derive(Clone, Copy, Debug)]
+pub struct CaptureLimits {
+    pub deadline: Duration,
+    pub stdout_bytes: usize,
+    pub stderr_bytes: usize,
+}
+
+impl CaptureLimits {
+    pub const QUERY: Self = Self {
+        deadline: Duration::from_secs(20),
+        stdout_bytes: 256 * 1024,
+        stderr_bytes: 16 * 1024,
+    };
+    pub const OAUTH: Self = Self {
+        deadline: Duration::from_secs(180),
+        stdout_bytes: 64 * 1024,
+        stderr_bytes: 16 * 1024,
+    };
+    pub const INSTALL: Self = Self {
+        deadline: Duration::from_secs(300),
+        stdout_bytes: 64 * 1024,
+        stderr_bytes: 16 * 1024,
+    };
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FailureKind {
+    Spawn,
+    Deadline,
+    StdoutLimit,
+    StderrLimit,
+    Capture,
+    CleanupPending,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChildState {
+    NotStarted,
+    Reaped,
+    Retained,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProcessFailure {
+    pub kind: FailureKind,
+    pub child_state: ChildState,
+}
+
+impl ProcessFailure {
+    pub fn may_try_another_candidate(self) -> bool {
+        self.kind == FailureKind::Spawn && self.child_state == ChildState::NotStarted
+    }
+}
+
+/// Candidate fallback is permitted only before a process starts. Nonzero exit,
+/// timeout, pipe failure, and pending cleanup are final for this invocation.
+pub fn capture_candidates(
+    commands: impl IntoIterator<Item = Command>,
+    limits: CaptureLimits,
+) -> Result<Output, ProcessFailure> {
+    for mut command in commands {
+        match capture(&mut command, limits) {
+            Err(failure) if failure.may_try_another_candidate() => continue,
+            result => return result,
+        }
+    }
+    Err(ProcessFailure {
+        kind: FailureKind::Spawn,
+        child_state: ChildState::NotStarted,
+    })
+}
+
+pub fn capture(command: &mut Command, limits: CaptureLimits) -> Result<Output, ProcessFailure> {
+    {
+        let mut pending = PENDING_CHILDREN
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        pending.retain_mut(|child| !matches!(child.try_wait(), Ok(Some(_))));
+        if !pending.is_empty() {
+            return Err(ProcessFailure {
+                kind: FailureKind::CleanupPending,
+                child_state: ChildState::Retained,
+            });
+        }
+    }
+    let started = Instant::now();
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|_| ProcessFailure {
+            kind: FailureKind::Spawn,
+            child_state: ChildState::NotStarted,
+        })?;
+    match capture_started(&mut child, limits, started) {
+        Ok(output) => Ok(output),
+        Err(kind) => Err(ProcessFailure {
+            kind,
+            child_state: settle_owned_child(child),
+        }),
+    }
+}
+
+fn settle_owned_child(mut child: Child) -> ChildState {
+    // Pipe readers are already dropped. Do not wait for a descendant to close
+    // an inherited descriptor, and never leave an unbounded reader thread.
+    match child.try_wait() {
+        Ok(Some(_)) => return ChildState::Reaped,
+        Ok(None) => {
+            let _ = child.kill();
+        }
+        Err(_) => {
+            // If OS ownership cannot be confirmed, never turn a stale numeric
+            // PID into a termination request. Keep the handle unresolved.
+            PENDING_CHILDREN
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(child);
+            return ChildState::Retained;
+        }
+    }
+    let started = Instant::now();
+    while started.elapsed() < CLEANUP_DEADLINE {
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return ChildState::Reaped;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    // An OS-level failure to terminate/reap is not a successful cleanup. Keep
+    // ownership and refuse subsequent capture until try_wait proves exit.
+    PENDING_CHILDREN
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .push(child);
+    ChildState::Retained
+}
+
+fn capture_started(
+    child: &mut Child,
+    limits: CaptureLimits,
+    started: Instant,
+) -> Result<Output, FailureKind> {
+    let mut stdout_pipe = child.stdout.take().ok_or(FailureKind::Capture)?;
+    let mut stderr_pipe = child.stderr.take().ok_or(FailureKind::Capture)?;
+    pipe::prepare(&stdout_pipe).map_err(|_| FailureKind::Capture)?;
+    pipe::prepare(&stderr_pipe).map_err(|_| FailureKind::Capture)?;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdout_eof = false;
+    let mut stderr_eof = false;
+    let mut status = None;
+    loop {
+        if started.elapsed() >= limits.deadline {
+            return Err(FailureKind::Deadline);
+        }
+        let out_progress = drain_one(
+            &mut stdout_pipe,
+            &mut stdout,
+            &mut stdout_eof,
+            limits.stdout_bytes,
+            FailureKind::StdoutLimit,
+        )?;
+        let err_progress = drain_one(
+            &mut stderr_pipe,
+            &mut stderr,
+            &mut stderr_eof,
+            limits.stderr_bytes,
+            FailureKind::StderrLimit,
+        )?;
+        if status.is_none() {
+            status = child.try_wait().map_err(|_| FailureKind::Capture)?;
+        }
+        if stdout_eof && stderr_eof {
+            if let Some(status) = status {
+                return Ok(Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+        }
+        if !out_progress && !err_progress {
+            std::thread::sleep(
+                POLL_INTERVAL.min(limits.deadline.saturating_sub(started.elapsed())),
+            );
+        }
+    }
+}
+
+fn drain_one<T: pipe::Pipe>(
+    pipe: &mut T,
+    output: &mut Vec<u8>,
+    eof: &mut bool,
+    limit: usize,
+    overflow: FailureKind,
+) -> Result<bool, FailureKind> {
+    if *eof {
+        return Ok(false);
+    }
+    let mut bytes = [0_u8; 8192];
+    let available = limit.saturating_sub(output.len());
+    let read_size = bytes.len().min(available.saturating_add(1));
+    match pipe::read_ready(pipe, &mut bytes[..read_size]) {
+        Ok(Some(0)) => {
+            *eof = true;
+            Ok(false)
+        }
+        Ok(Some(count)) if count > available => Err(overflow),
+        Ok(Some(count)) => {
+            output.extend_from_slice(&bytes[..count]);
+            Ok(true)
+        }
+        Ok(None) => Ok(false),
+        Err(error) if error.kind() == io::ErrorKind::Interrupted => Ok(false),
+        Err(_) => Err(FailureKind::Capture),
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    )
+))]
+mod pipe {
+    use std::io::{self, Read};
+    use std::os::fd::AsRawFd;
+    use std::os::raw::c_int;
+
+    pub trait Pipe: Read + AsRawFd {}
+    impl<T: Read + AsRawFd> Pipe for T {}
+
+    // Apple xnu bsd/sys/fcntl.h and Linux uapi/asm-generic/fcntl.h.
+    // These flags intentionally differ by OS; other targets fail closed below.
+    const F_GETFL: c_int = 3;
+    const F_SETFL: c_int = 4;
+    #[cfg(target_os = "macos")]
+    const O_NONBLOCK: c_int = 0x0004;
+    #[cfg(target_os = "linux")]
+    const O_NONBLOCK: c_int = 1 << 11;
+
+    extern "C" {
+        fn fcntl(fd: c_int, command: c_int, ...) -> c_int;
+    }
+
+    pub fn prepare<T: Pipe>(pipe: &T) -> io::Result<()> {
+        // SAFETY: fd belongs to the live, exclusively-owned child pipe; the
+        // commands and promoted c_int argument match this platform's ABI.
+        let flags = unsafe { fcntl(pipe.as_raw_fd(), F_GETFL) };
+        if flags < 0 || unsafe { fcntl(pipe.as_raw_fd(), F_SETFL, flags | O_NONBLOCK) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub fn read_ready<T: Pipe>(pipe: &mut T, buffer: &mut [u8]) -> io::Result<Option<usize>> {
+        match pipe.read(buffer) {
+            Ok(count) => Ok(Some(count)),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(windows)]
+mod pipe {
+    use std::ffi::c_void;
+    use std::io::{self, Read};
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+
+    pub trait Pipe: Read + AsRawHandle {}
+    impl<T: Read + AsRawHandle> Pipe for T {}
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn PeekNamedPipe(
+            handle: *mut c_void,
+            buffer: *mut c_void,
+            size: u32,
+            read: *mut u32,
+            available: *mut u32,
+            left: *mut u32,
+        ) -> i32;
+    }
+
+    pub fn prepare<T: Pipe>(_pipe: &T) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn read_ready<T: Pipe>(pipe: &mut T, buffer: &mut [u8]) -> io::Result<Option<usize>> {
+        let mut available = 0_u32;
+        // SAFETY: Command::spawn's parent-side pipes are overlapped handles
+        // (Rust std windows/pipe.rs); only this thread accesses this pipe.
+        // Peek only obtains the available byte count. No borrowed handle is
+        // closed, replaced, or shared with another reader.
+        let result = unsafe {
+            PeekNamedPipe(
+                pipe.as_raw_handle(),
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                &mut available,
+                ptr::null_mut(),
+            )
+        };
+        if result == 0 {
+            let error = io::Error::last_os_error();
+            return if error.kind() == io::ErrorKind::BrokenPipe {
+                Ok(Some(0))
+            } else {
+                Err(error)
+            };
+        }
+        if available == 0 {
+            return Ok(None);
+        }
+        let count = buffer.len().min(available as usize);
+        // No other reader can consume the peeked bytes between these calls.
+        pipe.read(&mut buffer[..count]).map(Some)
+    }
+}
+
+#[cfg(not(any(
+    windows,
+    target_os = "macos",
+    all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    )
+)))]
+mod pipe {
+    use std::io::{self, Read};
+    pub trait Pipe: Read {}
+    impl<T: Read> Pipe for T {}
+    pub fn prepare<T: Pipe>(_pipe: &T) -> io::Result<()> {
+        Err(io::ErrorKind::Unsupported.into())
+    }
+    pub fn read_ready<T: Pipe>(_pipe: &mut T, _buffer: &mut [u8]) -> io::Result<Option<usize>> {
+        Err(io::ErrorKind::Unsupported.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn child_case(case: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command.args([
+            "--exact",
+            "runtime_process::tests::runtime_child_fixture",
+            "--nocapture",
+        ]);
+        command.env("SIMPLICIO_DESKTOP_CAPTURE_TEST_CASE", case);
+        command
+    }
+
+    #[test]
+    fn runtime_child_fixture() {
+        let Ok(case) = std::env::var("SIMPLICIO_DESKTOP_CAPTURE_TEST_CASE") else {
+            return;
+        };
+        match case.as_str() {
+            "stdout-flood" => {
+                std::io::stdout().write_all(&[b'x'; 64 * 1024]).unwrap();
+                std::io::stdout().flush().unwrap();
+                std::thread::sleep(Duration::from_secs(2));
+            }
+            "stderr-flood" => {
+                std::io::stderr().write_all(&[b'x'; 64 * 1024]).unwrap();
+                std::io::stderr().flush().unwrap();
+                std::thread::sleep(Duration::from_secs(2));
+            }
+            "wait" => {
+                eprintln!("DO_NOT_LEAK_CAPTURE_SENTINEL");
+                std::thread::sleep(Duration::from_secs(2));
+            }
+            "bounded" => {
+                println!("fixture-ready");
+                eprintln!("fixture-diagnostic");
+            }
+            "exit-seven" => {
+                println!("{{\"status\":\"applied\"}}");
+                std::process::exit(7);
+            }
+            "pipe-holder" => {
+                std::thread::sleep(Duration::from_millis(600));
+                let path = std::env::var_os("SIMPLICIO_DESKTOP_CAPTURE_TEST_DONE").unwrap();
+                std::fs::write(path, b"holder-finished").unwrap();
+            }
+            "inherit-pipe" => {
+                let mut holder = child_case("pipe-holder");
+                holder.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+                // This finite fixture is the only descendant launched by a
+                // test. It self-terminates; the outer test waits for its done
+                // marker without killing a PID learned from process output.
+                let _holder = holder.spawn().unwrap();
+            }
+            _ => panic!("unknown fixture case"),
+        }
+        std::process::exit(0);
+    }
+
+    #[test]
+    fn stdout_is_capped_during_capture_not_after_collecting_the_child() {
+        let started = Instant::now();
+        let failure = capture(
+            &mut child_case("stdout-flood"),
+            CaptureLimits {
+                deadline: Duration::from_secs(3),
+                stdout_bytes: 1024,
+                stderr_bytes: 1024,
+            },
+        )
+        .err()
+        .expect("capture accepted output beyond its memory budget");
+        assert_eq!(failure.kind, FailureKind::StdoutLimit);
+        assert_eq!(failure.child_state, ChildState::Reaped);
+        assert!(!failure.may_try_another_candidate());
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "limit was checked only after the child finished"
+        );
+    }
+
+    fn short_limits() -> CaptureLimits {
+        CaptureLimits {
+            deadline: Duration::from_millis(200),
+            stdout_bytes: 4096,
+            stderr_bytes: 4096,
+        }
+    }
+
+    #[test]
+    fn deadline_terminates_and_reaps_only_the_started_child() {
+        let started = Instant::now();
+        let failure = capture(&mut child_case("wait"), short_limits())
+            .err()
+            .expect("deadline was ignored");
+        assert_eq!(failure.kind, FailureKind::Deadline);
+        assert_eq!(failure.child_state, ChildState::Reaped);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(!format!("{failure:?}").contains("DO_NOT_LEAK_CAPTURE_SENTINEL"));
+    }
+
+    #[test]
+    fn stderr_has_an_independent_memory_bound() {
+        let started = Instant::now();
+        let failure = capture(&mut child_case("stderr-flood"), short_limits())
+            .err()
+            .expect("stderr limit was ignored");
+        assert_eq!(failure.kind, FailureKind::StderrLimit);
+        assert_eq!(failure.child_state, ChildState::Reaped);
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn completed_output_preserves_exit_status_and_both_bounded_streams() {
+        let output = capture(&mut child_case("bounded"), CaptureLimits::QUERY).unwrap();
+        assert_eq!(output.status.code(), Some(0));
+        assert!(String::from_utf8_lossy(&output.stdout).contains("fixture-ready"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("fixture-diagnostic"));
+        assert!(output.stdout.len() < 4096 && output.stderr.len() < 4096);
+    }
+
+    #[test]
+    fn candidate_fallback_is_only_for_proven_spawn_failure() {
+        let missing = std::env::current_exe()
+            .unwrap()
+            .join("not-a-directory-or-runtime");
+        let error = capture(&mut Command::new(&missing), short_limits())
+            .err()
+            .expect("invalid executable path started");
+        assert_eq!(error.kind, FailureKind::Spawn);
+        assert_eq!(error.child_state, ChildState::NotStarted);
+        assert!(error.may_try_another_candidate());
+        let output = capture_candidates(
+            [Command::new(missing), child_case("bounded")],
+            CaptureLimits::QUERY,
+        )
+        .unwrap();
+        assert!(output.status.success());
+        let output = capture_candidates(
+            [child_case("exit-seven"), child_case("bounded")],
+            CaptureLimits::QUERY,
+        )
+        .unwrap();
+        assert_eq!(output.status.code(), Some(7));
+        let failure =
+            capture_candidates([child_case("wait"), child_case("bounded")], short_limits())
+                .err()
+                .expect("started effect was replayed");
+        assert_eq!(failure.kind, FailureKind::Deadline);
+    }
+
+    #[test]
+    fn inherited_pipe_does_not_hold_the_capture_or_an_orphan_reader_thread() {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let id = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let done = std::env::temp_dir().join(format!(
+            "simplicio-capture-{}-{id}.done",
+            std::process::id()
+        ));
+        assert!(!done.exists(), "fixture completion path must be fresh");
+        let mut command = child_case("inherit-pipe");
+        command.env("SIMPLICIO_DESKTOP_CAPTURE_TEST_DONE", &done);
+        let started = Instant::now();
+        let result = capture(&mut command, short_limits());
+        let elapsed = started.elapsed();
+        // Wait for this bounded fixture's own completion before reporting, so
+        // the test never leaves a long-lived pipe holder behind.
+        let cleanup = Instant::now();
+        while !done.exists() && cleanup.elapsed() < Duration::from_secs(3) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let completed = std::fs::read(&done);
+        if completed.is_ok() {
+            std::fs::remove_file(&done).unwrap();
+        }
+        assert_eq!(completed.unwrap(), b"holder-finished");
+        let failure = result
+            .err()
+            .expect("capture waited for an inherited pipe to close");
+        assert_eq!(failure.kind, FailureKind::Deadline);
+        assert_eq!(failure.child_state, ChildState::Reaped);
+        assert!(elapsed < Duration::from_millis(550));
+    }
+}

--- a/apps/desktop/src-tauri/src/supervisor.rs
+++ b/apps/desktop/src-tauri/src/supervisor.rs
@@ -58,12 +58,16 @@ impl SidecarSupervisor {
 
     pub fn mark_failed(&mut self) -> Duration {
         self.failures = self.failures.saturating_add(1);
-        let seconds = 2u64.saturating_pow(self.failures.saturating_sub(1) as u32).min(MAX_BACKOFF_SECONDS);
+        let seconds = 2u64
+            .saturating_pow(self.failures.saturating_sub(1) as u32)
+            .min(MAX_BACKOFF_SECONDS);
         self.backoff = Duration::from_secs(seconds);
         self.state = if self.failures >= self.max_restarts {
             SidecarState::Offline
         } else {
-            SidecarState::Degraded { attempt: self.failures }
+            SidecarState::Degraded {
+                attempt: self.failures,
+            }
         };
         self.backoff
     }
@@ -110,6 +114,9 @@ mod tests {
         for _ in 0..20 {
             supervisor.mark_failed();
         }
-        assert_eq!(supervisor.backoff(), Duration::from_secs(MAX_BACKOFF_SECONDS));
+        assert_eq!(
+            supervisor.backoff(),
+            Duration::from_secs(MAX_BACKOFF_SECONDS)
+        );
     }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,8 @@ import { PreferencesScreen } from "./screens/PreferencesScreen";
 import { SetupScreen } from "./screens/SetupScreen";
 import { ProjectDialog } from "./components/ProjectDialog";
 import { DesktopUpdates } from "./components/DesktopUpdates";
-import { installFailureMessage } from "./install_failures";
+import { installFailureMessage, installFailureRecovery, type InstallFailureRecovery } from "./install_failures";
+import { runtimeFailureMessage } from "./runtime_failures";
 import { isView, loadWorkbench, MAX_PROJECTS, moveHistory, navigate, WORKBENCH_KEY, type LocalProject, type NavigationState, type WorkbenchState } from "./workbench";
 import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
@@ -27,6 +28,8 @@ import { ActivityScreen } from "./screens/ActivityScreen";
 import { BotCenterScreen } from "./screens/BotCenterScreen";
 import { ProductSurfaceScreen } from "./screens/ProductScreens";
 import { TokensScreen } from "./screens/TokensScreen";
+import { ReferenceSettingsScreen } from "./screens/ReferenceSettingsScreen";
+import { isReferenceSettingsView } from "./reference_screens";
 import "./runtime_panels.css";
 
 function initialView(fallback: View): View {
@@ -41,6 +44,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   const [loadFailed, setLoadFailed] = useState(false);
   const [action, setAction] = useState<"login" | "logout" | "refresh" | "repair" | "subscribe" | "bot" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [applicationRecovery, setApplicationRecovery] = useState<InstallFailureRecovery | undefined>();
   const [workbench, setWorkbench] = useState(loadWorkbench);
   const [history, setHistory] = useState<NavigationState>(() => ({ entries: [{
     view: initialView(workbench.selectedProjectId ? "project" : "home"),
@@ -108,9 +112,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       .catch((error: unknown) => {
         if (current) {
           setLoadFailed(true);
-          setActionError(error instanceof Error && error.message === "desktop_snapshot_timeout"
-            ? "O Runtime não respondeu no prazo. A consulta pode continuar em andamento; tente atualizar o estado após verificar o Runtime."
-            : "Não foi possível consultar o Runtime. Tente atualizar o estado para verificar a conexão.");
+          setActionError(runtimeFailureMessage(error, "query"));
         }
       });
     return () => {
@@ -129,9 +131,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       setBotCenter(next.botCenter);
       setLoadFailed(false);
     } catch (error) {
-      setActionError(error instanceof Error && error.message === "desktop_snapshot_timeout"
-        ? "O Runtime não respondeu no prazo. A consulta anterior ainda pode estar em andamento; nenhuma nova consulta foi iniciada enquanto ela estiver pendente."
-        : "Não foi possível atualizar o Runtime.");
+      setActionError(runtimeFailureMessage(error, "query"));
     } finally {
       setAction(null);
       actionLock.current = false;
@@ -139,7 +139,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   }
 
   async function repairProviders(planDigest: string): Promise<boolean> {
-    if (actionLock.current) return false;
+    if (actionLock.current || (applicationRecovery && applicationRecovery !== "review")) return false;
     actionLock.current = true;
     setAction("repair");
     setActionError(null);
@@ -148,9 +148,11 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       setSnapshot(next);
       setBotCenter(next.botCenter);
       setLoadFailed(false);
+      setApplicationRecovery(undefined);
       return true;
     } catch (error) {
       setActionError(installFailureMessage(error));
+      setApplicationRecovery(installFailureRecovery(error));
       return false;
     } finally {
       setAction(null);
@@ -169,8 +171,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       setBotCenter(next.botCenter);
       setLoadFailed(false);
       if (next.access.state === "active") setView("setup");
-    } catch {
-      setActionError("O login não foi concluído.");
+    } catch (error) {
+      setActionError(runtimeFailureMessage(error, "login"));
     } finally {
       setAction(null);
       actionLock.current = false;
@@ -203,8 +205,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       setBotCenter(next.botCenter);
       setLoadFailed(false);
       setView("home");
-    } catch {
-      setActionError("Não foi possível sair com segurança.");
+    } catch (error) {
+      setActionError(runtimeFailureMessage(error, "logout"));
     } finally {
       setAction(null);
       actionLock.current = false;
@@ -229,7 +231,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   if (!snapshot && !loadFailed) return <LoadingScreen />;
 
   if (loadFailed) {
-    return <AccessGate state="unknown" busy={action !== null} error={actionError} onRefresh={refresh} onLogout={logout} logoutBusy={action === "logout"} />;
+    return <AccessGate state="unknown" busy={action !== null} error={actionError} onRefresh={refresh} onLogin={login} loginBusy={action === "login"} onLogout={logout} logoutBusy={action === "logout"} />;
   }
 
   if (!snapshot || snapshot.access.state === "signed_out") {
@@ -243,6 +245,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         busy={action !== null}
         error={actionError}
         onRefresh={refresh}
+        onLogin={login}
+        loginBusy={action === "login"}
         onSubscribe={subscribe}
         onLogout={logout}
         logoutBusy={action === "logout"}
@@ -250,9 +254,10 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     );
   }
 
-  if (view === "setup") return <SetupScreen snapshot={snapshot} busy={action !== null} applicationError={actionError}
+  if (view === "setup") return <SetupScreen snapshot={snapshot} busy={action !== null} applicationError={actionError} applicationRecovery={applicationRecovery}
     onSnapshot={(next) => { setSnapshot(next); setBotCenter(next.botCenter); }} onApply={repairProviders}
-    onFinish={() => setView("home")} onDiagnostics={() => setView("diagnostics")} />;
+    onVerificationFailure={() => setApplicationRecovery("refresh")}
+    onFinish={() => setView("home")} onDiagnostics={() => { setView("diagnostics"); void refresh(); }} />;
 
   return (
     <Shell snapshot={snapshot} view={view} onViewChange={setView} workbench={{ ...workbench, selectedProjectId: selectedProject?.id ?? null }}
@@ -282,6 +287,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
           repairing={action === "repair"}
           onRefresh={refresh}
           onRepair={repairProviders}
+          applicationRecovery={applicationRecovery}
+          onDiagnostics={() => { setView("diagnostics"); void refresh(); }}
         />
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
@@ -291,6 +298,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       )}
       {(view === "general" || view === "shortcuts" || view === "models") && <PreferencesScreen view={view} snapshot={snapshot} preferences={workbench.preferences} onPreferences={(preferences) => saveWorkbench({ ...workbench, preferences })} onProviders={() => setView("agents")} />}
       {view === "activity" && <ActivityScreen snapshot={snapshot} />}
+      {isReferenceSettingsView(view) && <ReferenceSettingsScreen key={view} view={view} snapshot={snapshot} onNavigate={setView} onRefresh={refresh} busy={action !== null} />}
       {showProjectDialog && <ProjectDialog onClose={() => setShowProjectDialog(false)} onAdd={addProject} />}
     </Shell>
   );

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { open as openFolderDialog } from "@tauri-apps/plugin-dialog";
 import type { AccessState, DesktopSnapshot } from "./contracts";
 import { createDemoSnapshot } from "./demo";
 import type { BotCenterSnapshot } from "./contracts";
@@ -8,8 +9,38 @@ import { parseTokenExportReceipt, parseTokenUsageReport, type TokenQuery, type T
 import { parseIntegrationPlan, type IntegrationPlan } from "./integration_setup";
 import { parseLocalProject, type LocalProject } from "./workbench";
 import { createReadonlyRequest } from "./readonly_request";
+import { createContextReader } from "./context_report";
+import { parseUsageProjects } from "./project_usage";
 
 const readSnapshot = createReadonlyRequest<DesktopSnapshot>(30_000, "desktop_snapshot_timeout");
+const readContext = createContextReader((repoPath) => invoke<unknown>("desktop_context_report", { repoPath: repoPath || null }));
+// Fresh authorization (20s) plus at most four isolated root scans (3s + cleanup each).
+const readUsageProjects = createReadonlyRequest<unknown>(45_000, "project_discovery_timeout");
+
+export async function loadDesktopUsageProjects() {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  return parseUsageProjects(await readUsageProjects(() => invoke<unknown>("desktop_usage_projects")));
+}
+
+export function loadDesktopContextReport(repoPath: string) {
+  if (!isTauri()) return Promise.reject(new Error("preview_no_runtime"));
+  return readContext(repoPath);
+}
+
+let projectPicker: Promise<LocalProject | null> | null = null;
+
+export function chooseDesktopProject(): Promise<LocalProject | null> {
+  if (!isTauri()) return Promise.reject(new Error("preview_no_filesystem"));
+  if (projectPicker) return projectPicker;
+  projectPicker = (async () => {
+    const path = await openFolderDialog({ title: "Adicionar projeto ao Simplicio", directory: true, multiple: false });
+    if (path === null) return null;
+    if (typeof path !== "string") throw new Error("project_path_invalid");
+    // The native validator owns canonicalization and local-path safety even for picker results.
+    return validateDesktopProject(path);
+  })().finally(() => { projectPicker = null; });
+  return projectPicker;
+}
 
 export async function validateDesktopProject(path: string): Promise<LocalProject> {
   if (!isTauri()) throw new Error("preview_no_filesystem");

--- a/apps/desktop/src/components/ContextSavings.tsx
+++ b/apps/desktop/src/components/ContextSavings.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+import { loadDesktopContextReport } from "../bridge";
+import { CONTEXT_CONFIDENCE, CONTEXT_EVIDENCE, contextErrorMessage, type ContextReport } from "../context_report";
+import "../context_report.css";
+
+export function ContextSavings({ repoPath, autoLoad = false }: { repoPath: string; autoLoad?: boolean }) {
+  const [report, setReport] = useState<ContextReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const pending = useRef(false);
+  const mounted = useRef(false);
+  const scope = repoPath.trim();
+  const currentScope = useRef(scope);
+  currentScope.current = scope;
+  const generation = useRef(0);
+
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; generation.current += 1; }; }, []);
+  useEffect(() => { generation.current += 1; setReport(null); setError(null); }, [scope]);
+
+  async function load() {
+    if (pending.current) return;
+    pending.current = true;
+    const request = ++generation.current;
+    const requestedScope = scope;
+    setBusy(true);
+    setReport(null);
+    setError(null);
+    try {
+      const result = await loadDesktopContextReport(requestedScope);
+      if (mounted.current && generation.current === request && currentScope.current === requestedScope) setReport(result);
+    } catch (cause) {
+      if (mounted.current && generation.current === request && currentScope.current === requestedScope) setError(contextErrorMessage(cause));
+    } finally {
+      pending.current = false;
+      if (mounted.current) setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    if (autoLoad && scope && !busy && !report && !error) void load();
+  }, [autoLoad, scope, busy, report, error]);
+
+  const number = (value: number | null) => value === null ? "—" : value.toLocaleString("pt-BR");
+  return <section className="panel context-report" aria-label="Economia de contexto">
+    <div className="context-report-heading">
+      <div><span className="eyebrow">Histórico local do projeto</span><h2>Economia de contexto</h2><p>Todo o histórico da pasta acima. Os filtros de período e sessão se aplicam apenas ao uso registrado.</p></div>
+      <button type="button" className="button button-secondary" disabled={busy} onClick={() => void load()}>{busy ? "Consultando economia…" : "Consultar economia de contexto"}</button>
+    </div>
+    <p className="context-disclaimer">Economia de contexto não é consumo faturado. Este relatório não demonstra, sozinho, preservação do conteúdo nem redução da cobrança do provedor.</p>
+    {busy && <p role="status">Consultando e verificando o histórico pelo Runtime…</p>}
+    {error && <p role="alert">{error}</p>}
+    {!report && !busy && !error && <p className="context-empty">Consulte o histórico desta pasta para ver as reduções de contexto e a qualidade da evidência.</p>}
+    {report && <>
+      <div className="context-metrics" data-testid="context-metrics">
+        <div><span>Reduções registradas</span><strong>{number(report.eventCount ? report.savedTokens : null)}</strong><small>Acumulado bruto do Runtime</small></div>
+        <div><span>Referência registrada</span><strong>{number(report.baselineTokens)}</strong><small>Base de comparação do Runtime</small></div>
+        <div><span>Com Simplicio</span><strong>{number(report.actualTokens)}</strong><small>Tokens registrados no histórico</small></div>
+        <div><span>Diferença líquida</span><strong>{number(report.netTokens)}</strong><small>{report.netTokens !== null && report.netTokens < 0 ? "Mais tokens do que a referência" : "Referência menos tokens registrados"}</small></div>
+      </div>
+      <p>{report.eventCount.toLocaleString("pt-BR")} {report.eventCount === 1 ? "evento de contexto" : "eventos de contexto"} · {report.ledgerEventCount.toLocaleString("pt-BR")} eventos no histórico.</p>
+      <div className="context-proof"><span>{CONTEXT_EVIDENCE[report.baselineKind]}</span><span>Confiança {CONTEXT_CONFIDENCE[report.confidence]}</span></div>
+      <p>{report.proof.measured} medidos · {report.proof.estimated} estimados · {report.proof.replayed} replays · {report.proof.benchmark} benchmarks · {report.proof.unavailable} sem classificação. Classificação informada pelo Runtime para o histórico completo.</p>
+      {(report.heuristicEventCount > 0 || report.unlabeledEstimateCount > 0) && <p className="context-caution">{report.heuristicEventCount} eventos usam contagem heurística; {report.unlabeledEstimateCount} estimativas não informam o método. Esses valores não equivalem a tokens faturados pelo provedor.</p>}
+      {report.llmSpendEventCount > 0 && <p className="context-caution">O histórico também tem {report.llmSpendEventCount} eventos de uso de LLM. O Runtime não separa a referência e o total com Simplicio para este caso; por isso a comparação permanece indisponível.</p>}
+      {report.netTokens !== null && report.netTokens !== report.savedTokens && <p className="context-caution">O acumulado bruto de reduções difere do saldo entre referência e uso registrado. Não o trate como economia líquida.</p>}
+      <details className="context-digest"><summary>Identificador do relatório</summary><code>{report.reportHash}</code><p>Resumo dos indicadores exibidos; não é assinatura de uma fatura.</p></details>
+    </>}
+  </section>;
+}

--- a/apps/desktop/src/components/DesktopUpdates.tsx
+++ b/apps/desktop/src/components/DesktopUpdates.tsx
@@ -2,13 +2,28 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { checkDesktopUpdate, compareVersions, DESKTOP_RELEASES_URL, DESKTOP_UPDATE_EVENT, DesktopUpdateError, type DesktopUpdateErrorCode, type DesktopUpdateResult } from "../desktop_updates";
+import { checkDesktopUpdate, compareVersions, DESKTOP_RELEASES_URL, DESKTOP_UPDATE_EVENT, DesktopUpdateError, type DesktopUpdateErrorCode, type DesktopUpdateProgress, type DesktopUpdateResult } from "../desktop_updates";
 import { Glyph } from "./Brand";
+import "../desktop_updates.css";
 
-type CheckState = DesktopUpdateResult | { state: "checking"; currentVersion: string | null } |
+type CheckProgress = DesktopUpdateProgress | { stage: "identity"; receivedBytes: 0 };
+type CheckState = DesktopUpdateResult | { state: "checking"; currentVersion: string | null; progress: CheckProgress } |
   { state: "error" | "offline"; currentVersion: string | null; code: DesktopUpdateErrorCode | "preview" | "native_unavailable" };
 
 const OPEN_UNCERTAIN = "Não foi possível confirmar a abertura; confira o navegador. A tentativa anterior ainda pode concluir. Uma nova tentativa só será feita se você clicar novamente.";
+
+const progressLabels: Record<CheckProgress["stage"], string> = {
+  identity: "Identificando este aplicativo",
+  requesting: "Consultando a distribuição oficial",
+  receiving: "Recebendo metadados das releases",
+  validating: "Validando versão e pacote Desktop",
+};
+
+function formatBytes(bytes: number): string {
+  const unit = bytes >= 1024 ** 3 ? "GiB" : bytes >= 1024 ** 2 ? "MiB" : bytes >= 1024 ? "KiB" : "B";
+  const divisor = unit === "GiB" ? 1024 ** 3 : unit === "MiB" ? 1024 ** 2 : unit === "KiB" ? 1024 : 1;
+  return `${(bytes / divisor).toLocaleString("pt-BR", { maximumFractionDigits: 1 })} ${unit}`;
+}
 
 const failureMessages: Record<DesktopUpdateErrorCode | "preview" | "native_unavailable", string> = {
   preview: "Esta é uma prévia no navegador. Abra o Simplicio instalado para consultar sua versão real e procurar atualizações.",
@@ -27,12 +42,14 @@ const failureMessages: Record<DesktopUpdateErrorCode | "preview" | "native_unava
 export function DesktopUpdates() {
   const native = isTauri();
   const dialog = useRef<HTMLDialogElement>(null);
+  const closeButton = useRef<HTMLButtonElement>(null);
+  const returnFocus = useRef<HTMLElement | null>(null);
   const activeCheck = useRef<AbortController | null>(null);
   const openLock = useRef(false);
   const openAttempt = useRef(0);
   const openTimer = useRef<number | undefined>(undefined);
   const [visible, setVisible] = useState(false);
-  const [status, setStatus] = useState<CheckState>({ state: "checking", currentVersion: null });
+  const [status, setStatus] = useState<CheckState>({ state: "checking", currentVersion: null, progress: { stage: "identity", receivedBytes: 0 } });
   const [opening, setOpening] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
 
@@ -46,6 +63,7 @@ export function DesktopUpdates() {
   }, []);
 
   const startCheck = useCallback(async () => {
+    if (!dialog.current?.open && document.activeElement instanceof HTMLElement) returnFocus.current = document.activeElement;
     setVisible(true);
     if (activeCheck.current) return;
     if (!native) {
@@ -54,7 +72,7 @@ export function DesktopUpdates() {
     }
     const controller = new AbortController();
     activeCheck.current = controller;
-    setStatus({ state: "checking", currentVersion: null });
+    setStatus({ state: "checking", currentVersion: null, progress: { stage: "identity", receivedBytes: 0 } });
     let installedVersion: string | null = null;
     let timedOut = false;
     let cancel: () => void = () => undefined;
@@ -69,8 +87,11 @@ export function DesktopUpdates() {
       if (controller.signal.aborted) throw new DesktopUpdateError("canceled");
       compareVersions(version, version);
       installedVersion = version;
-      if (activeCheck.current === controller) setStatus({ state: "checking", currentVersion: version });
-      return checkDesktopUpdate({ currentVersion: version, target, signal: controller.signal, online: navigator.onLine });
+      return checkDesktopUpdate({ currentVersion: version, target, signal: controller.signal, online: navigator.onLine,
+        onProgress: (progress) => {
+          if (activeCheck.current === controller && !controller.signal.aborted) setStatus({ state: "checking", currentVersion: version, progress });
+        },
+      });
     };
     try {
       const result = await Promise.race([check(), canceled]);
@@ -114,7 +135,10 @@ export function DesktopUpdates() {
   }, [native, startCheck, invalidateOpenAttempt]);
 
   useEffect(() => {
-    if (visible && dialog.current && !dialog.current.open) dialog.current.showModal();
+    if (visible && dialog.current && !dialog.current.open) {
+      dialog.current.showModal();
+      closeButton.current?.focus();
+    }
   }, [visible]);
 
   function close() {
@@ -125,6 +149,7 @@ export function DesktopUpdates() {
     setOpening(false);
     dialog.current?.close();
     setVisible(false);
+    if (returnFocus.current?.isConnected) returnFocus.current.focus();
   }
 
   async function openReleases() {
@@ -153,29 +178,54 @@ export function DesktopUpdates() {
 
   if (!visible) return null;
   const result = "release" in status ? status : null;
-  const failed = status.state === "error" || status.state === "offline";
+  const checking = status.state === "checking" ? status : null;
   const heading = status.state === "checking" ? "Procurando atualizações…" : status.state === "available" ? "Nova versão do Simplicio" :
     status.state === "up_to_date" ? "Simplicio está atualizado" : status.state === "newer_local" ? "Versão local mais recente" : "Atualização não confirmada";
-  const description = status.state === "checking" ? "Consultando os instaladores Desktop publicados no repositório oficial. Você pode cancelar esta consulta a qualquer momento." :
-    status.state === "available" ? `Simplicio ${status.release.version} está disponível para esta plataforma. Abra a release para consultar as instruções e baixar o instalador.` :
+  const description = status.state === "checking" ? "Consulta somente de metadados do Desktop." :
+    status.state === "available" ? `Simplicio ${status.release.version} está disponível para esta plataforma.` :
     status.state === "up_to_date" ? "Sua versão corresponde à mais recente com um instalador Desktop compatível nas releases consultadas." :
     status.state === "newer_local" ? `Este app é mais recente que o Desktop ${status.release.version} encontrado no repositório. Nenhum downgrade será feito.` :
     "code" in status ? failureMessages[status.code] : "Não foi possível confirmar a atualização.";
 
   return <dialog className="project-dialog desktop-updates-dialog" ref={dialog} aria-labelledby="desktop-updates-heading"
     aria-describedby="desktop-updates-description" data-update-state={status.state} onCancel={(event) => { event.preventDefault(); close(); }}>
-    <div className="dialog-heading"><span className="project-emblem"><Glyph name={status.state === "checking" ? "refresh" : failed ? "attention" : "check"} size={24} /></span>
-      <button className="icon-button" type="button" onClick={close} aria-label="Fechar atualizações"><Glyph name="close" size={18} /></button></div>
-    <div role="status" aria-live="polite" aria-atomic="true">
-      <h2 id="desktop-updates-heading">{heading}</h2>
-      <p id="desktop-updates-description">{description}</p>
-      {status.currentVersion && <p className="field-hint">Versão deste aplicativo: <strong>{status.currentVersion}</strong></p>}
+    <div className="desktop-update-topline"><span>Simplicio · Atualizações</span>
+      <button className="icon-button" ref={closeButton} type="button" onClick={close} aria-label="Fechar atualizações"><Glyph name="close" size={18} /></button></div>
+    <div className="desktop-update-summary">
+      <img className="desktop-update-icon" src="/icon.png" alt="" width="64" height="64" />
+      <div role="status" aria-live="polite" aria-atomic="true">
+        <h2 id="desktop-updates-heading">{heading}</h2>
+        <p id="desktop-updates-description">{description}</p>
+      </div>
     </div>
-    {result && <p className="field-hint">Pacote publicado: <strong>{result.release.assetName}</strong><br />
-      Plataforma: {result.target.platform} · {result.target.arch}. Consulta de até 30 releases recentes.</p>}
-    <p className="field-hint">Esta consulta não baixa nem instala arquivos, não verifica assinaturas e não modifica o Runtime, plugins ou integrações.</p>
+    <div className="desktop-update-content">
+    {checking && <div className="desktop-update-progress" data-update-stage={checking.progress.stage}>
+      <div className="desktop-update-progress-label"><span role="status" aria-live="polite">{progressLabels[checking.progress.stage]}</span>
+        <span>Etapa {checking.progress.stage === "identity" ? 1 : checking.progress.stage === "validating" ? 3 : 2} de 3</span></div>
+      <progress aria-label="Progresso da consulta de atualização" />
+      <p>{checking.progress.receivedBytes > 0 ? `${formatBytes(checking.progress.receivedBytes)} de metadados recebidos. ` : ""}O instalador não está sendo baixado.</p>
+    </div>}
+    {status.currentVersion && <p className="desktop-update-installed">Versão deste aplicativo: <strong>{status.currentVersion}</strong></p>}
+    {result && <>
+      <div className="desktop-update-package">
+        <div><span><Glyph name="monitor" size={14} />{result.target.platform === "macos" ? "macOS" : result.target.platform === "windows" ? "Windows" : "Linux"} · {result.target.arch}</span>
+          <span>{formatBytes(result.release.assetBytes)}</span></div>
+        <strong>{result.release.assetName}</strong>
+        <p>Release {result.release.tag}{result.release.publishedAt && <> · publicada em <time dateTime={result.release.publishedAt}>{new Date(result.release.publishedAt).toLocaleDateString("pt-BR", { timeZone: "UTC" })}</time></>}</p>
+      </div>
+      {result.release.notes ? <details className="desktop-update-notes">
+        <summary>Notas da publicação <Glyph name="chevron" size={16} /></summary>
+        <p>Texto público da release no GitHub; pode incluir Runtime e Desktop. Links e HTML não são executados aqui.</p>
+        <pre>{result.release.notes.text}</pre>
+        {result.release.notes.truncated && <p>Trecho limitado. Consulte a publicação completa na página oficial.</p>}
+      </details> : <p className="desktop-update-caption">Esta publicação não informou notas de versão.</p>}
+    </>}
+    {!checking && <div className="desktop-update-manual"><Glyph name="external" size={17} /><div><strong>Download e instalação manuais</strong>
+      <p>“Ver releases oficiais” abre a listagem no navegador. Localize {result ? `a release ${result.release.tag} e o pacote acima` : "um instalador compatível"} para baixar e instalar seguindo as instruções da publicação.</p></div></div>}
+    {!checking && <p className="desktop-update-caption">Consulta de até 30 releases recentes. Não baixa ou extrai instaladores, não verifica assinaturas e não altera o Runtime, plugins ou integrações.</p>}
+    </div>
     {openError && <p className="inline-error" role="alert">{openError}</p>}
-    <div className="dialog-actions">
+    <div className="dialog-actions desktop-update-actions">
       <button className="button button-secondary" type="button" onClick={close}>{status.state === "checking" ? "Cancelar consulta" : "Fechar"}</button>
       {status.state !== "checking" && <button className="button button-secondary" type="button" onClick={() => void startCheck()} disabled={!native}>Verificar novamente</button>}
       {status.state !== "checking" && <button className="button button-primary" type="button" onClick={() => void openReleases()} disabled={opening}>{opening ? "Abrindo…" : "Ver releases oficiais"}</button>}

--- a/apps/desktop/src/components/IntegrationSetup.tsx
+++ b/apps/desktop/src/components/IntegrationSetup.tsx
@@ -1,16 +1,20 @@
 import { useRef, useState } from "react";
 import { planDesktopIntegrations } from "../bridge";
 import type { IntegrationPlan } from "../integration_setup";
+import type { InstallFailureRecovery } from "../install_failures";
 
-export function IntegrationSetup({ busy, onApply }: { busy: boolean; onApply: (digest: string) => Promise<boolean> }) {
+export function IntegrationSetup({ busy, onApply, recovery, onDiagnostics }: {
+  busy: boolean; onApply: (digest: string) => Promise<boolean>; recovery?: InstallFailureRecovery; onDiagnostics?: () => void;
+}) {
   const [plan, setPlan] = useState<IntegrationPlan | null>(null);
   const [loading, setLoading] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const loadingLock = useRef(false);
+  const blocked = Boolean(recovery && recovery !== "review");
 
   async function preview() {
-    if (loadingLock.current || busy) return;
+    if (loadingLock.current || busy || blocked) return;
     loadingLock.current = true;
     setLoading(true); setPlan(null); setConfirmed(false); setMessage(null);
     try { setPlan(await planDesktopIntegrations()); }
@@ -19,11 +23,11 @@ export function IntegrationSetup({ busy, onApply }: { busy: boolean; onApply: (d
   }
 
   async function apply() {
-    if (!plan || !confirmed || busy || loadingLock.current) return;
+    if (!plan || !confirmed || busy || loadingLock.current || blocked) return;
     loadingLock.current = true;
     try {
       const ok = await onApply(plan.planDigest);
-      setMessage(ok ? "Configuração concluída pelo Runtime. Abra uma nova sessão nos clientes para confirmar a conexão MCP." : "A configuração não foi confirmada. Revise um novo plano antes de tentar novamente.");
+      setMessage(ok ? "Configuração concluída pelo Runtime. Abra uma nova sessão nos clientes para confirmar a conexão MCP." : "O resultado da configuração precisa ser esclarecido. Não repita a aplicação enquanto houver uma tentativa pendente ou incerta.");
     } finally {
       setPlan(null); setConfirmed(false); loadingLock.current = false;
     }
@@ -32,8 +36,9 @@ export function IntegrationSetup({ busy, onApply }: { busy: boolean; onApply: (d
   return <section className="panel integration-setup" aria-label="Configuração do MCP">
     <div><span className="eyebrow">Instalação guiada</span><h2>Configurar o Simplicio nos seus apps</h2>
       <p>O app inclui o Runtime. Após sua confirmação, ele copia o binário para a instalação gerenciada e registra MCP e hooks nos clientes detectados, com backups. Este fluxo não altera o PATH nem inicia um serviço global; plugins de marketplace e autorizações continuam sob controle de cada host.</p></div>
-    <button type="button" className="button button-secondary" disabled={busy || loading} onClick={() => void preview()}>{loading ? "Preparando plano…" : "Revisar configuração MCP"}</button>
-    {plan && <div className="integration-plan">
+    <button type="button" className="button button-secondary" disabled={busy || loading || blocked} onClick={() => void preview()}>{loading ? "Preparando plano…" : "Revisar configuração MCP"}</button>
+    {blocked && <div className="integration-recovery"><p>{recovery === "refresh" ? "A aplicação foi confirmada; falta verificar o estado final. Consulte o diagnóstico, sem reinstalar." : recovery === "wait" ? "Já há uma instalação em andamento. Aguarde sua conclusão antes de outra aplicação." : "Há uma instalação com resultado incerto. Novas aplicações estão bloqueadas nesta sessão; atualizar ou reiniciar o app não comprova a conclusão."}</p>{onDiagnostics && <button type="button" className="button button-secondary" disabled={busy} onClick={onDiagnostics}>Atualizar diagnóstico</button>}</div>}
+    {plan && !blocked && <div className="integration-plan">
       <p>{plan.source === "preview" ? "Demonstração: nenhuma alteração real." : "Plano do Runtime, ainda não executado."} {plan.changes.filter((row) => row.changed).length} alterações propostas.</p>
       <ul>{plan.changes.map((row) => <li key={row.label}><span>{row.label}</span><strong>{row.changed ? row.exists ? "Atualizar" : "Criar" : "Já configurado"}</strong></li>)}</ul>
       <label className="setup-consent"><input type="checkbox" checked={confirmed} disabled={busy} onChange={(event) => setConfirmed(event.target.checked)} />Autorizo o Runtime a aplicar este plano de instalação e registro.</label>

--- a/apps/desktop/src/components/ProjectDialog.tsx
+++ b/apps/desktop/src/components/ProjectDialog.tsx
@@ -1,49 +1,110 @@
 import { useEffect, useRef, useState } from "react";
-import { validateDesktopProject } from "../bridge";
+import { chooseDesktopProject, validateDesktopProject } from "../bridge";
 import { Glyph } from "./Brand";
 import type { LocalProject } from "../workbench";
 
 export function ProjectDialog({ onClose, onAdd }: { onClose: () => void; onAdd: (project: LocalProject) => void }) {
   const dialog = useRef<HTMLDialogElement>(null);
   const pathInput = useRef<HTMLInputElement>(null);
+  const chooseButton = useRef<HTMLButtonElement>(null);
   const lock = useRef(false);
+  const mounted = useRef(false);
+  const focusAfterOperation = useRef<"path" | "choose" | null>(null);
   const [path, setPath] = useState("");
   const [busy, setBusy] = useState(false);
+  const [choosing, setChoosing] = useState(false);
+  const [chosen, setChosen] = useState(false);
+  const [pathInvalid, setPathInvalid] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    dialog.current?.showModal();
-    pathInput.current?.focus();
+    const element = dialog.current;
+    const invoker = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    mounted.current = true;
+    element?.showModal();
+    chooseButton.current?.focus();
+    return () => {
+      mounted.current = false;
+      element?.close();
+      if (invoker?.isConnected) invoker.focus();
+    };
   }, []);
+
+  useEffect(() => {
+    if (busy || !focusAfterOperation.current) return;
+    (focusAfterOperation.current === "choose" ? chooseButton : pathInput).current?.focus();
+    focusAfterOperation.current = null;
+  }, [busy]);
+
+  function failureMessage(cause: unknown, picker = false) {
+    const reason = cause instanceof Error ? cause.message : typeof cause === "string" ? cause : "";
+    return reason.includes("preview_no_filesystem")
+      ? "Abra o aplicativo instalado para verificar uma pasta. A demonstração no navegador não acessa seus arquivos."
+      : picker ? "Não foi possível escolher a pasta. Tente novamente ou informe o caminho completo abaixo."
+        : "Não foi possível adicionar a pasta. Informe um caminho local absoluto, existente e acessível.";
+  }
+
+  async function choose() {
+    if (lock.current) return;
+    lock.current = true;
+    setBusy(true); setChoosing(true); setError(null); setPathInvalid(false); setChosen(false);
+    try {
+      const project = await chooseDesktopProject();
+      if (!mounted.current) return;
+      if (project) {
+        // A picker result is a path to review, not consent to add a bookmark.
+        setPath(project.path);
+        setChosen(true);
+        focusAfterOperation.current = "path";
+      } else {
+        focusAfterOperation.current = "choose";
+      }
+    } catch (cause) {
+      if (!mounted.current) return;
+      setError(failureMessage(cause, true));
+      focusAfterOperation.current = "choose";
+    } finally {
+      lock.current = false;
+      if (mounted.current) { setBusy(false); setChoosing(false); }
+    }
+  }
 
   async function add() {
     if (lock.current || !path.trim()) return;
     lock.current = true;
     setBusy(true);
     setError(null);
+    setPathInvalid(false);
     try {
-      onAdd(await validateDesktopProject(path.trim()));
+      const project = await validateDesktopProject(path.trim());
+      if (!mounted.current) return;
+      onAdd(project);
       onClose();
     } catch (cause) {
-      setError(String(cause).includes("preview_no_filesystem")
-        ? "Abra o aplicativo instalado para verificar uma pasta. A demonstração no navegador não acessa seus arquivos."
-        : "Não foi possível adicionar a pasta. Informe um caminho local absoluto, existente e acessível.");
+      if (!mounted.current) return;
+      setError(failureMessage(cause));
+      setPathInvalid(true);
+      focusAfterOperation.current = "path";
     } finally {
       lock.current = false;
-      setBusy(false);
+      if (mounted.current) setBusy(false);
     }
   }
 
-  return <dialog className="project-dialog" ref={dialog} aria-labelledby="add-project-heading" onCancel={(event) => { event.preventDefault(); if (!lock.current) onClose(); }}>
+  return <dialog className="project-dialog" ref={dialog} aria-labelledby="add-project-heading" aria-describedby="add-project-description" onCancel={(event) => { event.preventDefault(); if (!lock.current) onClose(); }}>
     <div className="dialog-heading"><span className="project-emblem"><Glyph name="folder" size={24} /></span><button className="icon-button" type="button" onClick={onClose} disabled={busy} aria-label="Fechar"><Glyph name="close" size={18} /></button></div>
     <h2 id="add-project-heading">Adicionar projeto</h2>
-    <p>Vincule uma pasta existente a este Desktop. Nenhum arquivo será copiado ou alterado.</p>
-    <form onSubmit={(event) => { event.preventDefault(); void add(); }}>
+    <p id="add-project-description">Vincule uma pasta existente a este Desktop. Nenhum arquivo será copiado ou alterado.</p>
+    <form aria-busy={busy} onSubmit={(event) => { event.preventDefault(); void add(); }}>
+      <button ref={chooseButton} className="button button-secondary project-picker" type="button" disabled={busy} aria-busy={choosing} onClick={() => void choose()}><Glyph name="folder" size={18} />{choosing ? "Escolhendo pasta…" : "Escolher pasta…"}</button>
+      <p className="project-path-alternative">ou informe o caminho completo</p>
       <label className="workbench-field">Caminho da pasta
-        <input ref={pathInput} value={path} onChange={(event) => setPath(event.target.value)} required maxLength={4096} disabled={busy} autoComplete="off" spellCheck={false} placeholder="/caminho/do/projeto ou C:\projetos\meu-app" />
+        <input ref={pathInput} value={path} onChange={(event) => { setPath(event.target.value); setError(null); setPathInvalid(false); setChosen(false); }} required maxLength={4096} disabled={busy} aria-invalid={pathInvalid} aria-describedby={error ? "project-path-hint project-path-error" : "project-path-hint"} autoComplete="off" spellCheck={false} placeholder="/caminho/do/projeto ou C:\projetos\meu-app" />
       </label>
-      <p className="field-hint">Cole o caminho completo da pasta. O aplicativo verifica se ela existe antes de adicioná-la.</p>
-      {error && <p className="inline-error" role="alert">{error}</p>}
+      <p className="field-hint" id="project-path-hint">Escolha uma pasta ou cole seu caminho. Revise antes de adicionar; o Runtime verifica o destino novamente.</p>
+      {chosen && <p className="project-chosen-note" role="status"><Glyph name="check" size={15} />Pasta escolhida. O projeto só será adicionado quando você confirmar.</p>}
+      {choosing && <p className="field-hint" role="status">Conclua ou cancele a escolha na janela do sistema.</p>}
+      {error && <p className="inline-error" id="project-path-error" role="alert">{error}</p>}
       <div className="dialog-actions"><button className="button button-secondary" type="button" disabled={busy} onClick={onClose}>Cancelar</button><button className="button button-primary" type="submit" disabled={busy || !path.trim()}>{busy ? "Verificando…" : "Adicionar projeto"}</button></div>
     </form>
   </dialog>;

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -1,26 +1,43 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
+import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
 import { isSettingsView, runtimeSummary, searchMatches, VIEW_LABELS, type LocalProject, type View, type WorkbenchState } from "../workbench";
 
 export type { View } from "../workbench";
 
-interface Destination { id: View; icon: GlyphName; group?: string }
+interface Destination { id: View; icon: GlyphName; group?: string; description?: string }
 const navigation: Destination[] = [
   { id: "home", icon: "home" }, { id: "activity", icon: "activity" },
+  { id: "automations", icon: "automation" },
   { id: "agents", icon: "teams" }, { id: "providers", icon: "providers" }, { id: "tokens", icon: "spark" },
 ];
+const referenceIcons: Record<ReferenceSettingsView, GlyphName> = {
+  "provider-accounts": "providers", orchestration: "teams", "computer-use": "monitor", voice: "live",
+  integrations: "providers", mobile: "monitor", "general-settings": "settings", artifacts: "folder",
+  "share-skills": "spark", git: "folder", "task-sources": "activity", terminal: "keyboard",
+  "quick-commands": "automation", browser: "external", emulator: "monitor", floating: "apps",
+  input: "keyboard", notifications: "attention", hosts: "monitor", servers: "providers",
+  permissions: "shield", privacy: "lock", advanced: "settings", experimental: "spark", plugins: "apps",
+};
+const groupOrder: Record<string, number> = {
+  CAPACIDADES: 0, CONFIGURAÇÃO: 1, FLUXOS: 2, INTERFACE: 3,
+  "HOSTS REMOTOS": 4, "PRIVACIDADE E SEGURANÇA": 5, AVANÇADO: 6, EXPERIMENTAL: 7,
+};
 const settings: Destination[] = [
   { id: "agents", icon: "teams", group: "CAPACIDADES" },
-  { id: "providers", icon: "providers", group: "CAPACIDADES" },
   { id: "models", icon: "spark", group: "CAPACIDADES" },
+  { id: "providers", icon: "providers", group: "CONFIGURAÇÃO" },
   { id: "settings", icon: "shield", group: "CONFIGURAÇÃO" },
   { id: "setup", icon: "check", group: "CONFIGURAÇÃO" },
-  { id: "diagnostics", icon: "monitor", group: "CONFIGURAÇÃO" },
-  { id: "memory", icon: "memory", group: "CONFIGURAÇÃO" },
+  { id: "memory", icon: "memory", group: "FLUXOS" },
+  { id: "tokens", icon: "spark", group: "FLUXOS" },
   { id: "general", icon: "settings", group: "INTERFACE" },
   { id: "shortcuts", icon: "keyboard", group: "INTERFACE" },
+  { id: "diagnostics", icon: "monitor", group: "AVANÇADO" },
+  ...REFERENCE_SCREENS.map(({ id, group, description }) => ({ id, group, description, icon: referenceIcons[id] })),
 ];
+settings.sort((left, right) => (groupOrder[left.group ?? ""] ?? 100) - (groupOrder[right.group ?? ""] ?? 100));
 
 interface ShellProps {
   children: ReactNode;
@@ -40,19 +57,107 @@ interface ShellProps {
 
 export function Shell({ children, snapshot, view, onViewChange, workbench, onAddProject, onProject,
   onBack, onForward, canBack, canForward, onRefresh, busy }: ShellProps) {
+  const [narrow, setNarrow] = useState(() => typeof window !== "undefined" && window.innerWidth < 760);
   const [collapsed, setCollapsed] = useState(() => typeof window !== "undefined" && window.innerWidth < 760);
   const [query, setQuery] = useState("");
   const search = useRef<HTMLInputElement>(null);
+  const sidebar = useRef<HTMLElement>(null);
+  const sidebarScroll = useRef<HTMLDivElement>(null);
+  const sidebarToggle = useRef<HTMLButtonElement>(null);
+  const mainContent = useRef<HTMLElement>(null);
   const lastWorkspace = useRef<View>("home");
+  const drawerOpen = narrow && !collapsed;
   const inSettings = isSettingsView(view);
   const status = runtimeSummary(snapshot);
+  const registrations = snapshot.providers.filter((provider) => provider.registrationState === "registered").length;
   const selected = workbench.projects.find((project) => project.id === workbench.selectedProjectId);
   const modifier = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform) ? "⌘" : "Ctrl";
+
+  const closeSidebar = useCallback((focus: "toggle" | "content" | null = "toggle") => {
+    setCollapsed(true);
+    setQuery("");
+    if (focus) requestAnimationFrame(() => {
+      if (!document.querySelector("dialog[open]")) {
+        (focus === "toggle" ? sidebarToggle.current : mainContent.current)?.focus({ preventScroll: true });
+      }
+    });
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    if (collapsed) setCollapsed(false);
+    else closeSidebar(drawerOpen ? "toggle" : null);
+  }, [collapsed, drawerOpen, closeSidebar]);
+
+  const selectView = useCallback((next: View) => {
+    if (drawerOpen) closeSidebar("content");
+    onViewChange(next);
+  }, [drawerOpen, closeSidebar, onViewChange]);
+
+  function addProject() {
+    if (drawerOpen) closeSidebar(null);
+    onAddProject();
+  }
+
+  function selectProject(project: LocalProject) {
+    if (drawerOpen) closeSidebar("content");
+    onProject(project);
+  }
+
+  useEffect(() => {
+    const media = window.matchMedia("(max-width: 759px)");
+    function resize() {
+      setNarrow(media.matches);
+      if (media.matches) closeSidebar(sidebar.current?.contains(document.activeElement) ? "toggle" : null);
+    }
+    media.addEventListener("change", resize);
+    return () => media.removeEventListener("change", resize);
+  }, [closeSidebar]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const frame = requestAnimationFrame(() => search.current?.focus());
+    function containFocus(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.isComposing || document.querySelector("dialog[open]")) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSidebar();
+      } else if (event.key === "Tab") {
+        const controls = Array.from(sidebar.current?.querySelectorAll<HTMLElement>("button:not(:disabled), input:not(:disabled), a[href], [tabindex='0']") ?? [])
+          .filter((element) => element.getClientRects().length > 0);
+        const first = controls[0];
+        const last = controls[controls.length - 1];
+        if ((event.shiftKey && document.activeElement === first) || (!event.shiftKey && document.activeElement === last)
+          || !sidebar.current?.contains(document.activeElement)) {
+          event.preventDefault();
+          (event.shiftKey ? last : first)?.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", containFocus);
+    return () => { cancelAnimationFrame(frame); document.removeEventListener("keydown", containFocus); };
+  }, [drawerOpen, closeSidebar]);
 
   useEffect(() => {
     setQuery("");
     if (!isSettingsView(view)) lastWorkspace.current = view;
   }, [view]);
+
+  useEffect(() => { sidebarScroll.current?.scrollTo({ top: 0 }); }, [query]);
+
+  useEffect(() => {
+    if (collapsed || query) return;
+    const frame = requestAnimationFrame(() => {
+      const scroller = sidebarScroll.current;
+      const active = scroller?.querySelector<HTMLElement>('[aria-current="page"]');
+      if (!scroller || !active) return;
+      const bounds = scroller.getBoundingClientRect();
+      const item = active.getBoundingClientRect();
+      const offset = item.top < bounds.top ? item.top - bounds.top : item.bottom > bounds.bottom ? item.bottom - bounds.bottom : 0;
+      // Keep this scroller independent of the document's keyboard starting point.
+      if (offset) scroller.scrollBy({ top: offset });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [view, collapsed, query]);
 
   useEffect(() => {
     function keydown(event: KeyboardEvent) {
@@ -64,73 +169,82 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
           requestAnimationFrame(() => search.current?.focus());
         } else if (event.key.toLowerCase() === "b") {
           event.preventDefault();
-          setCollapsed((current) => !current);
+          toggleSidebar();
         } else if (event.key === ",") {
           event.preventDefault();
-          onViewChange("settings");
+          selectView("settings");
         }
       } else if (event.altKey && event.key === "ArrowLeft") {
-        event.preventDefault(); if (canBack) onBack();
+        event.preventDefault(); if (canBack) { if (drawerOpen) closeSidebar("content"); onBack(); }
       } else if (event.altKey && event.key === "ArrowRight") {
-        event.preventDefault(); if (canForward) onForward();
+        event.preventDefault(); if (canForward) { if (drawerOpen) closeSidebar("content"); onForward(); }
       }
     }
     window.addEventListener("keydown", keydown);
     return () => window.removeEventListener("keydown", keydown);
-  }, [onViewChange, canBack, canForward, onBack, onForward]);
+  }, [selectView, toggleSidebar, drawerOpen, closeSidebar, canBack, canForward, onBack, onForward]);
 
   const destinations = query && !inSettings
     ? [...navigation, ...settings.filter((item) => !navigation.some((existing) => existing.id === item.id))]
     : inSettings ? settings : navigation;
-  const matches = destinations.filter((item) => searchMatches(VIEW_LABELS[item.id] + " " + (item.group ?? ""), query));
+  const matches = destinations.filter((item) => searchMatches(VIEW_LABELS[item.id] + " " + (item.group ?? "") + " " + (item.description ?? ""), query));
   const projects = workbench.projects.filter((project) => searchMatches(project.name + " " + project.path, query));
 
   return (
-    <div className={"app-shell workbench" + (collapsed ? " sidebar-collapsed" : "")} data-density={workbench.preferences.density}>
-      <aside className="sidebar" aria-label={inSettings ? "Configurações" : "Espaço de trabalho"}>
+    <div className={"app-shell workbench" + (collapsed ? " sidebar-collapsed" : "") + (drawerOpen ? " sidebar-overlay" : "")} data-density={workbench.preferences.density}>
+      <a className="workbench-skip" href="#workbench-content" inert={drawerOpen} onClick={(event) => { event.preventDefault(); mainContent.current?.focus(); }}>Ir para o conteúdo</a>
+      {drawerOpen && <button className="sidebar-scrim" type="button" aria-label="Fechar navegação" tabIndex={-1} onClick={() => closeSidebar()} />}
+      <aside ref={sidebar} id="workbench-sidebar" className="sidebar" role={drawerOpen ? "dialog" : undefined} aria-modal={drawerOpen ? true : undefined} aria-label={inSettings ? "Configurações" : "Espaço de trabalho"}>
         <div className="sidebar-heading">
-          {inSettings ? <button className="back-to-app" type="button" onClick={() => onViewChange(lastWorkspace.current)} aria-label="Voltar ao app"><Glyph name="back" size={18} />{!collapsed && <span>Voltar ao app</span>}</button>
-            : <button className="brand-home" type="button" onClick={() => onViewChange("home")} aria-label="Início do Simplicio"><Brand compact={collapsed} /></button>}
+          {inSettings ? <button className="back-to-app" type="button" onClick={() => selectView(lastWorkspace.current)} aria-label="Voltar ao app"><Glyph name="back" size={18} />{!collapsed && <span>Voltar ao app</span>}</button>
+            : <button className="brand-home" type="button" onClick={() => selectView("home")} aria-label="Início do Simplicio"><Brand compact={collapsed} /></button>}
+          {drawerOpen && <button className="icon-button sidebar-close" type="button" aria-label="Recolher barra lateral" onClick={() => closeSidebar()}><Glyph name="close" size={18} /></button>}
         </div>
         {!collapsed && <div className="sidebar-search-wrap">
           <label className="sidebar-search"><Glyph name="search" size={17} />
             <input ref={search} type="search" value={query} onChange={(event) => setQuery(event.target.value)} maxLength={120}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowDown") {
+                  const first = sidebar.current?.querySelector<HTMLButtonElement>(".primary-nav .nav-item, .project-nav");
+                  if (first) { event.preventDefault(); first.focus(); }
+                } else if (event.key === "Escape" && !drawerOpen && query) { event.preventDefault(); setQuery(""); }
+              }}
               aria-label={inSettings ? "Buscar configurações" : "Buscar projetos e páginas"}
               placeholder={inSettings ? "Buscar configurações" : "Buscar no Simplicio"} />
             {!query && <kbd>{modifier} K</kbd>}
           </label>
         </div>}
-        <div className="sidebar-scroll">
+        <div ref={sidebarScroll} className="sidebar-scroll">
           <nav className="primary-nav" aria-label={inSettings ? "Categorias de configurações" : "Navegação principal"}>
             {matches.map((item, index) => <div key={item.id}>
               {!collapsed && inSettings && item.group !== matches[index - 1]?.group && <p className="nav-caption">{item.group}</p>}
               <button className={"nav-item" + (view === item.id ? " active" : "")} type="button" aria-label={VIEW_LABELS[item.id]}
-                title={collapsed ? VIEW_LABELS[item.id] : undefined} aria-current={view === item.id ? "page" : undefined} onClick={() => onViewChange(item.id)}>
+                title={collapsed ? VIEW_LABELS[item.id] : undefined} aria-current={view === item.id ? "page" : undefined} onClick={() => selectView(item.id)}>
                 <Glyph name={item.icon} size={18} />{!collapsed && <span>{VIEW_LABELS[item.id]}</span>}
                 {!collapsed && !inSettings && item.id === "agents" && <small className="nav-count">{status.installed}</small>}
               </button>
             </div>)}
           </nav>
           {!inSettings && <section className="sidebar-projects" aria-label="Projetos locais">
-            <div className="projects-heading">{!collapsed && <h2>PROJETOS</h2>}<button className="icon-button" type="button" aria-label="Adicionar projeto à lista" title="Adicionar projeto" onClick={onAddProject}><Glyph name="plus" size={17} /></button></div>
+            <div className="projects-heading">{!collapsed && <h2>PROJETOS</h2>}<button className="icon-button" type="button" aria-label="Adicionar projeto à lista" title="Adicionar projeto" onClick={addProject}><Glyph name="plus" size={17} /></button></div>
             {projects.map((project) => <button type="button" key={project.id} className={"nav-item project-nav" + (view === "project" && selected?.id === project.id ? " active" : "")}
-              aria-label={"Abrir projeto " + project.name} title={project.path} aria-current={view === "project" && selected?.id === project.id ? "page" : undefined} onClick={() => onProject(project)}>
+              aria-label={"Abrir projeto " + project.name} title={project.path} aria-current={view === "project" && selected?.id === project.id ? "page" : undefined} onClick={() => selectProject(project)}>
               <Glyph name="folder" size={17} />{!collapsed && <span className="project-nav-copy"><span>{project.name}</span>{workbench.preferences.showProjectPaths && <small>{project.path}</small>}</span>}
             </button>)}
             {!collapsed && !query && !projects.length && <p className="sidebar-empty">Adicione uma pasta para começar.<br />Seus arquivos ficam no computador.</p>}
           </section>}
-          {!collapsed && query && !matches.length && (inSettings || !projects.length) && <div className="sidebar-empty" role="status">Nenhum resultado.<button className="text-button" type="button" onClick={() => setQuery("")}>Limpar busca</button></div>}
+          {!collapsed && query && !matches.length && (inSettings || !projects.length) && <div className="sidebar-empty" role="status">Nenhum resultado.<button className="text-button" type="button" onClick={() => { setQuery(""); search.current?.focus(); }}>Limpar busca</button></div>}
         </div>
         <div className="sidebar-bottom">
-          <button className="nav-item" type="button" aria-label="Configurações" title="Configurações" onClick={() => onViewChange("settings")}><Glyph name="settings" size={18} />{!collapsed && <span>Configurações</span>}</button>
-          <button className="icon-button" type="button" aria-label="Ver atalhos" title="Atalhos" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={18} /></button>
+          <button className="nav-item" type="button" aria-label="Configurações" title="Configurações" onClick={() => selectView("settings")}><Glyph name="settings" size={18} />{!collapsed && <span>Configurações</span>}</button>
+          <button className="icon-button" type="button" aria-label="Ver atalhos" title="Atalhos" onClick={() => selectView("shortcuts")}><Glyph name="keyboard" size={18} /></button>
         </div>
       </aside>
 
-      <div className="workspace">
+      <div className="workspace" inert={drawerOpen}>
         <header className="topbar">
           <div className="workbench-history">
-            <button className="icon-button" type="button" aria-label={collapsed ? "Expandir barra lateral" : "Recolher barra lateral"} aria-expanded={!collapsed} onClick={() => setCollapsed((current) => !current)}><Glyph name="sidebar" size={18} /></button>
+            <button ref={sidebarToggle} className="icon-button" type="button" aria-label={collapsed ? "Expandir barra lateral" : "Recolher barra lateral"} aria-expanded={!collapsed} aria-controls="workbench-sidebar" onClick={toggleSidebar}><Glyph name="sidebar" size={18} /></button>
             <span className="toolbar-separator" />
             <button className="icon-button" type="button" aria-label="Voltar" title="Voltar · Alt ←" onClick={onBack} disabled={!canBack}><Glyph name="back" size={17} /></button>
             <button className="icon-button" type="button" aria-label="Avançar" title="Avançar · Alt →" onClick={onForward} disabled={!canForward}><Glyph name="arrow" size={17} /></button>
@@ -138,18 +252,18 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
           <div className="topbar-path"><span>{inSettings ? "Configurações" : "Simplicio"}</span><span aria-hidden="true">/</span><strong>{view === "project" && selected ? selected.name : VIEW_LABELS[view]}</strong></div>
           <div className="topbar-actions">
             <button className="icon-button" type="button" aria-label="Atualizar Runtime" title="Atualizar estado do Runtime" disabled={busy} onClick={onRefresh}><Glyph name="refresh" size={17} /></button>
-            <button className="profile-button" type="button" aria-label="Abrir configurações da conta" title="Conta Simplicio" onClick={() => onViewChange("settings")}>{snapshot.access.displayName?.slice(0, 1).toUpperCase() ?? "S"}</button>
+            <button className="profile-button" type="button" aria-label="Abrir configurações da conta" title="Conta Simplicio" onClick={() => selectView("settings")}>{snapshot.access.displayName?.slice(0, 1).toUpperCase() ?? "S"}</button>
           </div>
         </header>
-        <main className={"main-content" + (inSettings ? " settings-content" : "")} id="workbench-content">{children}</main>
+        <main ref={mainContent} tabIndex={-1} className={"main-content" + (inSettings ? " settings-content" : "")} id="workbench-content">{children}</main>
       </div>
 
-      <footer className="workbench-status" aria-label="Estado do Simplicio">
-        <button type="button" onClick={() => onViewChange("diagnostics")} title="Abrir diagnóstico do Runtime"><span className={"status-dot " + (status.healthy ? "online" : "offline")} />{status.label}<span className="status-version">v{snapshot.runtime.version || "—"}</span></button>
+      <footer className="workbench-status" aria-label="Estado do Simplicio" inert={drawerOpen}>
+        <button type="button" onClick={() => selectView("diagnostics")} title="Abrir diagnóstico do Runtime"><span className={"status-dot " + (status.healthy ? "online" : "offline")} />{status.label}<span className="status-version">v{snapshot.runtime.version || "—"}</span></button>
         {snapshot.source === "preview" && <span className="preview-badge">Demonstração</span>}
         <span className="status-spacer" />
-        <button className="status-savings" type="button" onClick={() => onViewChange("tokens")}><Glyph name="spark" size={14} />{status.measuredSavings === null ? "Economia sem medição" : status.measuredSavings.toLocaleString("pt-BR") + " tokens poupados"}</button>
-        <button type="button" onClick={() => onViewChange("providers")}><Glyph name="providers" size={14} />{status.connected} MCP ativos</button>
+        <button className="status-savings" type="button" onClick={() => selectView("tokens")}><Glyph name="spark" size={14} />{status.measuredSavings === null ? "Economia sem medição" : status.measuredSavings.toLocaleString("pt-BR") + " tokens poupados"}</button>
+        <button type="button" onClick={() => selectView("providers")} title={`${registrations} registros detectados. A conexão exige registro e handshake atuais; a ausência de confirmação não prova que o cliente está desconectado.`}><Glyph name="providers" size={14} />{status.connected} MCP {status.connected === 1 ? "confirmado" : "confirmados"}<span className="status-registrations">· {registrations} {registrations === 1 ? "registro detectado" : "registros detectados"}</span></button>
         <span className="status-host"><Glyph name="monitor" size={14} />Este computador</span>
       </footer>
     </div>

--- a/apps/desktop/src/components/TokenProjects.tsx
+++ b/apps/desktop/src/components/TokenProjects.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import { chooseDesktopProject, loadDesktopUsageProjects } from "../bridge";
+import { projectDiscoveryError, type UsageProjects } from "../project_usage";
+import "../project_usage.css";
+
+export function TokenProjects({ repoPath, allowAutoSelect, onSelect }: {
+  repoPath: string; allowAutoSelect: boolean; onSelect: (path: string) => void;
+}) {
+  const [discovery, setDiscovery] = useState<UsageProjects | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [choosing, setChoosing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const request = useRef(0);
+  const readLock = useRef(false);
+  const pickerLock = useRef(false);
+  const mounted = useRef(false);
+  const latest = useRef({ repoPath, allowAutoSelect, onSelect });
+  latest.current = { repoPath, allowAutoSelect, onSelect };
+
+  async function discover() {
+    if (readLock.current) return;
+    readLock.current = true;
+    const generation = ++request.current;
+    setBusy(true); setError(null);
+    try {
+      const result = await loadDesktopUsageProjects();
+      if (generation !== request.current) return;
+      setDiscovery(result);
+      if (latest.current.allowAutoSelect && !latest.current.repoPath.trim() && result.projects.length) {
+        latest.current.onSelect(result.projects[0].path);
+      }
+    } catch (cause) {
+      if (generation === request.current) setError(projectDiscoveryError(cause));
+    } finally {
+      readLock.current = false;
+      if (generation === request.current) setBusy(false);
+    }
+  }
+
+  useEffect(() => { mounted.current = true; void discover(); return () => { mounted.current = false; request.current += 1; readLock.current = false; }; }, []);
+
+  async function choose() {
+    if (pickerLock.current) return;
+    pickerLock.current = true;
+    setChoosing(true); setError(null);
+    try {
+      const project = await chooseDesktopProject();
+      if (project && mounted.current) latest.current.onSelect(project.path);
+    } catch { if (mounted.current) setError("Não foi possível abrir ou validar a pasta. Informe o caminho manualmente abaixo."); }
+    finally { pickerLock.current = false; if (mounted.current) setChoosing(false); }
+  }
+
+  const selected = discovery?.projects.find((project) => project.path === repoPath.trim());
+  return <section className="panel token-projects" aria-label="Pastas com uso do Simplicio">
+    <div className="token-projects-heading"><div><span className="eyebrow">Descoberta automática</span><h2>Pastas com registros do Simplicio</h2><p>Selecione um projeto encontrado para consultar seus relatórios. Os dados permanecem neste computador.</p></div><button className="button button-secondary" type="button" disabled={busy} onClick={() => void discover()}>{busy ? "Buscando pastas…" : "Atualizar pastas"}</button></div>
+    <div className="token-projects-controls">
+      <label>Projetos encontrados<select aria-label="Projetos com uso do Simplicio" value={selected?.id ?? ""} disabled={!discovery?.projects.length} onChange={(event) => {
+        const project = discovery?.projects.find((item) => item.id === event.target.value);
+        if (project) onSelect(project.path);
+      }}><option value="">{busy ? "Procurando ledgers locais…" : "Selecione uma pasta"}</option>{discovery?.projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}</select></label>
+      <button className="button button-secondary" type="button" disabled={choosing} onClick={() => void choose()}>{choosing ? "Escolhendo…" : "Escolher outra pasta…"}</button>
+    </div>
+    {error && <p className="token-projects-notice" aria-live="polite">{error}</p>}
+    {discovery && <>
+      <p>{discovery.projects.length} {discovery.projects.length === 1 ? "pasta encontrada" : "pastas encontradas"}. {selected && <>Nesta pasta: {selected.evidenceType === "both" ? "ledgers de contexto e uso" : selected.evidenceType === "context" ? "ledger de contexto" : "ledger de uso"}.</>}</p>
+      <p className="token-projects-note">Um ledger encontrado é um candidato; o Runtime verifica o relatório antes de mostrar os números. A descoberta não lê os documentos do projeto.</p>
+      {discovery.partial && <p className="token-projects-notice">Descoberta parcial: algum limite, pasta inacessível ou leitura sem resposta restringiu a busca. As pastas encontradas continuam disponíveis; use a seleção manual para outras.</p>}
+      {!!discovery.unavailableRoots?.length && <p className="token-projects-note">Locais não concluídos: {discovery.unavailableRoots.map((name) => name === "Configured repository" ? "Repositório configurado" : name).join(", ")}. A escolha manual continua disponível.</p>}
+      {!discovery.projects.length && <p>Nenhum ledger foi encontrado nesta busca. Escolha uma pasta manualmente para consultar outro local.</p>}
+      <details><summary>Locais e limites da busca</summary><ul>{discovery.roots.map((root) => <li key={root.path}><strong>{root.name}</strong><code>{root.path}</code></li>)}</ul><p>Até 5 níveis, 4.000 diretórios e 64 resultados recentes. O orçamento é dividido entre os locais pesquisados. A busca não percorre a pasta pessoal inteira, não segue links simbólicos e ignora caches e dependências. Cada local é consultado em um processo separado com prazo de 3 segundos; se uma leitura não responder, os resultados dos outros locais são preservados.</p></details>
+    </>}
+  </section>;
+}

--- a/apps/desktop/src/context_report.css
+++ b/apps/desktop/src/context_report.css
@@ -1,0 +1,20 @@
+.context-report { margin-top: 22px; padding: 24px; min-width: 0; }
+.context-report-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 22px; }
+.context-report-heading > div { min-width: 0; }
+.context-report h2 { margin: 6px 0 8px; font-size: 20px; letter-spacing: -.035em; }
+.context-report p { color: var(--muted, #667085); font-size: 13px; line-height: 1.6; overflow-wrap: anywhere; }
+.context-report-heading button { flex-shrink: 0; max-width: 100%; }
+.context-disclaimer { border-left: 2px solid var(--line, #e5e7eb); padding-left: 12px; }
+.context-empty { padding: 20px 0 4px; }
+.context-metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 18px; padding: 22px 0; }
+.context-metrics > div { min-width: 0; display: grid; gap: 9px; align-content: start; }
+.context-metrics span, .context-metrics small { font-size: 12px; color: var(--muted, #667085); overflow-wrap: anywhere; }
+.context-metrics strong { font-size: clamp(23px, 2.7vw, 32px); font-weight: 550; letter-spacing: -.055em; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+.context-proof { display: flex; flex-wrap: wrap; gap: 8px; }
+.context-proof span { border: 1px solid var(--line, #e5e7eb); border-radius: 6px; padding: 5px 9px; font-size: 12px; }
+.context-report .context-caution { color: #795019; background: #fffaf1; padding: 12px 14px; border-radius: 7px; }
+.context-digest { margin-top: 18px; font-size: 12px; }
+.context-digest summary { cursor: pointer; color: var(--muted, #667085); }
+.context-digest code { display: block; margin-top: 10px; overflow-wrap: anywhere; }
+@media (max-width: 1080px) { .context-report-heading { flex-direction: column; gap: 10px; } .context-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 600px) { .context-report { padding: 18px; } .context-metrics { gap: 20px 12px; } .context-report-heading button { white-space: normal; } }

--- a/apps/desktop/src/context_report.test.ts
+++ b/apps/desktop/src/context_report.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { contextErrorMessage, createContextReader, parseContextReport } from "./context_report";
+
+function fixture(): Record<string, unknown> {
+  return {
+    schema: "simplicio.desktop-context-report/v1", source: "runtime", scope: "project_history",
+    eventCount: 12, ledgerEventCount: 12, llmSpendEventCount: 0, savedTokens: 350,
+    baselineTokens: 1000, actualTokens: 650, netTokens: 350,
+    baselineKind: "mixed", confidence: "low", heuristicEventCount: 10, unlabeledEstimateCount: 1,
+    proof: { measured: 9, estimated: 3, replayed: 0, benchmark: 0, unavailable: 0 },
+    reportHash: `sha256:${"c".repeat(64)}`,
+  };
+}
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe("bounded context report", () => {
+  it("projects only metrics, not raw records or arbitrary extension fields", () => {
+    const report = parseContextReport({ ...fixture(), records: ["secret"], cost: 99, source_artifacts: ["/private"] });
+    expect(report.savedTokens).toBe(350);
+    expect(report.netTokens).toBe(350);
+    expect(report.proof.estimated).toBe(3);
+    expect(JSON.stringify(report)).not.toMatch(/secret|source_artifacts|cost/);
+  });
+
+  it("preserves a negative net instead of using the gross savings as the net result", () => {
+    const report = parseContextReport({ ...fixture(), actualTokens: 1100, netTokens: -100 });
+    expect(report.netTokens).toBe(-100);
+    expect(report.savedTokens).toBe(350);
+  });
+
+  it("requires unknown comparisons when the history contains LLM spending", () => {
+    const raw = { ...fixture(), eventCount: 10, llmSpendEventCount: 2 };
+    expect(() => parseContextReport(raw)).toThrow("context_report_invalid");
+    expect(parseContextReport({ ...raw, baselineTokens: null, actualTokens: null, netTokens: null }).netTokens).toBeNull();
+  });
+
+  it.each([
+    { source: "preview" }, { schema: "other" }, { savedTokens: Number.MAX_SAFE_INTEGER + 1 },
+    { savedTokens: -1 }, { eventCount: 13 }, { ledgerEventCount: 0 }, { netTokens: 349 },
+    { heuristicEventCount: 12 }, { confidence: "guaranteed" }, { baselineKind: "anything" },
+    { proof: { measured: 10, estimated: 3, replayed: 0, benchmark: 0, unavailable: 0 } },
+    { reportHash: "not-a-digest" },
+  ])("rejects invalid data %j", (patch) => {
+    expect(() => parseContextReport({ ...fixture(), ...patch })).toThrow("context_report_invalid");
+  });
+
+  it("shares same-project reads and rejects different scopes while a native call is outstanding", async () => {
+    let complete!: (value: unknown) => void;
+    const invoke = vi.fn(() => new Promise<unknown>((resolve) => { complete = resolve; }));
+    const read = createContextReader(invoke);
+    const first = read(" /tmp/project ");
+    expect(read("/tmp/project")).toBe(first);
+    await expect(read("/tmp/other")).rejects.toThrow("context_report_busy");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    complete(fixture());
+    await expect(first).resolves.toMatchObject({ savedTokens: 350 });
+  });
+
+  it("retains the project lock after observer timeout until the native operation actually settles", async () => {
+    vi.useFakeTimers();
+    let complete!: (value: unknown) => void;
+    const invoke = vi.fn(() => new Promise<unknown>((resolve) => { complete = resolve; }));
+    const read = createContextReader(invoke, 20);
+    const first = read("/tmp/a");
+    const failure = expect(first).rejects.toThrow("context_report_timeout");
+    await vi.advanceTimersByTimeAsync(21);
+    await failure;
+    expect(read("/tmp/a")).toBe(first);
+    await expect(read("/tmp/b")).rejects.toThrow("context_report_busy");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    complete(fixture());
+    await vi.advanceTimersByTimeAsync(0);
+    const second = read("/tmp/b");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    complete(fixture());
+    await expect(second).resolves.toMatchObject({ savedTokens: 350 });
+  });
+
+  it("does not leak unknown native errors or turn unavailable evidence into savings", () => {
+    expect(contextErrorMessage("context_ledger_invalid")).toContain("integridade");
+    expect(contextErrorMessage("secret token: private")).not.toContain("secret");
+    expect(contextErrorMessage("context_ledger_empty")).toContain("não significa consumo zero");
+  });
+});

--- a/apps/desktop/src/context_report.ts
+++ b/apps/desktop/src/context_report.ts
@@ -1,0 +1,115 @@
+const PROOFS = ["measured", "estimated", "replayed", "benchmark", "unavailable"] as const;
+type ProofKind = typeof PROOFS[number];
+type BaselineKind = ProofKind | "mixed";
+type Confidence = "low" | "medium" | "high" | "measured" | "unavailable";
+
+export interface ContextReport {
+  schema: "simplicio.desktop-context-report/v1";
+  source: "runtime";
+  scope: "project_history";
+  eventCount: number;
+  ledgerEventCount: number;
+  llmSpendEventCount: number;
+  savedTokens: number;
+  baselineTokens: number | null;
+  actualTokens: number | null;
+  netTokens: number | null;
+  baselineKind: BaselineKind;
+  confidence: Confidence;
+  heuristicEventCount: number;
+  unlabeledEstimateCount: number;
+  proof: Record<ProofKind, number>;
+  reportHash: string;
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("context_report_invalid");
+  return value as Record<string, unknown>;
+}
+
+function count(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new Error("context_report_invalid");
+  return value;
+}
+
+export function parseContextReport(value: unknown): ContextReport {
+  const raw = object(value);
+  const invalid = () => { throw new Error("context_report_invalid"); };
+  if (raw.schema !== "simplicio.desktop-context-report/v1" || raw.source !== "runtime" || raw.scope !== "project_history"
+    || typeof raw.reportHash !== "string" || !/^sha256:[a-f0-9]{64}$/.test(raw.reportHash)) return invalid();
+  const eventCount = count(raw.eventCount);
+  const ledgerEventCount = count(raw.ledgerEventCount);
+  const llmSpendEventCount = count(raw.llmSpendEventCount);
+  if (!ledgerEventCount || eventCount + llmSpendEventCount !== ledgerEventCount) return invalid();
+  const savedTokens = count(raw.savedTokens);
+  if (!eventCount && savedTokens !== 0) return invalid();
+  const baselineTokens = raw.baselineTokens === null ? null : count(raw.baselineTokens);
+  const actualTokens = raw.actualTokens === null ? null : count(raw.actualTokens);
+  let netTokens: number | null = null;
+  if (!llmSpendEventCount) {
+    if (baselineTokens === null || actualTokens === null || typeof raw.netTokens !== "number"
+      || !Number.isSafeInteger(raw.netTokens) || raw.netTokens !== baselineTokens - actualTokens) return invalid();
+    netTokens = raw.netTokens;
+  } else if (baselineTokens !== null || actualTokens !== null || raw.netTokens !== null) return invalid();
+  const baselineKind = raw.baselineKind;
+  const confidence = raw.confidence;
+  if (typeof baselineKind !== "string" || ![...PROOFS, "mixed"].includes(baselineKind)
+    || typeof confidence !== "string" || !["low", "medium", "high", "measured", "unavailable"].includes(confidence)) return invalid();
+  const heuristicEventCount = count(raw.heuristicEventCount);
+  const unlabeledEstimateCount = count(raw.unlabeledEstimateCount);
+  if (heuristicEventCount + unlabeledEstimateCount > ledgerEventCount) return invalid();
+  const rawProof = object(raw.proof);
+  const proof = Object.fromEntries(PROOFS.map((key) => [key, count(rawProof[key])])) as Record<ProofKind, number>;
+  if (Object.values(proof).reduce((sum, n) => sum + n, 0) !== ledgerEventCount) return invalid();
+  return { schema: "simplicio.desktop-context-report/v1", source: "runtime", scope: "project_history",
+    eventCount, ledgerEventCount, llmSpendEventCount, savedTokens, baselineTokens, actualTokens, netTokens,
+    baselineKind: baselineKind as BaselineKind, confidence: confidence as Confidence,
+    heuristicEventCount, unlabeledEstimateCount, proof, reportHash: raw.reportHash };
+}
+
+/** A timed-out observer does not release a native request or let a different project reuse its result. */
+export function createContextReader(
+  invoke: (repoPath: string) => Promise<unknown>,
+  timeoutMs = 45_000,
+): (repoPath: string) => Promise<ContextReport> {
+  let pending: { scope: string; promise: Promise<ContextReport> } | null = null;
+  return (repoPath) => {
+    const scope = repoPath.trim();
+    if (pending) return pending.scope === scope ? pending.promise : Promise.reject(new Error("context_report_busy"));
+    const native = Promise.resolve().then(() => invoke(scope)).then(parseContextReport);
+    const promise = new Promise<ContextReport>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("context_report_timeout")), timeoutMs);
+      native.then(
+        (report) => { clearTimeout(timer); pending = null; resolve(report); },
+        (error: unknown) => { clearTimeout(timer); pending = null; reject(error); },
+      );
+    });
+    pending = { scope, promise };
+    return promise;
+  };
+}
+
+export const CONTEXT_EVIDENCE: Record<BaselineKind, string> = {
+  measured: "Evidência marcada como medida", estimated: "Evidência estimada", replayed: "Evidência de replay",
+  benchmark: "Evidência de benchmark", mixed: "Evidência mista", unavailable: "Tipo de evidência não informado",
+};
+export const CONTEXT_CONFIDENCE: Record<Confidence, string> = {
+  low: "baixa", medium: "média", high: "alta", measured: "medida pelo Runtime", unavailable: "não informada",
+};
+
+export function contextErrorMessage(cause: unknown): string {
+  const code = cause instanceof Error ? cause.message : String(cause);
+  switch (code) {
+    case "context_query_invalid": return "Escolha uma pasta local existente com caminho absoluto e consulte novamente.";
+    case "context_ledger_unavailable": return "Esta pasta não tem um histórico local de economia disponível. Escolha o projeto em que o Simplicio foi usado. Nenhum histórico foi criado nesta consulta.";
+    case "context_ledger_empty": return "O histórico desta pasta ainda não contém eventos de economia. Ausência de dados não significa consumo zero.";
+    case "context_ledger_invalid": return "A verificação de integridade do histórico falhou. Os números não serão exibidos; verifique o ledger pelo Runtime.";
+    case "context_report_invalid": return "O Runtime devolveu um relatório incompatível. Nenhuma economia foi assumida.";
+    case "context_report_busy": return "A consulta da outra pasta ainda está em andamento. Aguarde sua conclusão antes de consultar esta pasta.";
+    case "context_report_timeout": return "O Runtime demorou para responder. A consulta anterior não será duplicada enquanto estiver em andamento.";
+    case "desktop_access_not_active": return "Verifique o acesso da conta no Simplicio antes de consultar este relatório.";
+    case "desktop_access_unverified": return "O Runtime não confirmou o acesso da conta nesta consulta. Verifique a conta e tente novamente; nenhuma assinatura foi considerada inativa.";
+    case "preview_no_runtime": return "Este relatório exige o aplicativo desktop conectado ao Runtime local. A prévia não lê arquivos.";
+    default: return "Não foi possível consultar a economia desta pasta. Verifique o Runtime e tente novamente.";
+  }
+}

--- a/apps/desktop/src/desktop_updates.css
+++ b/apps/desktop/src/desktop_updates.css
@@ -1,0 +1,67 @@
+/* Compact, light update task surface. Progress belongs to metadata, not an installer. */
+.desktop-updates-dialog.project-dialog {
+  width: min(548px, calc(100vw - 32px));
+  max-height: calc(100dvh - 40px);
+  box-sizing: border-box;
+  padding: 18px 24px 22px;
+  overflow: hidden;
+  background: #fff;
+  color: #23272e;
+  border: 1px solid #dce1e5;
+  border-radius: 14px;
+  box-shadow: 0 24px 80px #17221e26, 0 4px 18px #17221e12;
+}
+.desktop-updates-dialog[open] { display: flex; flex-direction: column; }
+.desktop-updates-dialog > :not(.desktop-update-content) { flex-shrink: 0; }
+.desktop-updates-dialog .desktop-update-content { min-height: 0; overflow: auto; scrollbar-width: thin; scrollbar-color: #cdd6d0 transparent; }
+.desktop-updates-dialog .desktop-update-topline { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 0 -6px 17px 0; color: #69727d; font-size: 11px; }
+.desktop-updates-dialog .desktop-update-summary { display: grid; grid-template-columns: 64px minmax(0, 1fr); align-items: start; gap: 18px; }
+.desktop-updates-dialog .desktop-update-icon { display: block; width: 64px; height: 64px; border-radius: 15px; border: 1px solid #e7ebe8; object-fit: cover; box-shadow: 0 2px 5px #233d2909; }
+.desktop-updates-dialog.project-dialog h2 { margin: 2px 0 8px; color: #23272e; font-size: 20px; font-weight: 650; letter-spacing: -.03em; line-height: 1.3; overflow-wrap: anywhere; }
+.desktop-updates-dialog.project-dialog p { margin: 0; font-size: 12px; color: #69727d; line-height: 1.65; overflow-wrap: anywhere; }
+.desktop-updates-dialog .desktop-update-progress { margin-top: 24px; }
+.desktop-updates-dialog .desktop-update-progress-label { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; color: #454e58; font-size: 12px; }
+.desktop-updates-dialog .desktop-update-progress-label > span:last-child { color: #69727d; flex-shrink: 0; font-size: 10px; }
+.desktop-updates-dialog progress { display: block; width: 100%; height: 6px; margin: 10px 0 8px; border: 0; border-radius: 10px; overflow: hidden; appearance: none; background: #e5ede8; }
+.desktop-updates-dialog progress:indeterminate { background: linear-gradient(90deg, #e5ede8 0%, #e5ede8 35%, #299c76 45%, #299c76 55%, #e5ede8 65%, #e5ede8 100%); background-size: 260% 100%; animation: desktop-updates-indeterminate 1.6s ease-in-out infinite; }
+.desktop-updates-dialog progress::-webkit-progress-bar { background: transparent; }
+.desktop-updates-dialog progress::-webkit-progress-value { background: transparent; }
+.desktop-updates-dialog progress::-moz-progress-bar { background: transparent; }
+.desktop-updates-dialog .desktop-update-progress > p { font-size: 11px; }
+.desktop-updates-dialog.project-dialog .desktop-update-installed { margin: 18px 0 0; font-size: 11px; }
+.desktop-updates-dialog .desktop-update-installed strong { color: #454e58; font-weight: 550; font-variant-numeric: tabular-nums; }
+.desktop-updates-dialog .desktop-update-package { margin-top: 14px; padding: 14px 16px; border: 1px solid #e3e8e5; border-radius: 9px; background: #f8faf9; }
+.desktop-updates-dialog .desktop-update-package > div { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; font-size: 11px; color: #69727d; }
+.desktop-updates-dialog .desktop-update-package > div > span:first-child { display: inline-flex; align-items: center; gap: 6px; color: #365746; }
+.desktop-updates-dialog .desktop-update-package > strong { display: block; font-size: 12px; font-weight: 550; color: #303c35; overflow-wrap: anywhere; }
+.desktop-updates-dialog .desktop-update-package > p { margin-top: 5px; font-size: 10px; }
+.desktop-updates-dialog .desktop-update-notes { margin-top: 12px; border-bottom: 1px solid #edf0f2; padding-bottom: 10px; }
+.desktop-updates-dialog .desktop-update-notes summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 0; font-size: 12px; font-weight: 550; color: #454e58; cursor: pointer; list-style: none; border-radius: 4px; }
+.desktop-updates-dialog .desktop-update-notes summary::-webkit-details-marker { display: none; }
+.desktop-updates-dialog .desktop-update-notes[open] summary .glyph { transform: rotate(180deg); }
+.desktop-updates-dialog .desktop-update-notes p { margin: 8px 0; font-size: 11px; }
+.desktop-updates-dialog .desktop-update-notes pre { max-height: 168px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; margin: 10px 0; padding: 12px; border: 1px solid #edf0f2; border-radius: 6px; background: #fafbfb; color: #454e58; font-size: 12px; font-family: inherit; line-height: 1.7; }
+.desktop-updates-dialog .desktop-update-manual { display: flex; align-items: flex-start; gap: 9px; margin-top: 18px; color: #69727d; }
+.desktop-updates-dialog .desktop-update-manual > .glyph { flex-shrink: 0; margin-top: 2px; }
+.desktop-updates-dialog .desktop-update-manual strong { font-size: 12px; font-weight: 550; color: #454e58; }
+.desktop-updates-dialog .desktop-update-manual p { margin-top: 4px; font-size: 11px; }
+.desktop-updates-dialog.project-dialog .desktop-update-caption { margin-top: 14px; font-size: 10px; line-height: 1.7; }
+.desktop-updates-dialog.project-dialog .inline-error { margin-top: 14px; color: #903b27; }
+.desktop-updates-dialog .desktop-update-actions { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 8px; margin-top: 18px; padding-top: 16px; border-top: 1px solid #edf0f2; background: #fff; }
+.desktop-updates-dialog .button { min-height: 38px; padding: 8px 12px; border-radius: 7px; font-size: 11px; font-weight: 550; }
+.desktop-updates-dialog .button-secondary { background: #fff; border-color: #dce1e5; color: #454e58; }
+.desktop-updates-dialog .button-primary { background: #24694d; border-color: #24694d; color: #fff; }
+.desktop-updates-dialog .button:disabled { opacity: .5; cursor: default; }
+.desktop-updates-dialog .button-primary:hover:not(:disabled) { background: #1b583e; border-color: #1b583e; }
+.desktop-updates-dialog .button-secondary:hover:not(:disabled) { background: #f6f8f7; border-color: #bcc8c1; }
+.desktop-updates-dialog :is(button, summary):focus-visible { outline: 2px solid #176d50; outline-offset: 3px; }
+@keyframes desktop-updates-indeterminate { from { background-position: 100% 0; } to { background-position: -100% 0; } }
+@media (prefers-reduced-motion: reduce) { .desktop-updates-dialog progress:indeterminate { animation: none; background-position: 50% 0; } }
+@media (max-width: 520px) {
+  .desktop-updates-dialog.project-dialog { padding: 14px 18px 18px; }
+  .desktop-updates-dialog .desktop-update-summary { grid-template-columns: 48px minmax(0, 1fr); gap: 14px; }
+  .desktop-updates-dialog .desktop-update-icon { width: 48px; height: 48px; border-radius: 12px; }
+  .desktop-updates-dialog.project-dialog h2 { font-size: 18px; }
+  .desktop-updates-dialog .desktop-update-progress-label { flex-wrap: wrap; gap: 5px; }
+  .desktop-updates-dialog .desktop-update-actions .button { flex: 1 1 100%; }
+}

--- a/apps/desktop/src/desktop_updates.test.ts
+++ b/apps/desktop/src/desktop_updates.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { checkDesktopUpdate, compareVersions, DESKTOP_RELEASES_API, DESKTOP_RELEASES_URL, MAX_RELEASE_BYTES, MAX_RELEASES, parseDesktopUpdateTarget, selectDesktopRelease, type DesktopUpdateTarget } from "./desktop_updates";
+import { checkDesktopUpdate, compareVersions, DESKTOP_RELEASES_API, DESKTOP_RELEASES_URL, MAX_RELEASE_BYTES, MAX_RELEASE_NOTES, MAX_RELEASES, parseDesktopUpdateTarget, selectDesktopRelease, type DesktopUpdateProgress, type DesktopUpdateTarget } from "./desktop_updates";
 
 const mac: DesktopUpdateTarget = { platform: "macos", arch: "arm64" };
 const windows: DesktopUpdateTarget = { platform: "windows", arch: "x64" };
@@ -110,13 +110,92 @@ describe("published Desktop asset selection", () => {
     expect(() => selectDesktopRelease(Array.from({ length: MAX_RELEASES + 1 }, () => release("3.8.39")), mac)).toThrow("invalid_response");
     const fixture = release("3.8.39");
     expect(() => selectDesktopRelease([{ ...fixture, assets: Array.from({ length: 129 }, () => fixture.assets[0]) }], mac)).toThrow("invalid_response");
-    const selected = selectDesktopRelease([{ ...fixture, body: "<script>secret</script>", author: { token: "secret" } }], mac);
-    expect(Object.keys(selected).sort()).toEqual(["assetBytes", "assetName", "releaseUrl", "tag", "version"]);
+    const selected = selectDesktopRelease([{ ...fixture, body: "Notas públicas", author: { token: "secret" } }], mac);
+    expect(Object.keys(selected).sort()).toEqual(["assetBytes", "assetName", "notes", "publishedAt", "releaseUrl", "tag", "version"]);
     expect(JSON.stringify(selected)).not.toContain("secret");
+  });
+
+  it("returns bounded public notes as inert text, without bidi or control characters", () => {
+    const body = "\u202e## Novidades\u0000\r\n<img src='https://untrusted.invalid'>\rTexto público";
+    const selected = selectDesktopRelease([{ ...release("3.8.39"), body }], mac);
+    expect(selected.notes).toEqual({ text: "## Novidades\n<img src='https://untrusted.invalid'>\nTexto público", truncated: false });
+    const long = selectDesktopRelease([{ ...release("3.8.39"), body: "x".repeat(MAX_RELEASE_NOTES + 20) }], mac);
+    expect(long.notes).toEqual({ text: "x".repeat(MAX_RELEASE_NOTES), truncated: true });
+    const emoji = selectDesktopRelease([{ ...release("3.8.39"), body: "x".repeat(MAX_RELEASE_NOTES - 1) + "🌱" }], mac);
+    expect(emoji.notes?.text).toBe("x".repeat(MAX_RELEASE_NOTES - 1));
+  });
+
+  it("treats missing or non-text notes as unavailable rather than inventing a changelog", () => {
+    for (const body of [null, undefined, {}, "\r\n\u0000\u202e"]) {
+      expect(selectDesktopRelease([{ ...release("3.8.39"), body }], mac).notes).toBeNull();
+    }
+  });
+
+  it("accepts only a real publication date in the expected ISO format", () => {
+    expect(selectDesktopRelease([{ ...release("3.8.39"), published_at: "2026-08-31T01:34:29Z" }], mac).publishedAt).toBe("2026-08-31T01:34:29Z");
+    for (const published_at of [null, 123, "yesterday", "2026-02-30T01:34:29Z", "2026-13-31T01:34:29Z", "2026-08-31T01:34:29Z\n"]) {
+      expect(selectDesktopRelease([{ ...release("3.8.39"), published_at }], mac).publishedAt).toBeNull();
+    }
   });
 });
 
 describe("bounded metadata-only update checks", () => {
+  it("reports real metadata stages and decoded bytes, not an installer download percentage", async () => {
+    const payload = [{ ...release("3.8.39"), body: "Atualização pública" }];
+    const byteLength = new TextEncoder().encode(JSON.stringify(payload)).byteLength;
+    const onProgress = vi.fn<(value: DesktopUpdateProgress) => void>();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse(payload, { "content-length": "40", "content-encoding": "gzip" }));
+    await checkDesktopUpdate({ currentVersion: "3.8.38", target: mac, fetcher, onProgress });
+    expect(onProgress.mock.calls.map(([value]) => value)).toEqual([
+      { stage: "requesting", receivedBytes: 0 }, { stage: "receiving", receivedBytes: 0 },
+      { stage: "receiving", receivedBytes: byteLength }, { stage: "validating", receivedBytes: byteLength },
+    ]);
+  });
+
+  it("bounds progress notifications for tiny stream chunks and isolates observer failures", async () => {
+    const bytes = new TextEncoder().encode(JSON.stringify([{ ...release("3.8.39"), body: "x".repeat(40_000) }]));
+    const body = new ReadableStream<Uint8Array>({ start(controller) {
+      for (let offset = 0; offset < bytes.length; offset += 128) controller.enqueue(bytes.slice(offset, offset + 128));
+      controller.close();
+    } });
+    const onProgress = vi.fn<(value: DesktopUpdateProgress) => void>(() => { throw new Error("observer failed"); });
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(body, { headers: { "content-type": "application/json" } }));
+    await expect(checkDesktopUpdate({ currentVersion: "3.8.39", target: mac, fetcher, onProgress })).resolves.toMatchObject({ state: "up_to_date" });
+    expect(onProgress.mock.calls.length).toBeLessThanOrEqual(Math.ceil(bytes.length / 16_384) + 3);
+    expect(onProgress).toHaveBeenLastCalledWith({ stage: "validating", receivedBytes: bytes.length });
+  });
+
+  it("cancels the pending body reader on deadline and stops reporting progress", async () => {
+    vi.useFakeTimers();
+    const cancelBody = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel: cancelBody });
+    const onProgress = vi.fn<(value: DesktopUpdateProgress) => void>();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(body, { headers: { "content-type": "application/json" } }));
+    const result = checkDesktopUpdate({ currentVersion: "3.8.39", target: mac, fetcher, onProgress, timeoutMs: 25 });
+    const rejected = expect(result).rejects.toMatchObject({ code: "timeout" });
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(onProgress.mock.calls.map(([value]) => value.stage)).toEqual(["requesting", "receiving"]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores late metadata and cancels its body when a fetch ignores cancellation", async () => {
+    const controller = new AbortController();
+    let resolveFetch: (value: Response) => void = () => undefined;
+    const fetcher = vi.fn<typeof fetch>(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+    const onProgress = vi.fn<(value: DesktopUpdateProgress) => void>();
+    const result = checkDesktopUpdate({ currentVersion: "3.8.39", target: mac, fetcher, onProgress, signal: controller.signal });
+    const rejected = expect(result).rejects.toMatchObject({ code: "canceled" });
+    controller.abort();
+    await rejected;
+    const cancelBody = vi.fn();
+    resolveFetch(new Response(new ReadableStream({ cancel: cancelBody }), { headers: { "content-type": "application/json" } }));
+    await Promise.resolve();
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    expect(onProgress.mock.calls.map(([value]) => value.stage)).toEqual(["requesting"]);
+  });
+
   it.each([["3.8.38", "available"], ["3.8.39", "up_to_date"], ["3.8.40", "newer_local"]] as const)("reports %s as %s only after validated Desktop metadata", async (currentVersion, state) => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([release("3.8.39")]));
     await expect(checkDesktopUpdate({ currentVersion, target: mac, fetcher })).resolves.toMatchObject({ state, currentVersion, target: mac });

--- a/apps/desktop/src/desktop_updates.ts
+++ b/apps/desktop/src/desktop_updates.ts
@@ -3,6 +3,7 @@ export const DESKTOP_RELEASES_URL = "https://github.com/wesleysimplicio/simplici
 export const DESKTOP_RELEASES_API = "https://api.github.com/repos/wesleysimplicio/simplicio/releases?per_page=30";
 export const MAX_RELEASES = 30;
 export const MAX_RELEASE_BYTES = 2 * 1024 * 1024;
+export const MAX_RELEASE_NOTES = 3_000;
 const MAX_ASSETS = 128;
 const CHECK_TIMEOUT_MS = 15_000;
 
@@ -17,6 +18,13 @@ export type DesktopRelease = {
   releaseUrl: string;
   assetName: string;
   assetBytes: number;
+  publishedAt: string | null;
+  notes: { text: string; truncated: boolean } | null;
+};
+
+export type DesktopUpdateProgress = {
+  stage: "requesting" | "receiving" | "validating";
+  receivedBytes: number;
 };
 
 export type DesktopUpdateResult = {
@@ -114,6 +122,20 @@ function desktopAssetRank(name: string, version: string, target: DesktopUpdateTa
   return rank < 0 ? null : rank;
 }
 
+function releaseNotes(value: unknown): DesktopRelease["notes"] {
+  if (typeof value !== "string") return null;
+  // This is public, untrusted publication text, never HTML/Markdown to execute.
+  const text = value.slice(0, MAX_RELEASE_NOTES).replace(/[\uD800-\uDBFF]$/, "")
+    .replace(/\r\n?/g, "\n").replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2066-\u2069]/g, "").trim();
+  return text ? { text, truncated: value.length > MAX_RELEASE_NOTES } : null;
+}
+
+function publicationDate(value: unknown): string | null {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value)) return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) && date.toISOString() === value.replace(/Z$/, ".000Z") ? value : null;
+}
+
 export function selectDesktopRelease(payload: unknown, target: DesktopUpdateTarget): DesktopRelease {
   const validTarget = parseDesktopUpdateTarget(target);
   if (!Array.isArray(payload) || payload.length > MAX_RELEASES) throw new DesktopUpdateError("invalid_response");
@@ -135,14 +157,20 @@ export function selectDesktopRelease(payload: unknown, target: DesktopUpdateTarg
       if (selected === null || rank < selected.rank) selected = { name: asset.name, bytes: asset.size, rank };
     }
     if (selected && (latest === null || compareVersions(version, latest.version) > 0)) {
-      latest = { version, tag: entry.tag_name, releaseUrl, assetName: selected.name, assetBytes: selected.bytes };
+      latest = { version, tag: entry.tag_name, releaseUrl, assetName: selected.name, assetBytes: selected.bytes,
+        publishedAt: publicationDate(entry.published_at), notes: releaseNotes(entry.body) };
     }
   }
   if (!latest) throw new DesktopUpdateError("no_compatible_release");
   return latest;
 }
 
-async function readBoundedJson(response: Response): Promise<unknown> {
+async function readBoundedJson(response: Response, signal: AbortSignal, progress: (value: DesktopUpdateProgress) => void): Promise<unknown> {
+  const interrupted = () => signal.reason instanceof DesktopUpdateError ? signal.reason : new DesktopUpdateError("canceled");
+  if (signal.aborted) {
+    void response.body?.cancel().catch(() => undefined);
+    throw interrupted();
+  }
   const declaredLength = Number(response.headers.get("content-length"));
   if (declaredLength > MAX_RELEASE_BYTES || !response.body ||
     !/^application\/json(?:;|$)/i.test(response.headers.get("content-type") ?? "")) {
@@ -152,10 +180,15 @@ async function readBoundedJson(response: Response): Promise<unknown> {
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8", { fatal: true });
   let size = 0;
+  let reportedSize = 0;
   let text = "";
+  const cancelReader = () => { void reader.cancel().catch(() => undefined); };
+  signal.addEventListener("abort", cancelReader, { once: true });
+  progress({ stage: "receiving", receivedBytes: 0 });
   try {
     while (true) {
       const { done, value } = await reader.read();
+      if (signal.aborted) throw interrupted();
       if (done) break;
       size += value.byteLength;
       if (size > MAX_RELEASE_BYTES) {
@@ -163,12 +196,20 @@ async function readBoundedJson(response: Response): Promise<unknown> {
         throw new DesktopUpdateError("invalid_response");
       }
       text += decoder.decode(value, { stream: true });
+      // Bound observer work even when the stream arrives in tiny chunks.
+      if (size - reportedSize >= 16_384) {
+        progress({ stage: "receiving", receivedBytes: size });
+        reportedSize = size;
+      }
     }
+    if (size !== reportedSize) progress({ stage: "receiving", receivedBytes: size });
+    progress({ stage: "validating", receivedBytes: size });
     return JSON.parse(text + decoder.decode()) as unknown;
   } catch (error) {
     if (error instanceof DesktopUpdateError) throw error;
     throw new DesktopUpdateError("invalid_response");
   } finally {
+    signal.removeEventListener("abort", cancelReader);
     reader.releaseLock();
   }
 }
@@ -180,6 +221,7 @@ export async function checkDesktopUpdate(options: {
   fetcher?: typeof fetch;
   online?: boolean;
   timeoutMs?: number;
+  onProgress?: (value: DesktopUpdateProgress) => void;
 }): Promise<DesktopUpdateResult> {
   versionParts(options.currentVersion);
   const target = parseDesktopUpdateTarget(options.target);
@@ -191,17 +233,23 @@ export async function checkDesktopUpdate(options: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let cancel: () => void = () => undefined;
   const interrupted = new Promise<never>((_, reject) => {
-    cancel = () => { controller.abort(); reject(new DesktopUpdateError("canceled")); };
+    cancel = () => { const error = new DesktopUpdateError("canceled"); controller.abort(error); reject(error); };
     options.signal?.addEventListener("abort", cancel, { once: true });
-    timer = setTimeout(() => { controller.abort(); reject(new DesktopUpdateError("timeout")); }, timeoutMs);
+    timer = setTimeout(() => { const error = new DesktopUpdateError("timeout"); controller.abort(error); reject(error); }, timeoutMs);
   });
+  const progress = (value: DesktopUpdateProgress) => {
+    if (controller.signal.aborted) return;
+    // Presentation must not decide whether release metadata is valid.
+    try { options.onProgress?.(value); } catch { /* Ignore an optional observer failure. */ }
+  };
   const request = async (): Promise<DesktopUpdateResult> => {
+    progress({ stage: "requesting", receivedBytes: 0 });
     const response = await (options.fetcher ?? fetch)(DESKTOP_RELEASES_API, {
       method: "GET", headers: { Accept: "application/vnd.github+json" },
       credentials: "omit", cache: "no-store", redirect: "error", referrerPolicy: "no-referrer", signal: controller.signal,
     });
     if (!response.ok) throw new DesktopUpdateError(response.status === 403 || response.status === 429 ? "rate_limited" : "request_failed");
-    const release = selectDesktopRelease(await readBoundedJson(response), target);
+    const release = selectDesktopRelease(await readBoundedJson(response, controller.signal, progress), target);
     const comparison = compareVersions(options.currentVersion, release.version);
     return { state: comparison < 0 ? "available" : comparison > 0 ? "newer_local" : "up_to_date", currentVersion: options.currentVersion, target, release };
   };

--- a/apps/desktop/src/install_failures.test.ts
+++ b/apps/desktop/src/install_failures.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { installFailureMessage } from "./install_failures";
+import { installFailureMessage, installFailureRecovery } from "./install_failures";
 
 describe("safe installer failure messages", () => {
   it("shows only a bounded nonzero OS exit code and warns about partial effects", () => {
@@ -36,5 +36,85 @@ describe("safe installer failure messages", () => {
     expect(installFailureMessage("integration_plan_changed_review_again")).toContain("Revise a configuração");
     expect(installFailureMessage("integration_install_busy")).toContain("já está em andamento");
     expect(installFailureMessage("integration_install_busy")).not.toContain("alterações parciais");
+  });
+
+  it("permits a reviewed retry only when the installer is known not to have started", () => {
+    const message = installFailureMessage("integration_install_not_started");
+    expect(message).toContain("não foi iniciado");
+    expect(message).toContain("Revise um novo plano");
+    expect(message).toContain("antes de tentar novamente");
+    expect(message).not.toContain("alterações parciais");
+  });
+
+  it("keeps post-start uncertainty blocked without treating refresh or restart as reconciliation", () => {
+    for (const code of [
+      "integration_install_timeout", "integration_install_stderr_too_large",
+      "integration_install_cleanup_unconfirmed", "integration_install_reconciliation_required",
+      "integration_install_output_unavailable", "integration_install_no_exit_code",
+      "integration_install_invalid_json", "integration_install_response_too_large",
+      "integration_install_receipt_unconfirmed", "integration_install_exit_code:7",
+    ]) {
+      const message = installFailureMessage(code);
+      expect(message).toContain("bloqueadas nesta sessão");
+      expect(message).toContain("reiniciar o app não confirma");
+      expect(message).not.toContain("tentar novamente");
+      expect(message.length).toBeLessThan(400);
+    }
+    expect(installFailureMessage("integration_install_timeout")).toContain("prazo de execução");
+    expect(installFailureMessage("integration_install_stderr_too_large")).toContain("saída de diagnóstico");
+    expect(installFailureMessage("integration_install_cleanup_unconfirmed")).toContain("encerramento do processo");
+    expect(installFailureMessage("integration_install_reconciliation_required")).toContain("tentativa anterior");
+  });
+
+  it("asks only for another query when the receipt already confirmed the installation", () => {
+    const message = installFailureMessage("integration_install_applied_snapshot_unavailable");
+    expect(message).toContain("confirmou a aplicação");
+    expect(message).toContain("Consulte novamente o diagnóstico");
+    expect(message).toContain("não reinstale");
+    expect(message).not.toContain("tentar outra instalação");
+    expect(message).not.toContain("bloqueadas");
+  });
+
+  it("does not authorize a retry or assert a known process state for unknown failures", () => {
+    const message = installFailureMessage("unrecognized-before-or-after-start");
+    expect(message).toContain("Não repita a aplicação até esclarecer o resultado");
+    expect(message).not.toContain("tentar novamente");
+    expect(message).not.toContain("não foi iniciado");
+    expect(message).not.toContain("bloqueadas nesta sessão");
+  });
+});
+
+describe("installer recovery without repeated side effects", () => {
+  it("allows only a fresh review when native preflight failed before any installer started", () => {
+    const code = "integration_preflight_unavailable";
+    expect(installFailureRecovery(code)).toBe("review");
+    expect(installFailureRecovery(new Error(code))).toBe("review");
+    expect(installFailureMessage(code)).toContain("O instalador não foi iniciado");
+    expect(installFailureMessage(code)).toContain("revise um novo plano");
+    expect(installFailureMessage(code)).not.toContain("alterações parciais");
+  });
+
+  it("requires explicit plan review for a changed plan or a proven failure to start", () => {
+    expect(installFailureRecovery("integration_plan_changed_review_again")).toBe("review");
+    expect(installFailureRecovery(new Error("integration_install_not_started"))).toBe("review");
+  });
+
+  it("waits for a running attempt and only refreshes after a confirmed receipt", () => {
+    expect(installFailureRecovery("integration_install_busy")).toBe("wait");
+    expect(installFailureRecovery("integration_install_applied_snapshot_unavailable")).toBe("refresh");
+  });
+
+  it("does not release post-start uncertainty or unknown errors for a new install", () => {
+    for (const error of [
+      "integration_install_timeout", "integration_install_stderr_too_large",
+      "integration_install_cleanup_unconfirmed", "integration_install_reconciliation_required",
+      "integration_install_output_unavailable", "integration_install_no_exit_code",
+      "integration_install_invalid_json", "integration_install_response_too_large",
+      "integration_install_receipt_unconfirmed", "integration_install_exit_code:7",
+      "runtime_not_started", "integration_install_not_started ",
+      "integration_preflight_unavailable ", "integration_preflight_unavailable: extra",
+      new Error("integration_install_not_started: extra"), { message: "integration_install_not_started" },
+      "__proto__", "constructor", null, "x".repeat(100_000),
+    ]) expect(installFailureRecovery(error)).toBe("reconcile");
   });
 });

--- a/apps/desktop/src/install_failures.ts
+++ b/apps/desktop/src/install_failures.ts
@@ -1,28 +1,57 @@
-const REVIEW_BEFORE_RETRY = "Pode haver alterações parciais. Atualize o diagnóstico e revise um novo plano antes de tentar novamente.";
+const RECONCILIATION_REQUIRED = "Pode haver alterações parciais. Novas aplicações estão bloqueadas nesta sessão. Consulte o diagnóstico para esclarecer o resultado; atualizar ou reiniciar o app não confirma a conclusão.";
+
+export type InstallFailureRecovery = "review" | "wait" | "reconcile" | "refresh";
+
+/** A recovery hint, never authorization to repeat a native side effect. */
+export function installFailureRecovery(error: unknown): InstallFailureRecovery {
+  switch (nativeCode(error)) {
+    case "integration_preflight_unavailable":
+    case "integration_plan_changed_review_again":
+    case "integration_install_not_started":
+      return "review";
+    case "integration_install_busy":
+      return "wait";
+    case "integration_install_applied_snapshot_unavailable":
+      return "refresh";
+    default:
+      return "reconcile";
+  }
+}
 
 const MESSAGES: Readonly<Record<string, string>> = {
+  integration_preflight_unavailable: "Não foi possível confirmar o Runtime e o plano antes da instalação. O instalador não foi iniciado. Consulte o diagnóstico e revise um novo plano antes de confirmar novamente.",
   integration_plan_changed_review_again: "O plano mudou. Revise a configuração novamente antes de aplicar.",
-  integration_install_busy: "Uma instalação já está em andamento. Aguarde a conclusão antes de tentar novamente.",
-  integration_install_output_unavailable: `Não foi possível obter o resultado do instalador. ${REVIEW_BEFORE_RETRY}`,
-  integration_install_no_exit_code: `O instalador terminou sem um código de saída confirmado. ${REVIEW_BEFORE_RETRY}`,
-  integration_install_invalid_json: `O instalador devolveu uma resposta inválida. ${REVIEW_BEFORE_RETRY}`,
-  integration_install_response_too_large: `A resposta do instalador ultrapassou o limite permitido. ${REVIEW_BEFORE_RETRY}`,
-  integration_install_receipt_unconfirmed: `O Runtime não confirmou um recibo de instalação completo. ${REVIEW_BEFORE_RETRY}`,
-  integration_install_applied_snapshot_unavailable: "O instalador confirmou a aplicação, mas não foi possível consultar o estado final do Runtime. As configurações ainda não foram verificadas; atualize o diagnóstico antes de tentar outra instalação.",
+  integration_install_busy: "Uma instalação já está em andamento. Aguarde a conclusão; não inicie outra aplicação.",
+  integration_install_not_started: "O instalador não foi iniciado. Revise um novo plano e confirme a configuração antes de tentar novamente.",
+  integration_install_timeout: `O instalador ultrapassou o prazo de execução sem confirmar a aplicação. ${RECONCILIATION_REQUIRED}`,
+  integration_install_output_unavailable: `Não foi possível obter o resultado do instalador. ${RECONCILIATION_REQUIRED}`,
+  integration_install_no_exit_code: `O instalador terminou sem um código de saída confirmado. ${RECONCILIATION_REQUIRED}`,
+  integration_install_invalid_json: `O instalador devolveu uma resposta inválida. ${RECONCILIATION_REQUIRED}`,
+  integration_install_response_too_large: `A resposta do instalador ultrapassou o limite permitido. ${RECONCILIATION_REQUIRED}`,
+  integration_install_stderr_too_large: `A saída de diagnóstico do instalador ultrapassou o limite permitido. ${RECONCILIATION_REQUIRED}`,
+  integration_install_receipt_unconfirmed: `O Runtime não confirmou um recibo de instalação completo. ${RECONCILIATION_REQUIRED}`,
+  integration_install_cleanup_unconfirmed: `Não foi possível confirmar o encerramento do processo do instalador. ${RECONCILIATION_REQUIRED}`,
+  integration_install_reconciliation_required: `Uma tentativa anterior ainda tem resultado incerto. ${RECONCILIATION_REQUIRED}`,
+  integration_install_applied_snapshot_unavailable: "O instalador confirmou a aplicação, mas não foi possível consultar o estado final do Runtime. Consulte novamente o diagnóstico para verificar as configurações; não reinstale para repetir essa consulta.",
 };
 
 /** Translate only closed native codes; never reflect stdout, stderr or user paths. */
 export function installFailureMessage(error: unknown): string {
-  const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+  const code = nativeCode(error);
   if (code.length <= 100 && Object.prototype.hasOwnProperty.call(MESSAGES, code)) return MESSAGES[code];
   if (code.length <= 100) {
     const match = /^integration_install_exit_code:(-?\d{1,11})$/.exec(code);
     if (match) {
       const exitCode = Number(match[1]);
       if (Number.isInteger(exitCode) && exitCode !== 0 && exitCode >= -2_147_483_648 && exitCode <= 2_147_483_647) {
-        return `O instalador encerrou com código ${exitCode}. ${REVIEW_BEFORE_RETRY}`;
+        return `O instalador encerrou com código ${exitCode}. ${RECONCILIATION_REQUIRED}`;
       }
     }
   }
-  return `O Runtime não confirmou a instalação completa. ${REVIEW_BEFORE_RETRY}`;
+  return "O Runtime não confirmou a instalação completa. Não repita a aplicação até esclarecer o resultado. Pode haver alterações parciais; consultar o diagnóstico ou reiniciar o app não confirma a conclusão.";
+}
+
+function nativeCode(error: unknown): string {
+  const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+  return typeof code === "string" && code.length <= 100 ? code : "";
 }

--- a/apps/desktop/src/project_usage.css
+++ b/apps/desktop/src/project_usage.css
@@ -1,0 +1,17 @@
+.token-projects { margin: 0 0 20px; padding: 22px 24px; min-width: 0; }
+.token-projects-heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 18px; }
+.token-projects-heading > div { min-width: 0; }
+.token-projects h2 { margin: 6px 0 8px; font-size: 19px; letter-spacing: -.03em; }
+.token-projects p { font-size: 13px; line-height: 1.6; color: var(--muted, #667085); overflow-wrap: anywhere; }
+.token-projects-controls { display: flex; gap: 12px; align-items: flex-end; margin: 18px 0 8px; }
+.token-projects-controls label { flex: 1; min-width: 0; display: grid; gap: 8px; font-size: 13px; }
+.token-projects-controls select { width: 100%; max-width: 100%; min-width: 0; border: 1px solid var(--line, #dce0e5); border-radius: 7px; background: #fff; color: inherit; padding: 10px 12px; font: inherit; text-overflow: ellipsis; }
+.token-projects button { flex-shrink: 0; }
+.token-projects .token-projects-note { font-size: 12px; }
+.token-projects .token-projects-notice { color: #795019; padding: 10px 12px; background: #fffaf1; border-radius: 6px; }
+.token-projects details { margin-top: 12px; font-size: 12px; color: var(--muted, #667085); }
+.token-projects summary { cursor: pointer; }
+.token-projects ul { padding-left: 18px; }
+.token-projects code { display: block; overflow-wrap: anywhere; margin-top: 4px; }
+.token-projects li { margin: 12px 0; }
+@media (max-width: 800px) { .token-projects-heading, .token-projects-controls { flex-direction: column; align-items: stretch; } .token-projects { padding: 18px; } .token-projects button { align-self: flex-start; max-width: 100%; white-space: normal; } }

--- a/apps/desktop/src/project_usage.test.ts
+++ b/apps/desktop/src/project_usage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseUsageProjects, projectDiscoveryError } from "./project_usage";
+
+const entry = { id: `project-${"a".repeat(64)}`, name: "Aulas", path: "/tmp/Aulas", evidenceType: "context", lastModifiedEpoch: 1788180000 };
+const fixture = () => ({ schema: "simplicio.desktop-project-usage/v1", projects: [entry], candidateCount: 1,
+  roots: [{ name: "Projetos", path: "/tmp/Projetos" }], partial: false, reasons: [], directoriesVisited: 3,
+  scope: { kind: "conventional_roots_and_configured_repo", maxDepth: 5, maxDirectories: 4000, maxResults: 64, deadlineMs: 2000 } });
+
+describe("automatic project discovery projection", () => {
+  it("accepts bounded candidate metadata without treating it as verified token consumption", () => {
+    const parsed = parseUsageProjects({ ...fixture(), secret: "not-forwarded", projects: [{ ...entry, prompt: "not-forwarded" }] });
+    expect(parsed.projects[0].evidenceType).toBe("context");
+    expect(JSON.stringify(parsed)).not.toContain("not-forwarded");
+  });
+
+  it("preserves partial coverage instead of calling a bounded scan complete", () => {
+    const parsed = parseUsageProjects({ ...fixture(), partial: true, reasons: ["deadline_reached"], candidateCount: 5 });
+    expect(parsed.partial).toBe(true);
+    expect(parsed.candidateCount).toBe(5);
+  });
+
+  it("keeps an unavailable timestamp unknown", () => {
+    expect(parseUsageProjects({ ...fixture(), projects: [{ ...entry, lastModifiedEpoch: null }] }).projects[0].lastModifiedEpoch).toBeNull();
+  });
+
+  it("retains successful roots while qualifying an isolated directory timeout", () => {
+    const parsed = parseUsageProjects({ ...fixture(), partial: true, reasons: ["root_timeout"], unavailableRoots: ["Desktop"] });
+    expect(parsed.projects).toHaveLength(1);
+    expect(parsed.unavailableRoots).toEqual(["Desktop"]);
+    expect(parsed.partial).toBe(true);
+  });
+
+  it("accepts the same normalized local Windows paths and project IDs as the native picker", () => {
+    const path = "C:\\Users\\person\\Projects\\Aulas";
+    const parsed = parseUsageProjects({ ...fixture(), projects: [{ ...entry, path }],
+      roots: [{ name: "Projects", path: "C:\\Users\\person\\Projects" }] });
+    expect(parsed.projects[0].path).toBe(path);
+    expect(parsed.projects[0].id).toMatch(/^project-[a-f0-9]{64}$/);
+  });
+
+  it.each([
+    { schema: "unknown" }, { projects: [entry, entry] }, { projects: Array.from({ length: 65 }, () => entry) },
+    { projects: [{ ...entry, path: "../private" }] }, { projects: [{ ...entry, evidenceType: "billed" }] },
+    { projects: [{ ...entry, lastModifiedEpoch: -1 }] }, { candidateCount: 0 }, { candidateCount: 4001 },
+    { directoriesVisited: 4001 }, { partial: "no" }, { reasons: ["private-token: secret"] },
+    { roots: [{ name: "x", path: "//remote/share" }] },
+    { projects: [{ ...entry, id: `sha256:${"a".repeat(64)}` }] },
+    { projects: [{ ...entry, path: "\\\\?\\C:\\Users\\person\\Projects\\Aulas" }] },
+    { roots: [{ name: "Projects", path: "\\\\?\\C:\\Users\\person\\Projects" }] },
+    { unavailableRoots: ["Desktop"], partial: false },
+    { unavailableRoots: ["Desktop", "Desktop"], partial: true },
+    { unavailableRoots: ["private-token: secret"], partial: true },
+    { unavailableRoots: "Desktop", partial: true },
+  ])("rejects malformed discovery %j", (patch) => {
+    expect(() => parseUsageProjects({ ...fixture(), ...patch })).toThrow();
+  });
+
+  it("does not echo native diagnostics", () => {
+    expect(projectDiscoveryError("secret=private")).not.toContain("private");
+    expect(projectDiscoveryError("preview_no_runtime")).toContain("app desktop");
+    expect(projectDiscoveryError("desktop_access_unverified")).toContain("não confirmou");
+  });
+});

--- a/apps/desktop/src/project_usage.ts
+++ b/apps/desktop/src/project_usage.ts
@@ -1,0 +1,70 @@
+import { parseLocalProject, type LocalProject } from "./workbench";
+
+export interface UsageProject extends LocalProject {
+  evidenceType: "context" | "usage" | "both";
+  lastModifiedEpoch: number | null;
+}
+export interface UsageProjects {
+  schema: "simplicio.desktop-project-usage/v1";
+  projects: UsageProject[];
+  candidateCount: number;
+  roots: Array<{ name: string; path: string }>;
+  partial: boolean;
+  reasons: string[];
+  directoriesVisited: number;
+  unavailableRoots?: string[];
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("project_discovery_invalid");
+  return value as Record<string, unknown>;
+}
+function count(value: unknown, limit = Number.MAX_SAFE_INTEGER): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0 || value > limit) throw new Error("project_discovery_invalid");
+  return value;
+}
+
+export function parseUsageProjects(value: unknown): UsageProjects {
+  const raw = object(value);
+  const scope = object(raw.scope);
+  if (raw.schema !== "simplicio.desktop-project-usage/v1" || scope.kind !== "conventional_roots_and_configured_repo"
+    || !Array.isArray(raw.projects) || raw.projects.length > 64 || !Array.isArray(raw.roots) || raw.roots.length > 4
+    || typeof raw.partial !== "boolean" || !Array.isArray(raw.reasons) || raw.reasons.length > 32) throw new Error("project_discovery_invalid");
+  const seen = new Set<string>();
+  const projects = raw.projects.map((item: unknown): UsageProject => {
+    const entry = object(item);
+    const project = parseLocalProject(entry);
+    if (seen.has(project.id) || seen.has(project.path) || !["context", "usage", "both"].includes(String(entry.evidenceType))) throw new Error("project_discovery_invalid");
+    seen.add(project.id); seen.add(project.path);
+    return { ...project, evidenceType: entry.evidenceType as UsageProject["evidenceType"], lastModifiedEpoch: entry.lastModifiedEpoch == null ? null : count(entry.lastModifiedEpoch) };
+  });
+  const roots = raw.roots.map((item: unknown) => {
+    const entry = object(item);
+    if (typeof entry.name !== "string" || !entry.name.trim() || entry.name.length > 256
+      || typeof entry.path !== "string" || entry.path.length > 4096 || /[\u0000-\u001f]/.test(entry.path)
+      || !/^(?:\/(?!\/)|[a-zA-Z]:[\\/])/.test(entry.path)) throw new Error("project_discovery_invalid");
+    return { name: entry.name, path: entry.path };
+  });
+  const candidateCount = count(raw.candidateCount, 4000);
+  if (candidateCount < projects.length || (!raw.partial && candidateCount !== projects.length)) throw new Error("project_discovery_invalid");
+  const reasons = raw.reasons.map((reason: unknown) => {
+    if (typeof reason !== "string" || !/^[a-z_]{1,80}$/.test(reason)) throw new Error("project_discovery_invalid");
+    return reason;
+  });
+  const missing = raw.unavailableRoots ?? [];
+  if (!Array.isArray(missing) || missing.length > 4
+    || missing.some((name) => typeof name !== "string" || !["Projetos", "Projects", "Desktop", "Configured repository"].includes(name))
+    || new Set(missing).size !== missing.length) throw new Error("project_discovery_invalid");
+  if (missing.length && !raw.partial) throw new Error("project_discovery_invalid");
+  return { schema: "simplicio.desktop-project-usage/v1", projects, candidateCount, roots,
+    partial: raw.partial, reasons, directoriesVisited: count(raw.directoriesVisited, 4000), unavailableRoots: missing };
+}
+
+export function projectDiscoveryError(cause: unknown): string {
+  const code = cause instanceof Error ? cause.message : String(cause);
+  if (code === "preview_no_runtime") return "A descoberta automática funciona no app desktop com o Runtime local.";
+  if (code === "project_discovery_timeout") return "A descoberta demorou para responder. Você pode informar a pasta manualmente; a consulta pendente não será duplicada.";
+  if (code === "desktop_access_not_active") return "Verifique o acesso da conta antes de descobrir as pastas.";
+  if (code === "desktop_access_unverified") return "O Runtime não confirmou o acesso da conta nesta consulta. Verifique a conta e tente novamente; nenhuma assinatura foi considerada inativa.";
+  return "Não foi possível descobrir as pastas automaticamente. Você ainda pode escolher uma pasta abaixo.";
+}

--- a/apps/desktop/src/reference_screens.ts
+++ b/apps/desktop/src/reference_screens.ts
@@ -1,0 +1,36 @@
+/** Navigation coverage for the supplied Orca references; availability is owned by each real contract. */
+export const REFERENCE_SCREENS = [
+  { id: "provider-accounts", label: "Contas de IA", group: "CAPACIDADES", description: "Provedores, modelos e autenticação gerenciada pelos seus agentes." },
+  { id: "orchestration", label: "Orquestração", group: "CAPACIDADES", description: "Execução governada, agentes e evidências do Simplicio Loop." },
+  { id: "computer-use", label: "Uso do computador", group: "CAPACIDADES", description: "Automação de aplicativos, ferramentas e permissões do sistema." },
+  { id: "voice", label: "Voz", group: "CAPACIDADES", description: "Entrada de áudio, transcrição e modelos de voz." },
+  { id: "general-settings", label: "Geral", group: "CONFIGURAÇÃO", description: "Preferências do aplicativo e ambiente de execução." },
+  { id: "integrations", label: "Integrações de serviços", group: "CONFIGURAÇÃO", description: "GitHub, GitLab, Linear e Jira, separados das conexões MCP." },
+  { id: "mobile", label: "Simplicio Mobile", group: "CONFIGURAÇÃO", description: "Dispositivos e pareamento com este computador." },
+  { id: "artifacts", label: "Artefatos", group: "FLUXOS", description: "Relatórios, diagnósticos e arquivos produzidos pelo Runtime." },
+  { id: "share-skills", label: "Compartilhar skills", group: "FLUXOS", description: "Skills disponíveis e seus limites de instalação e compartilhamento." },
+  { id: "git", label: "Git e código-fonte", group: "FLUXOS", description: "Projetos locais, repositórios e revisão de alterações." },
+  { id: "task-sources", label: "Fontes de tarefas", group: "FLUXOS", description: "Origem das tarefas de GitHub, GitLab, Linear e Jira." },
+  { id: "terminal", label: "Terminal", group: "FLUXOS", description: "CLI local e comandos explícitos do Simplicio." },
+  { id: "quick-commands", label: "Comandos rápidos", group: "FLUXOS", description: "Comandos documentados para consulta e diagnóstico." },
+  { id: "browser", label: "Navegador", group: "FLUXOS", description: "Abertura de links, sessão e automação de navegação." },
+  { id: "emulator", label: "Emulador mobile", group: "FLUXOS", description: "Dispositivos de desenvolvimento e ambientes de teste." },
+  { id: "floating", label: "Janela flutuante", group: "FLUXOS", description: "Espaço de trabalho e organização das janelas." },
+  { id: "input", label: "Entrada e edição", group: "INTERFACE", description: "Navegação por teclado, campos e comportamento de edição." },
+  { id: "notifications", label: "Notificações", group: "INTERFACE", description: "Avisos do aplicativo e disponibilidade de notificações nativas." },
+  { id: "hosts", label: "Hosts SSH", group: "HOSTS REMOTOS", description: "Conexões remotas explícitas e seus requisitos de segurança." },
+  { id: "servers", label: "Servidores Simplicio", group: "HOSTS REMOTOS", description: "Runtime local e disponibilidade de servidores remotos." },
+  { id: "permissions", label: "Permissões do sistema", group: "PRIVACIDADE E SEGURANÇA", description: "Microfone, câmera, tela, acessibilidade e acesso local." },
+  { id: "privacy", label: "Privacidade e telemetria", group: "PRIVACIDADE E SEGURANÇA", description: "Dados locais, redação e evidências compartilhadas." },
+  { id: "advanced", label: "Avançado", group: "AVANÇADO", description: "Compatibilidade, rede e diagnóstico do Runtime." },
+  { id: "experimental", label: "Experimental", group: "EXPERIMENTAL", description: "Recursos que dependem de contratos ainda não disponíveis." },
+  { id: "plugins", label: "Plugins", group: "EXPERIMENTAL", description: "Pacotes do Simplicio para os seus agentes e IDEs." },
+] as const;
+
+export type ReferenceSettingsView = typeof REFERENCE_SCREENS[number]["id"];
+
+export function isReferenceSettingsView(view: string): view is ReferenceSettingsView {
+  return REFERENCE_SCREENS.some((screen) => screen.id === view);
+}
+
+export const REFERENCE_LABELS = Object.fromEntries(REFERENCE_SCREENS.map((screen) => [screen.id, screen.label])) as Record<ReferenceSettingsView, string>;

--- a/apps/desktop/src/reference_settings.css
+++ b/apps/desktop/src/reference_settings.css
@@ -1,0 +1,208 @@
+.page.reference-settings-page { width: 100%; max-width: 1120px; margin: 0 auto; padding: 38px clamp(20px, 4vw, 52px) 54px; color: #202823; background: #fff; min-width: 0; }
+.reference-settings-page *, .reference-settings-page *::before, .reference-settings-page *::after { box-sizing: border-box; }
+.reference-settings-page button, .reference-settings-page input, .reference-settings-page select { font: inherit; }
+.reference-settings-page button:focus-visible, .reference-settings-page input:focus-visible, .reference-settings-page summary:focus-visible { outline: 2px solid #397454; outline-offset: 3px; }
+.reference-settings-page button:disabled, .reference-settings-page select:disabled { cursor: not-allowed; }
+.reference-settings-page .button { min-height: 36px; font-size: 12px; flex-shrink: 0; }
+.reference-settings-page .text-button { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; text-align: left; }
+.reference-settings-page .button:disabled { color: #686e6a; background: #f5f6f5; border-color: #e1e4e1; opacity: 1; }
+.reference-settings-page .workbench-select { max-width: 250px; min-width: 160px; min-height: 36px; border: 1px solid #e1e5e1; color: #686e6a; background: #fafbfa; font-size: 12px; border-radius: 8px; }
+.reference-settings-page .glyph { flex-shrink: 0; }
+.reference-settings-page p { overflow-wrap: anywhere; }
+.reference-settings-page .ref-page-heading { display: flex; gap: 20px; align-items: flex-start; justify-content: space-between; border-bottom: 1px solid #e7eae7; margin: 0 0 30px; padding-bottom: 25px; }
+.reference-settings-page .ref-page-heading > div { min-width: 0; }
+.reference-settings-page .ref-page-heading h1 { margin: 5px 0 9px; font-size: 29px; line-height: 1.2; letter-spacing: -.035em; font-weight: 650; color: #1c2520; }
+.reference-settings-page .ref-page-heading p { max-width: 640px; margin: 0; font-size: 13px; line-height: 1.65; color: #707870; }
+.reference-settings-page .ref-page-heading > button { margin-top: 20px; }
+.reference-settings-page .ref-eyebrow { font-size: 10px; font-weight: 650; letter-spacing: .13em; color: #7c837d; }
+.reference-settings-page .ref-section { margin: 27px 0; }
+.reference-settings-page .ref-section-heading { display: flex; justify-content: space-between; gap: 18px; align-items: center; margin-bottom: 12px; }
+.reference-settings-page .ref-section-heading h2 { margin: 0; font-size: 15px; line-height: 1.5; letter-spacing: -.01em; font-weight: 640; }
+.reference-settings-page .ref-section-heading p { font-size: 12px; line-height: 1.6; color: #747d75; margin: 4px 0 0; }
+.reference-settings-page .ref-slab { border: 1px solid #e3e7e3; border-radius: 13px; background: #fff; min-width: 0; }
+.reference-settings-page .ref-row { display: flex; align-items: center; gap: 14px; padding: 19px 22px; min-width: 0; }
+.reference-settings-page .ref-row + .ref-row { border-top: 1px solid #eef0ee; }
+.reference-settings-page .ref-row-copy { flex: 1; min-width: 0; }
+.reference-settings-page .ref-row-copy > strong { display: block; font-size: 13px; font-weight: 580; overflow-wrap: anywhere; line-height: 1.5; }
+.reference-settings-page .ref-row-copy > p { font-size: 12px; color: #737c74; margin: 4px 0 0; line-height: 1.6; }
+.reference-settings-page .ref-row-icon { color: #78847a; display: inline-flex; align-items: center; }
+.reference-settings-page .ref-row-control { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 9px; max-width: 48%; }
+.reference-settings-page .ref-row-control kbd { padding: 6px 9px; border: 1px solid #dce2dc; border-radius: 6px; font-size: 12px; white-space: nowrap; color: #4e5b51; background: #fafbfa; }
+.reference-settings-page .ref-unavailable-control { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
+.reference-settings-page .ref-unavailable-control small { color: #787e79; max-width: 210px; text-align: right; font-size: 10px; line-height: 1.45; }
+.reference-settings-page .ref-badge { display: inline-flex; align-items: center; justify-content: center; gap: 5px; max-width: 100%; border: 1px solid #e2e6e2; background: #f6f8f6; padding: 4px 8px; border-radius: 6px; color: #647067; font-size: 10px; line-height: 1.4; text-align: center; }
+.reference-settings-page .ref-badge-positive { color: #276144; background: #eef8f1; border-color: #cfe6d7; }
+.reference-settings-page .ref-notice { display: flex; gap: 12px; align-items: flex-start; padding: 17px 19px; background: #f5f8f5; border: 1px solid #e1e9e2; border-radius: 11px; margin: 0 0 26px; }
+.reference-settings-page .ref-notice > .glyph { color: #55705c; margin-top: 1px; }
+.reference-settings-page .ref-notice strong { font-size: 12px; line-height: 1.6; font-weight: 610; }
+.reference-settings-page .ref-notice p { font-size: 12px; line-height: 1.7; color: #6e776f; margin: 4px 0 0; }
+.reference-settings-page .ref-preview-note { display: flex; gap: 9px; padding: 11px 15px; margin: 0 0 22px; border: 1px solid #e9e3cd; border-radius: 8px; color: #756747; background: #fcfaf4; font-size: 11px; line-height: 1.6; }
+.reference-settings-page .ref-action-row, .reference-settings-page .ref-link-grid { display: flex; gap: 10px; flex-wrap: wrap; margin: 22px 0; }
+.reference-settings-page .ref-account-card { padding: 23px; margin: 20px 0; border: 1px solid #e3e7e3; border-radius: 13px; }
+.reference-settings-page .ref-account-heading { display: flex; gap: 14px; align-items: flex-start; }
+.reference-settings-page .ref-account-heading h2 { font-size: 15px; font-weight: 640; margin: 1px 0 5px; }
+.reference-settings-page .ref-account-heading p { font-size: 12px; color: #737c74; margin: 0; line-height: 1.65; }
+.reference-settings-page .ref-monogram { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 39px; width: 39px; height: 39px; border: 1px solid #e2e6e2; border-radius: 10px; background: #f7f9f7; color: #556359; font-size: 12px; font-weight: 620; letter-spacing: .025em; }
+.reference-settings-page .ref-monogram-claude-code { color: #98694d; background: #fbf4ec; border-color: #eee1d4; }
+.reference-settings-page .ref-monogram-codex { color: #324c3c; background: #f0f5f0; }
+.reference-settings-page .ref-monogram-gemini { color: #54749a; background: #f3f7fb; border-color: #e1e8f0; }
+.reference-settings-page .ref-account-card > .ref-row { padding: 24px 0 17px; }
+.reference-settings-page .ref-account-default { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px; border: 1px solid #e0e5df; border-radius: 8px; background: #fafbf9; }
+.reference-settings-page .ref-account-default strong { font-size: 12px; font-weight: 570; }
+.reference-settings-page .ref-account-default p { margin: 4px 0 0; font-size: 11px; line-height: 1.6; color: #778076; }
+.reference-settings-page .ref-account-evidence { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 10px; font-size: 11px; color: #747e75; padding-top: 14px; }
+.reference-settings-page .ref-service-stack { padding: 15px; display: grid; gap: 12px; }
+.reference-settings-page .ref-service-card { padding: 18px; border: 1px solid #e4e8e4; border-radius: 10px; background: #fcfdfc; }
+.reference-settings-page .ref-service-top { display: flex; align-items: center; gap: 12px; }
+.reference-settings-page .ref-service-top > div { flex: 1; min-width: 0; }
+.reference-settings-page .ref-service-top h3 { margin: 0 0 4px; font-size: 13px; font-weight: 620; }
+.reference-settings-page .ref-service-top p { margin: 0; font-size: 11px; line-height: 1.6; color: #778078; }
+.reference-settings-page .ref-service-bottom { display: flex; align-items: center; gap: 20px; margin-top: 16px; padding-top: 15px; border-top: 1px solid #e9ede9; }
+.reference-settings-page .ref-service-bottom > p { flex: 1; font-size: 11px; color: #748076; line-height: 1.7; margin: 0; }
+.reference-settings-page .ref-status-banner { display: flex; align-items: center; gap: 16px; padding: 24px; background: #f6f9f6; border: 1px solid #dfe8e0; border-radius: 12px; margin: 25px 0; }
+.reference-settings-page .ref-status-banner > div { flex: 1; }
+.reference-settings-page .ref-status-banner h2, .reference-settings-page .ref-status-banner h3 { margin: 0 0 5px; font-size: 15px; font-weight: 620; }
+.reference-settings-page .ref-status-banner p { font-size: 12px; color: #728074; line-height: 1.65; margin: 0; }
+.reference-settings-page .ref-status-banner-inner { margin: 14px; border-radius: 9px; }
+.reference-settings-page .ref-disabled-switch { opacity: .45; }
+.reference-settings-page .ref-disabled-segments { display: flex; border: 1px solid #e0e5e0; border-radius: 8px; padding: 3px; background: #fafbfa; }
+.reference-settings-page .ref-disabled-segments button { border: 0; background: transparent; font-size: 11px; padding: 7px 9px; color: #7f8780; }
+.reference-settings-page .ref-pairing-layout { display: grid; grid-template-columns: minmax(0, 1fr) 220px; gap: 25px; padding: 25px; }
+.reference-settings-page .ref-pairing-steps { display: grid; gap: 23px; }
+.reference-settings-page .ref-pairing-steps > div { display: flex; align-items: flex-start; gap: 13px; }
+.reference-settings-page .ref-pairing-steps > div > span, .reference-settings-page .ref-browser-steps article > span { display: flex; align-items: center; justify-content: center; width: 26px; height: 26px; flex: 0 0 26px; border-radius: 50%; background: #eef3ee; color: #5d7564; font-size: 11px; border: 1px solid #dbe5dd; }
+.reference-settings-page .ref-pairing-steps p { margin: 0; font-size: 11px; line-height: 1.7; color: #758078; }
+.reference-settings-page .ref-pairing-steps strong { display: block; color: #3f5045; font-size: 12px; margin-bottom: 4px; }
+.reference-settings-page .ref-pairing-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 12px; padding: 22px; border: 1px dashed #d7e0d7; border-radius: 13px; color: #7a877c; background: #fafcf9; }
+.reference-settings-page .ref-pairing-empty strong { font-size: 12px; line-height: 1.6; }
+.reference-settings-page .ref-pairing-empty span { font-size: 11px; }
+.reference-settings-page .ref-empty { padding: 31px 23px; text-align: center; color: #829087; }
+.reference-settings-page .ref-empty h3 { font-size: 13px; color: #506255; margin: 14px 0 6px; font-weight: 550; }
+.reference-settings-page .ref-empty p { color: #77837b; font-size: 12px; line-height: 1.7; max-width: 540px; margin: 0 auto 12px; }
+.reference-settings-page .ref-table-wrap { overflow: auto; }
+.reference-settings-page .ref-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.reference-settings-page .ref-table caption { text-align: left; padding: 17px 22px 10px; color: #78847b; font-size: 11px; }
+.reference-settings-page .ref-table th { font-weight: 570; color: #68766c; background: #fafcf9; text-align: left; padding: 12px 18px; border-bottom: 1px solid #e7ece7; }
+.reference-settings-page .ref-table td { padding: 14px 18px; border-bottom: 1px solid #edf0ec; color: #4f6054; overflow-wrap: anywhere; }
+.reference-settings-page .ref-table td .glyph { vertical-align: middle; margin-right: 8px; color: #809185; }
+.reference-settings-page .ref-command-card { padding: 21px 23px 13px; }
+.reference-settings-page .ref-command-card + .ref-command-card { border-top: 1px solid #e9ede8; }
+.reference-settings-page .ref-command-card h3 { font-size: 13px; font-weight: 570; margin: 0 0 5px; }
+.reference-settings-page .ref-command-card > p { font-size: 12px; color: #748177; line-height: 1.65; margin: 0 0 13px; }
+.reference-settings-page .ref-command-line { display: flex; gap: 13px; align-items: center; justify-content: space-between; padding: 10px 12px; border: 1px solid #e1e7e1; border-radius: 9px; background: #f7f9f6; }
+.reference-settings-page .ref-command-line code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; line-height: 1.7; color: #395642; overflow-wrap: anywhere; }
+.reference-settings-page .ref-copy-status { display: block; min-height: 18px; color: #68796e; font-size: 10px; line-height: 1.6; margin-top: 5px; }
+.reference-settings-page .ref-terminal-intro { display: flex; gap: 18px; align-items: center; padding: 24px; background: #f8faf7; border-radius: 13px 13px 0 0; border-bottom: 1px solid #e6ece4; }
+.reference-settings-page .ref-terminal-intro h3 { margin: 0 0 7px; font-size: 14px; font-weight: 580; }
+.reference-settings-page .ref-terminal-intro p { margin: 0; font-size: 12px; color: #728177; line-height: 1.7; }
+.reference-settings-page .ref-terminal-symbol { font: 25px ui-monospace, SFMono-Regular, Menlo, monospace; color: #4b6b55; }
+.reference-settings-page .ref-source-list { padding: 16px; display: grid; gap: 11px; }
+.reference-settings-page .ref-source-details { border: 1px solid #e4e9e3; border-radius: 10px; background: #fdfefd; }
+.reference-settings-page .ref-source-details summary { display: flex; align-items: center; gap: 12px; padding: 18px; cursor: pointer; list-style: none; }
+.reference-settings-page .ref-source-details summary::-webkit-details-marker { display: none; }
+.reference-settings-page .ref-source-details summary > span:nth-child(2) { flex: 1; min-width: 0; }
+.reference-settings-page .ref-source-details summary strong { font-size: 13px; font-weight: 580; display: block; }
+.reference-settings-page .ref-source-details summary small { display: block; font-size: 11px; line-height: 1.5; color: #78847a; margin-top: 5px; }
+.reference-settings-page .ref-source-details[open] summary > .glyph { transform: rotate(180deg); }
+.reference-settings-page .ref-source-body { border-top: 1px solid #e9ede7; padding: 16px 19px 20px; }
+.reference-settings-page .ref-source-body > p { margin: 0; font-size: 12px; color: #708175; line-height: 1.7; }
+.reference-settings-page .ref-source-body .ref-row { padding: 17px 0; }
+.reference-settings-page .ref-help-details { margin: 21px 0; border: 1px solid #e3e8e1; padding: 16px 19px; border-radius: 9px; background: #fbfcfa; }
+.reference-settings-page .ref-help-details summary { cursor: pointer; font-size: 12px; font-weight: 560; color: #4c6353; }
+.reference-settings-page .ref-help-details p { font-size: 12px; line-height: 1.8; color: #718076; margin: 12px 0 0; }
+.reference-settings-page .ref-help-inset { margin: 0 20px 20px; }
+.reference-settings-page .ref-help-inset .ref-unavailable-control { align-items: flex-start; margin-top: 17px; }
+.reference-settings-page .ref-help-inset .ref-unavailable-control small { text-align: left; }
+.reference-settings-page .ref-browser-steps { display: grid; gap: 0; margin: 0 21px 19px; border: 1px solid #e4eae2; border-radius: 11px; }
+.reference-settings-page .ref-browser-steps article { display: flex; gap: 15px; padding: 20px; }
+.reference-settings-page .ref-browser-steps article + article { border-top: 1px solid #e9eee6; }
+.reference-settings-page .ref-browser-steps h3 { margin: 3px 0 7px; font-size: 13px; font-weight: 580; }
+.reference-settings-page .ref-browser-steps p { font-size: 12px; line-height: 1.7; color: #738178; margin: 0 0 12px; }
+.reference-settings-page .ref-browser-steps .ref-unavailable-control { align-items: flex-start; }
+.reference-settings-page .ref-browser-steps .ref-unavailable-control small { text-align: left; }
+.reference-settings-page .ref-device-grid, .reference-settings-page .ref-feature-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 15px; padding: 18px; }
+.reference-settings-page .ref-device-card { border: 1px solid #e5eae3; border-radius: 11px; padding: 25px; color: #6c8172; text-align: center; background: #fafcf8; }
+.reference-settings-page .ref-device-card h3 { font-size: 15px; margin: 12px 0; color: #3d5847; }
+.reference-settings-page .ref-device-card p { font-size: 12px; line-height: 1.7; margin: 15px 0 20px; color: #758779; }
+.reference-settings-page .ref-device-card .ref-unavailable-control { align-items: center; }
+.reference-settings-page .ref-device-card .ref-unavailable-control small { text-align: center; }
+.reference-settings-page .ref-window-layout { display: grid; grid-template-columns: 100px minmax(0, 1fr); margin: 24px; min-height: 140px; border: 1px solid #dfe7db; border-radius: 11px; overflow: hidden; }
+.reference-settings-page .ref-window-layout > span { background: #f1f5ed; padding: 23px 13px; border-right: 1px solid #dfe7db; font-size: 11px; color: #778871; }
+.reference-settings-page .ref-window-layout > div { padding: 25px; color: #4e694f; }
+.reference-settings-page .ref-window-layout strong { font-size: 13px; }
+.reference-settings-page .ref-window-layout p { margin: 9px 0 0; font-size: 12px; line-height: 1.7; color: #7b8a76; }
+.reference-settings-page .ref-permission-list .ref-row-control { gap: 13px; }
+.reference-settings-page .ref-feature-grid { padding: 0; margin: 27px 0; }
+.reference-settings-page .ref-feature-card { padding: 24px; border: 1px solid #e2e8df; border-radius: 12px; background: #fcfdfb; color: #627b60; }
+.reference-settings-page .ref-feature-card h2 { color: #3e583e; font-size: 15px; margin: 17px 0 7px; font-weight: 600; }
+.reference-settings-page .ref-feature-card p { font-size: 12px; line-height: 1.7; color: #768771; margin: 0 0 17px; }
+.reference-settings-page .ref-plugin-toolbar { display: flex; flex-wrap: wrap; gap: 13px; align-items: center; justify-content: space-between; padding: 18px; border-bottom: 1px solid #e8ede4; }
+.reference-settings-page .ref-plugin-toolbar .segmented-control { flex-shrink: 0; }
+.reference-settings-page .ref-plugin-toolbar .segmented-control button { font-size: 11px; }
+.reference-settings-page .ref-search { display: flex; gap: 8px; align-items: center; padding: 8px 10px; border: 1px solid #dfe6db; border-radius: 8px; color: #7d8c76; flex: 1; min-width: 200px; }
+.reference-settings-page .ref-search input { width: 100%; min-width: 0; border: 0; outline: none; background: transparent; font-size: 12px; color: #435d40; }
+.reference-settings-page .ref-search:focus-within { outline: 2px solid #397454; outline-offset: 2px; }
+.reference-settings-page .ref-search input:focus-visible { outline: none; }
+.reference-settings-page .ref-plugin-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 13px; padding: 18px; }
+.reference-settings-page .ref-plugin-card { display: flex; flex-direction: column; padding: 20px; border: 1px solid #e0e7dc; border-radius: 11px; background: #fafcf8; }
+.reference-settings-page .ref-plugin-title { display: flex; align-items: center; gap: 10px; }
+.reference-settings-page .ref-plugin-title > div { min-width: 0; }
+.reference-settings-page .ref-plugin-title h3 { margin: 0 0 5px; font-size: 13px; font-weight: 630; overflow-wrap: anywhere; }
+.reference-settings-page .ref-plugin-title div > span { font-size: 10px; color: #829079; }
+.reference-settings-page .ref-plugin-card > p { font-size: 12px; line-height: 1.7; color: #73856c; margin: 17px 0 15px; }
+.reference-settings-page .ref-plugin-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 19px; }
+.reference-settings-page .ref-plugin-card > .ref-unavailable-control { margin-top: auto; }
+.reference-settings-page .ref-evidence-footer { display: flex; align-items: flex-start; gap: 9px; border-top: 1px solid #ebeee7; padding-top: 19px; margin-top: 36px; color: #82907a; }
+.reference-settings-page .ref-evidence-footer p { font-size: 10px; line-height: 1.7; margin: 0; }
+@media (max-width: 820px) {
+  .page.reference-settings-page { padding: 27px 22px 40px; }
+  .reference-settings-page .ref-page-heading { flex-direction: column; gap: 10px; }
+  .reference-settings-page .ref-page-heading > button { margin-top: 0; }
+  .reference-settings-page .ref-pairing-layout { grid-template-columns: minmax(0, 1fr); }
+  .reference-settings-page .ref-pairing-empty { min-height: 160px; }
+  .reference-settings-page .ref-permission-list .ref-row { flex-wrap: wrap; }
+  .reference-settings-page .ref-permission-list .ref-row-control { max-width: 100%; width: 100%; justify-content: flex-start; padding-left: 34px; }
+  .reference-settings-page .ref-permission-list .ref-unavailable-control { align-items: flex-start; }
+  .reference-settings-page .ref-permission-list .ref-unavailable-control small { text-align: left; }
+}
+@media (max-width: 580px) {
+  .page.reference-settings-page { padding: 23px 16px 35px; }
+  .reference-settings-page .ref-page-heading h1 { font-size: 25px; }
+  .reference-settings-page .ref-section-heading { align-items: flex-start; flex-direction: column; }
+  .reference-settings-page .ref-row { flex-wrap: wrap; padding: 17px; gap: 10px; }
+  .reference-settings-page .ref-row-control { width: 100%; max-width: 100%; justify-content: flex-start; }
+  .reference-settings-page .ref-row-copy { min-width: 180px; }
+  .reference-settings-page .ref-unavailable-control { align-items: flex-start; }
+  .reference-settings-page .ref-unavailable-control small { max-width: 100%; text-align: left; }
+  .reference-settings-page .ref-account-card { padding: 17px; }
+  .reference-settings-page .ref-account-default { flex-wrap: wrap; }
+  .reference-settings-page .ref-service-stack { padding: 11px; }
+  .reference-settings-page .ref-service-card { padding: 14px; }
+  .reference-settings-page .ref-service-top { flex-wrap: wrap; }
+  .reference-settings-page .ref-service-top > .ref-badge { margin-left: 50px; }
+  .reference-settings-page .ref-service-bottom { align-items: flex-start; flex-direction: column; gap: 11px; }
+  .reference-settings-page .ref-status-banner { padding: 18px; flex-wrap: wrap; }
+  .reference-settings-page .ref-status-banner > div { min-width: 190px; }
+  .reference-settings-page .ref-status-banner > .ref-badge { margin-left: 40px; }
+  .reference-settings-page .ref-pairing-layout { padding: 20px; }
+  .reference-settings-page .ref-command-card { padding: 18px 15px 11px; }
+  .reference-settings-page .ref-command-line { align-items: flex-start; flex-direction: column; gap: 8px; }
+  .reference-settings-page .ref-source-list { padding: 10px; }
+  .reference-settings-page .ref-source-details summary { flex-wrap: wrap; padding: 15px; }
+  .reference-settings-page .ref-source-details summary > .ref-badge { margin-left: 50px; }
+  .reference-settings-page .ref-source-body { padding: 14px; }
+  .reference-settings-page .ref-browser-steps { margin: 0 13px 15px; }
+  .reference-settings-page .ref-browser-steps article { gap: 10px; padding: 16px 13px; }
+  .reference-settings-page .ref-browser-steps .button { white-space: normal; }
+  .reference-settings-page .ref-device-grid, .reference-settings-page .ref-feature-grid, .reference-settings-page .ref-plugin-grid { grid-template-columns: minmax(0, 1fr); }
+  .reference-settings-page .ref-window-layout { margin: 18px; grid-template-columns: 65px minmax(0, 1fr); }
+  .reference-settings-page .ref-window-layout > span { padding: 20px 7px; font-size: 10px; }
+  .reference-settings-page .ref-window-layout > div { padding: 20px 17px; }
+  .reference-settings-page .ref-plugin-toolbar { padding: 13px; }
+  .reference-settings-page .ref-plugin-toolbar .segmented-control { flex-shrink: 1; max-width: 100%; }
+  .reference-settings-page .ref-search { min-width: 0; flex-basis: 100%; }
+  .reference-settings-page .ref-permission-list .ref-row-control { padding-left: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .reference-settings-page *, .reference-settings-page *::before, .reference-settings-page *::after { animation: none !important; transition: none !important; }
+}

--- a/apps/desktop/src/runtime_failures.test.ts
+++ b/apps/desktop/src/runtime_failures.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { runtimeFailureMessage } from "./runtime_failures";
+
+describe("safe Runtime failure messages", () => {
+  it("distinguishes the native query deadline from the Desktop waiting deadline", () => {
+    expect(runtimeFailureMessage("runtime_query_timeout")).toContain("20 segundos");
+    expect(runtimeFailureMessage(new Error("desktop_snapshot_timeout"))).toContain("ainda pode estar concluindo");
+    expect(runtimeFailureMessage("runtime_query_timeout")).not.toContain("ainda pode estar concluindo");
+  });
+
+  it("does not turn OAuth timeout or a later command failure into an account conclusion", () => {
+    expect(runtimeFailureMessage("runtime_oauth_timeout", "login")).toContain("3 minutos");
+    expect(runtimeFailureMessage("runtime_not_started", "login")).toContain("Não foi possível iniciar um comando");
+    for (const code of ["runtime_oauth_timeout", "runtime_query_timeout", "runtime_not_started", "runtime_stdout_limit", "unknown"]) {
+      const message = runtimeFailureMessage(code, "login");
+      expect(message).toContain("resultado final do login não foi confirmado");
+      expect(message).toContain("Consulte o estado da conta antes de iniciar outro login");
+      expect(message).not.toContain("login não foi iniciado");
+      expect(message).not.toContain("assinatura inativa");
+      expect(message).not.toContain("tentar novamente");
+    }
+    const message = runtimeFailureMessage("runtime_not_started", "logout");
+    expect(message).toContain("saída da conta não foi confirmada");
+    expect(message).not.toContain("logout não foi iniciado");
+  });
+
+  it("distinguishes bounded output failures and uncertain cleanup without exposing diagnostics", () => {
+    expect(runtimeFailureMessage("runtime_stdout_limit")).toContain("resposta do Runtime ultrapassou o limite");
+    expect(runtimeFailureMessage("runtime_stderr_limit")).toContain("saída de diagnóstico do Runtime ultrapassou o limite");
+    expect(runtimeFailureMessage("runtime_output_unavailable")).toContain("Não foi possível obter a saída");
+    expect(runtimeFailureMessage("runtime_process_cleanup_unconfirmed")).toContain("encerramento de um processo");
+    expect(runtimeFailureMessage("runtime_process_cleanup_unconfirmed")).toContain("Novos comandos do Runtime estão bloqueados");
+    expect(runtimeFailureMessage("runtime_install_timeout")).toContain("Não repita a instalação sem esclarecer o resultado");
+    expect(runtimeFailureMessage("runtime_install_timeout")).toContain("5 minutos");
+  });
+
+  it("does not reflect unknown strings, object fields, oversized output or secrets", () => {
+    for (const error of ["secret-do-not-reflect /private/path", new Error("secret-do-not-reflect"),
+      "runtime_query_timeout: secret-do-not-reflect", "__proto__", "constructor", "x".repeat(100_000),
+      { message: "runtime_not_started" }, null]) {
+      const message = runtimeFailureMessage(error);
+      expect(message).toContain("Não foi possível confirmar o resultado");
+      expect(message).not.toContain("secret-do-not-reflect");
+      expect(message).not.toContain("/private/path");
+      expect(message.length).toBeLessThan(500);
+    }
+  });
+});

--- a/apps/desktop/src/runtime_failures.ts
+++ b/apps/desktop/src/runtime_failures.ts
@@ -1,0 +1,29 @@
+export type RuntimeOperation = "query" | "login" | "logout";
+
+const REASONS: Readonly<Record<string, string>> = {
+  runtime_not_started: "Não foi possível iniciar um comando do Simplicio Runtime.",
+  runtime_query_timeout: "Uma etapa do Runtime ultrapassou o prazo de 20 segundos.",
+  runtime_oauth_timeout: "O login ultrapassou o prazo de 3 minutos sem confirmação.",
+  runtime_install_timeout: "A instalação ultrapassou o prazo de 5 minutos sem confirmação. Não repita a instalação sem esclarecer o resultado.",
+  runtime_stdout_limit: "A resposta do Runtime ultrapassou o limite permitido.",
+  runtime_stderr_limit: "A saída de diagnóstico do Runtime ultrapassou o limite permitido.",
+  runtime_output_unavailable: "Não foi possível obter a saída de um comando do Runtime.",
+  runtime_process_cleanup_unconfirmed: "Não foi possível confirmar o encerramento de um processo do Runtime. Novos comandos do Runtime estão bloqueados enquanto esse processo permanecer pendente.",
+  desktop_snapshot_timeout: "A consulta do Desktop não respondeu no prazo. O Runtime ainda pode estar concluindo a consulta.",
+};
+
+const NEXT_STEPS: Readonly<Record<RuntimeOperation, string>> = {
+  query: "Verifique o Runtime e consulte novamente o estado; nenhum resultado atual foi confirmado.",
+  login: "O resultado final do login não foi confirmado. Consulte o estado da conta antes de iniciar outro login.",
+  logout: "A saída da conta não foi confirmada. Consulte o estado da conta antes de repetir a ação.",
+};
+
+/** Keep native output out of UI errors, including when its command phase is unknown. */
+export function runtimeFailureMessage(error: unknown, operation: RuntimeOperation = "query"): string {
+  const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+  const reason = typeof code === "string" && code.length <= 100 && Object.prototype.hasOwnProperty.call(REASONS, code)
+    ? REASONS[code] : "Não foi possível confirmar o resultado do Simplicio Runtime.";
+  // Login/logout run an action followed by a query. A spawn failure may belong to
+  // that later query, so it never proves that the account action did not start.
+  return `${reason} ${NEXT_STEPS[operation]}`;
+}

--- a/apps/desktop/src/screens/AccessScreens.tsx
+++ b/apps/desktop/src/screens/AccessScreens.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AccessState } from "../contracts";
 import { Brand, Glyph } from "../components/Brand";
 
@@ -17,6 +17,8 @@ export function LoadingScreen() {
 export function SignInScreen({ busy, error, onLogin, initialStep = "welcome" }:
   { busy: boolean; error: string | null; onLogin: () => void; initialStep?: "welcome" | "login" }) {
   const [step, setStep] = useState(initialStep);
+  const primaryAction = useRef<HTMLButtonElement>(null);
+  useEffect(() => { primaryAction.current?.focus(); }, [step]);
   const platform = typeof navigator === "undefined" ? "Desktop"
     : /Mac/.test(navigator.platform) ? "Mac" : /Win/.test(navigator.platform) ? "Windows" : "Linux";
   return <div className="access-layout entry-flow">
@@ -25,13 +27,13 @@ export function SignInScreen({ busy, error, onLogin, initialStep = "welcome" }:
       <img className="entry-mark" src="/icon.png" width="88" height="88" alt="" />
       <h1 id="welcome-title">Simplicio <em>para {platform}</em></h1>
       <p>Seu Runtime, pronto para trabalhar com você.</p>
-      <button className="button entry-primary" type="button" onClick={() => setStep("login")}>Começar<Glyph name="arrow" size={18} /></button>
+      <button ref={primaryAction} className="button entry-primary" type="button" onClick={() => setStep("login")}>Começar<Glyph name="arrow" size={18} /></button>
       <span className="entry-caption">Projetos, agentes e economia. No seu computador.</span>
     </section> : <section className="entry-login access-panel" aria-labelledby="login-title">
       <h1 id="login-title">Entre no Simplicio</h1>
       <div className="entry-login-card">
         <p className="entry-account-copy">Conecte sua conta SimpleTI para continuar.</p>
-        <button className="button entry-google" type="button" onClick={onLogin} disabled={busy}>
+        <button ref={primaryAction} className="button entry-google" type="button" onClick={onLogin} disabled={busy} aria-busy={busy}>
           <span className="google-mark" aria-hidden="true">G</span>{busy ? "Aguardando navegador…" : "Continuar com Google"}
         </button>
         {busy && <p className="entry-wait" role="status"><span className="setup-spinner" aria-hidden="true" />Conclua o login no navegador. O app continua quando o Runtime confirmar sua sessão.</p>}
@@ -73,6 +75,8 @@ export function AccessGate({
   busy,
   error,
   onRefresh,
+  onLogin,
+  loginBusy = false,
   onSubscribe,
   onLogout,
   logoutBusy = false,
@@ -82,12 +86,15 @@ export function AccessGate({
   busy: boolean;
   error: string | null;
   onRefresh: () => void;
+  onLogin?: () => void;
+  loginBusy?: boolean;
   onSubscribe?: () => void;
   onLogout?: () => void;
   logoutBusy?: boolean;
 }) {
   const content = accessContent[state];
   const [showDiagnostic, setShowDiagnostic] = useState(false);
+  const actionBusy = busy || loginBusy || logoutBusy;
   return (
     <div className="locked-layout">
       <div className="locked-glow" aria-hidden="true" />
@@ -109,13 +116,18 @@ export function AccessGate({
             className="button button-primary"
             type="button"
             onClick={state === "inactive" ? onSubscribe : onRefresh}
-            disabled={busy}
+            disabled={actionBusy}
           >
-            {busy ? "Aguarde…" : content.primary}<Glyph name="arrow" />
+            {actionBusy ? "Aguarde…" : content.primary}<Glyph name="arrow" />
           </button>
           {state === "inactive" && (
-            <button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}>
+            <button className="button button-secondary" type="button" onClick={onRefresh} disabled={actionBusy}>
               {content.secondary}
+            </button>
+          )}
+          {state === "unknown" && onLogin && (
+            <button className="button button-secondary" type="button" onClick={onLogin} disabled={actionBusy} aria-busy={loginBusy}>
+              {loginBusy ? "Aguardando navegador…" : "Entrar ou reconectar"}
             </button>
           )}
           {state === "unknown" && (
@@ -124,11 +136,12 @@ export function AccessGate({
             </button>
           )}
           {onLogout && (
-            <button className="button button-secondary" type="button" onClick={onLogout} disabled={busy || logoutBusy} aria-busy={logoutBusy}>
+            <button className="button button-secondary" type="button" onClick={onLogout} disabled={actionBusy} aria-busy={logoutBusy}>
               {logoutBusy ? "Saindo…" : "Sair da conta"}
             </button>
           )}
         </div>
+        {state === "unknown" && loginBusy && <p className="entry-wait" role="status">Conclua o login no navegador. O acesso permanece desconhecido até o Runtime confirmar sua sessão.</p>}
         {error && <p className="action-error" role="alert">{error}</p>}
         {showDiagnostic && state === "unknown" && (
           <div className="access-diagnostic" aria-live="polite">

--- a/apps/desktop/src/screens/ProductScreens.tsx
+++ b/apps/desktop/src/screens/ProductScreens.tsx
@@ -15,6 +15,7 @@ import { createTokenReport } from "../token_report";
 import { createOmniSearchProjection } from "../omnisearch_projection";
 import { createLibraryProjection } from "../library_projection";
 import { createSuggestionInboxProjection } from "../suggestion_inbox";
+import { VIEW_LABELS } from "../workbench";
 
 type ProductView = Extract<View, "today" | "chats" | "teams" | "automations" | "apps">;
 
@@ -32,7 +33,7 @@ function SurfaceHeading({ view, snapshot }: { view: ProductView; snapshot: Deskt
     <section className="page-heading product-heading">
       <div>
         <span className="eyebrow">{copy.eyebrow}</span>
-        <h1>{copy.title}</h1>
+        <h1>{VIEW_LABELS[view]}</h1>
         <p>{copy.description}</p>
       </div>
       <span className={`projection-badge ${snapshot.source === "preview" ? "preview" : "live"}`}>

--- a/apps/desktop/src/screens/ProvidersScreen.tsx
+++ b/apps/desktop/src/screens/ProvidersScreen.tsx
@@ -4,6 +4,7 @@ import { Glyph } from "../components/Brand";
 import { providerRegistry } from "../provider_registry";
 import { IntegrationSetup } from "../components/IntegrationSetup";
 import { searchMatches } from "../workbench";
+import type { InstallFailureRecovery } from "../install_failures";
 
 const stateCopy: Record<ProviderState, string> = {
   connected: "Conectado", registered: "Registrado", detected: "Detectado",
@@ -34,8 +35,8 @@ function ProviderRow({ provider }: { provider: ProviderConnection }) {
   </article>;
 }
 
-export function ProvidersScreen({ snapshot, busy, repairing, onRefresh, onRepair, inventoryOnly = false }:
-  { snapshot: DesktopSnapshot; busy: boolean; repairing: boolean; onRefresh: () => void; onRepair: (digest: string) => Promise<boolean>; inventoryOnly?: boolean }) {
+export function ProvidersScreen({ snapshot, busy, repairing, onRefresh, onRepair, inventoryOnly = false, applicationRecovery, onDiagnostics }:
+  { snapshot: DesktopSnapshot; busy: boolean; repairing: boolean; onRefresh: () => void; onRepair: (digest: string) => Promise<boolean>; inventoryOnly?: boolean; applicationRecovery?: InstallFailureRecovery; onDiagnostics?: () => void }) {
   const [filter, setFilter] = useState<"all" | "installed" | "available" | "attention">("all");
   const [query, setQuery] = useState("");
   const [kind, setKind] = useState<"all" | "agent" | "editor">("all");
@@ -59,7 +60,7 @@ export function ProvidersScreen({ snapshot, busy, repairing, onRefresh, onRepair
       <button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}><Glyph name="refresh" size={17} />{busy && !repairing ? "Verificando…" : "Verificar"}</button>
     </section>
 
-    {!inventoryOnly && <IntegrationSetup busy={busy} onApply={onRepair} />}
+    {!inventoryOnly && <IntegrationSetup busy={busy} onApply={onRepair} recovery={applicationRecovery} onDiagnostics={onDiagnostics} />}
 
     <section className="connection-overview" aria-label="Resumo das conexões">
       <div><Glyph name="monitor" size={18} /><span><strong>{installed}</strong> aplicativos detectados</span></div>

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.test.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.test.tsx
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createDemoSnapshot } from "../demo";
+import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
+import type { DesktopSnapshot } from "../contracts";
+import { ReferenceSettingsScreen, createReferenceSettingsEvidence, copyReferenceCommand, REFERENCE_QUICK_COMMANDS } from "./ReferenceSettingsScreen";
+
+function snapshot(runtime = false): DesktopSnapshot {
+  const value = structuredClone(createDemoSnapshot("active"));
+  if (runtime) {
+    value.source = "runtime";
+    if (value.botCenter) value.botCenter.source = "runtime";
+  }
+  return value;
+}
+
+function markup(view: ReferenceSettingsView, value = snapshot()) {
+  return renderToStaticMarkup(<ReferenceSettingsScreen view={view} snapshot={value} onNavigate={() => {}} onRefresh={() => {}} />);
+}
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe("reference settings route coverage", () => {
+  it.each(REFERENCE_SCREENS)("renders the distinct $id surface with its exact navigation heading", (screen) => {
+    const html = markup(screen.id);
+    expect(html).toContain("<h1>" + screen.label + "</h1>");
+    expect(html).toContain('data-settings-view="' + screen.id + '"');
+    expect(html).toContain("<h2>");
+    expect(html).toContain("Prévia visual.");
+    expect(html).toContain('aria-label="Atualizar consulta do Runtime"');
+    expect(html).toContain("Nenhum estado da prévia é usado como comprovação");
+    expect(html).not.toContain("voce@example.com");
+    expect(html).not.toContain("window.open");
+    expect(html).not.toMatch(/<input[^>]+type="(?:password|email|url)"/);
+    expect(html).not.toContain("<form");
+  });
+
+  it.each(REFERENCE_SCREENS)("renders $id from a real-shaped snapshot without acquiring more privileges", (screen) => {
+    const html = markup(screen.id, snapshot(true));
+    expect(html).toContain("<h1>" + screen.label + "</h1>");
+    expect(html).not.toContain("Prévia visual.");
+    expect(html).toContain("Abrir esta tela não renova a consulta nem autoriza ações.");
+    expect(html).not.toContain("voce@example.com");
+    expect(html).not.toContain("storage.setItem");
+  });
+
+  it("keeps copy actions clearly distinct from execution", () => {
+    const html = markup("quick-commands");
+    for (const command of Object.values(REFERENCE_QUICK_COMMANDS)) {
+      expect(html).toContain(command.command);
+      expect(html).toContain('aria-label="Copiar ' + command.label + '"');
+    }
+    expect(html).toContain("Copiar não executa");
+    expect(html).not.toContain("Copiado");
+  });
+
+  it("does not infer an admitted parallel capacity from the displayed bot inventory", () => {
+    const html = markup("orchestration", snapshot(true));
+    expect(html).toContain("O limite de paralelismo não foi consultado nesta tela.");
+    expect(html).toContain("Limite não consultado");
+    expect(html).not.toContain("até 32 bots");
+  });
+
+  it("does not render fake pairing codes, QR images, cookies or addresses", () => {
+    const html = markup("mobile", snapshot(true));
+    expect(html).toContain("Nenhum código emitido");
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Gerar QR code<\/button>/);
+    expect(html).not.toMatch(/<img|<canvas|(?:orca|simplicio):\/\/pair|192\.168|ws:\/\//);
+    expect(markup("browser")).not.toContain('type="password"');
+  });
+
+  it("does not infer OS permissions from healthy Runtime or computer session availability", () => {
+    const value = snapshot(true);
+    if (value.botCenter) value.botCenter.computer.available = true;
+    const html = markup("permissions", value);
+    expect(html).toContain("Não consultada");
+    expect(html).not.toMatch(/>Concedida<|>Negada<|GRANTED|DENIED/);
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Solicitar microfone<\/button>/);
+    expect(markup("computer-use", value)).toContain("Permissões do sistema são verificadas separadamente.");
+  });
+
+  it("does not treat the public plugin catalog as an installed inventory", () => {
+    const html = markup("plugins", snapshot(true));
+    expect(html).toContain("Catálogo público");
+    expect(html).toContain("Instalação não verificada");
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Instalar Simplicio<\/button>/);
+    expect(html).not.toMatch(/>Instalado<|>Instalados<|>Ativar plugin</);
+    expect(html).toContain("Ele não comprova a instalação");
+  });
+
+  it("does not reuse the Simplicio login as provider-account authentication", () => {
+    const value = snapshot(true);
+    const provider = value.providers[0];
+    provider.installState = "installed";
+    provider.registrationState = "registered";
+    provider.handshakeState = "live";
+    provider.freshness = "current";
+    const html = markup("provider-accounts", value);
+    expect(html).toContain("Handshake MCP confirmado");
+    expect(html).toContain("Identidade e sessão não consultadas");
+    expect(html).not.toMatch(/>Conta ativa<|>Autenticado<|>System default</);
+  });
+
+  it("disables refresh while another root action owns its lock", () => {
+    const html = renderToStaticMarkup(<ReferenceSettingsScreen view="voice" snapshot={snapshot()} onNavigate={() => {}} onRefresh={() => {}} busy />);
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*aria-label="Atualizar consulta do Runtime"/);
+    expect(html).toContain("Consultando…");
+  });
+});
+
+describe("bounded read-only settings evidence", () => {
+  it("discards positive demo data from every runtime evidence lane", () => {
+    const evidence = createReferenceSettingsEvidence(snapshot());
+    expect(evidence.providers).toEqual([]);
+    expect(evidence.bots).toEqual([]);
+    expect(evidence.skills).toEqual([]);
+    expect(evidence.models).toEqual([]);
+    expect(evidence.computer).toBeNull();
+    expect(evidence.artifacts).toEqual([]);
+    expect(evidence.runtimeVersion).toBe("Não verificada na prévia");
+  });
+
+  it("does not promote a label to a live connection when handshake is missing", () => {
+    const value = snapshot(true);
+    value.providers[0] = { ...value.providers[0], state: "connected", installState: "installed", registrationState: "registered", handshakeState: "unverified", freshness: "current" };
+    expect(createReferenceSettingsEvidence(value).providers.find((provider) => provider.id === value.providers[0].id)?.state).toBe("registered");
+  });
+
+  it("does not use preview Agent Plane evidence inside a Runtime snapshot", () => {
+    const value = snapshot(true);
+    if (value.botCenter) value.botCenter.source = "preview";
+    const evidence = createReferenceSettingsEvidence(value);
+    expect(evidence.bots).toEqual([]);
+    expect(evidence.models).toEqual([]);
+    expect(evidence.computer).toBeNull();
+    expect(evidence.artifacts).toEqual([]);
+  });
+
+  it("keeps identity, prompts, configuration, local paths and secret-like labels out", () => {
+    const value = snapshot(true);
+    value.access.email = "private-person@example.test";
+    value.access.displayName = "Private Name";
+    value.providers[0].detail = "private-config-body";
+    value.providers[0].name = "/Users/private-person/secrets";
+    const center = value.botCenter!;
+    center.bots[0].displayName = "pypi-abcdefghijklmnopqrstuvwxyz";
+    center.bots[0].toolset = ["/Users/private/tools", "tool-a"];
+    center.bots[0].skills = ["C:\\Users\\private\\skill", "skill-a"];
+    center.sessions[0].events[0].content = "private-prompt-body";
+    const serialized = JSON.stringify(createReferenceSettingsEvidence(value));
+    expect(serialized).not.toMatch(/private-person|Private Name|private-config-body|private-prompt-body|pypi-abcdefghijklmnopqrstuvwxyz|C:\\\\Users/);
+    expect(serialized).toContain("tool-a");
+    expect(serialized).toContain("skill-a");
+  });
+
+  it("bounds provider, bot, model, skill and tool collections", () => {
+    const value = snapshot(true);
+    const provider = value.providers[0];
+    value.providers = Array.from({ length: 50 }, (_, index) => ({ ...provider, id: "provider-" + index }));
+    const center = value.botCenter!;
+    const bot = center.bots[0];
+    center.bots = Array.from({ length: 50 }, (_, index) => ({ ...bot, botId: "bot-" + index, model: "model-" + index, skills: Array.from({ length: 150 }, (_, skill) => "skill-" + skill), toolset: Array.from({ length: 150 }, (_, tool) => "tool-" + tool) }));
+    const evidence = createReferenceSettingsEvidence(value);
+    expect(evidence.providers).toHaveLength(32);
+    expect(evidence.bots).toHaveLength(32);
+    expect(evidence.models).toHaveLength(32);
+    expect(evidence.skills).toHaveLength(128);
+    expect(evidence.tools).toHaveLength(128);
+  });
+
+  it("renders metadata as inert text and degrades invalid timestamps", () => {
+    const value = snapshot(true);
+    value.generatedAt = "not-a-date";
+    const center = value.botCenter!;
+    center.bots[0].displayName = '<img src="https://example.test/private" onerror="alert(1)">';
+    const html = markup("orchestration", value);
+    expect(html).not.toContain('<img src="https://example.test');
+    expect(html).toContain("&lt;img");
+    expect(html).toContain("Data não informada");
+    expect(html).not.toContain("Invalid Date");
+  });
+});
+
+describe("fixed command clipboard operation", () => {
+  it("copies only the selected allowlisted text", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    expect(await copyReferenceCommand("version", write)).toBe("copied");
+    expect(write).toHaveBeenCalledExactlyOnceWith("simplicio version");
+  });
+
+  it("rejects unknown keys and missing APIs without trying a fallback executor", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    expect(await copyReferenceCommand(JSON.parse('"__proto__"'), write)).toBe("unavailable");
+    expect(await copyReferenceCommand("version", undefined)).toBe("unavailable");
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("handles explicit denial and synchronous errors", async () => {
+    expect(await copyReferenceCommand("version", async () => { throw new Error("denied"); })).toBe("unavailable");
+    expect(await copyReferenceCommand("version", () => { throw new Error("not allowed"); })).toBe("unavailable");
+  });
+
+  it("settles uncertainty after four seconds, never retries, and ignores late success", async () => {
+    vi.useFakeTimers();
+    let resolve!: () => void;
+    const write = vi.fn(() => new Promise<void>((done) => { resolve = done; }));
+    const result = copyReferenceCommand("version", write);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBe("uncertain");
+    expect(write).toHaveBeenCalledTimes(1);
+    resolve();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await result).toBe("uncertain");
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels the UI wait without claiming to cancel an already pending clipboard request", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let reject!: (reason: Error) => void;
+    const write = vi.fn(() => new Promise<void>((_resolve, fail) => { reject = fail; }));
+    const result = copyReferenceCommand("access", write, controller.signal);
+    await vi.advanceTimersByTimeAsync(1);
+    controller.abort();
+    expect(await result).toBe("cancelled");
+    reject(new Error("late denial"));
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not start a clipboard request for an already cancelled view", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const write = vi.fn().mockResolvedValue(undefined);
+    expect(await copyReferenceCommand("plan", write, controller.signal)).toBe("cancelled");
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
@@ -1,0 +1,483 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import type { DesktopSnapshot, ProviderConnection } from "../contracts";
+import { Glyph, type GlyphName } from "../components/Brand";
+import { providerRegistry } from "../provider_registry";
+import { createSettingsProjection } from "../settings_projection";
+import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
+import { searchMatches, type View } from "../workbench";
+import "../reference_settings.css";
+
+export interface ReferenceSettingsProps {
+  view: ReferenceSettingsView;
+  snapshot: DesktopSnapshot;
+  onNavigate: (view: View) => void;
+  onRefresh?: () => void;
+  busy?: boolean;
+}
+
+export const REFERENCE_QUICK_COMMANDS = {
+  version: { label: "Versão do Runtime", command: "simplicio version", description: "Consulta a versão do executável encontrado no seu terminal." },
+  access: { label: "Estado da conta", command: "simplicio auth status --json", description: "Consulta a autenticação do Runtime. Não inicia um novo login." },
+  plugins: { label: "Registry de plugins", command: "simplicio plugin list --json", description: "Lista o registry do Runtime; não comprova os pacotes nativos de cada IDE." },
+  plan: { label: "Prévia de integração", command: "simplicio install --global --dry-run --json", description: "Mostra o plano MCP/hooks sem aplicar alterações." },
+} as const;
+type CommandId = keyof typeof REFERENCE_QUICK_COMMANDS;
+type CopyOutcome = "copied" | "unavailable" | "uncertain" | "cancelled";
+
+/** Only copies allowlisted text. It never executes a command or reads the clipboard. */
+export function copyReferenceCommand(id: CommandId, write: ((text: string) => Promise<void>) | undefined, signal?: AbortSignal): Promise<CopyOutcome> {
+  if (signal?.aborted) return Promise.resolve("cancelled");
+  if (!Object.prototype.hasOwnProperty.call(REFERENCE_QUICK_COMMANDS, id) || !write) return Promise.resolve("unavailable");
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (outcome: CopyOutcome) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", cancelled);
+      resolve(outcome);
+    };
+    const cancelled = () => finish("cancelled");
+    const timer = setTimeout(() => finish("uncertain"), 4000);
+    signal?.addEventListener("abort", cancelled, { once: true });
+    Promise.resolve().then(() => {
+      if (signal?.aborted) { finish("cancelled"); return; }
+      return write(REFERENCE_QUICK_COMMANDS[id].command);
+    }).then(() => finish(signal?.aborted ? "cancelled" : "copied"), () => finish("unavailable"));
+  });
+}
+
+function metadataLabel(value: unknown, fallback: string, maximum = 140): string {
+  if (typeof value !== "string") return fallback;
+  const clean = value.replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, "").trim();
+  if (!clean || /^(?:\/|[a-z]:[\\/])/i.test(clean) || /(?:pypi-|gh[pousr]_|sk-)[a-z0-9_-]{16}/i.test(clean)) return fallback;
+  return clean.slice(0, maximum);
+}
+
+function observedTime(value: unknown): string {
+  if (typeof value !== "string" || value.length > 40 || !/^\d{4}-\d{2}-\d{2}T/.test(value)) return "Data não informada";
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toLocaleString("pt-BR") : "Data não informada";
+}
+
+/** This projection deliberately excludes identities, prompts, config bodies, URLs and local paths. */
+export function createReferenceSettingsEvidence(snapshot: DesktopSnapshot) {
+  const runtime = snapshot.source === "runtime";
+  const center = runtime && snapshot.botCenter?.source === "runtime" ? snapshot.botCenter : undefined;
+  const inventory = createSettingsProjection(snapshot);
+  return {
+    source: snapshot.source,
+    observedAt: observedTime(snapshot.generatedAt),
+    runtimeVersion: runtime ? metadataLabel(snapshot.runtime.version, "Não informada", 48) : "Não verificada na prévia",
+    runtimeState: runtime ? ({ healthy: "Saudável", starting: "Iniciando", degraded: "Degradado", offline: "Offline" }[snapshot.runtime.state] ?? "Não informado") : "Prévia",
+    transport: runtime ? ({ sidecar: "Executável local", daemon: "Daemon", unavailable: "Indisponível" }[snapshot.runtime.transport] ?? "Não informado") : "Não verificado",
+    providers: runtime ? providerRegistry(snapshot.providers.slice(0, 32)).map((provider) => ({
+      id: provider.id, name: metadataLabel(provider.name, "Cliente"), state: provider.state,
+      protocol: provider.protocol, registrationState: provider.registrationState,
+    })) : [],
+    models: inventory.models.slice(0, 32).map((item) => metadataLabel(item.label, "Modelo não informado")),
+    skills: inventory.skills.slice(0, 128).map((item) => metadataLabel(item.label, "Skill não informada")),
+    tools: inventory.tools.slice(0, 128).map((item) => metadataLabel(item.label, "Ferramenta não informada")),
+    bots: center?.bots.slice(0, 32).map((bot) => ({
+      name: metadataLabel(bot.displayName, "Agente"), lifecycle: bot.lifecycle,
+      model: metadataLabel(bot.model, "Modelo não informado"), profile: metadataLabel(bot.agentProfileId, "Perfil não informado"),
+    })) ?? [],
+    computer: center ? {
+      available: center.computer.available,
+      state: center.computer.state,
+      observedAt: observedTime(center.computer.lastEventAt),
+    } : null,
+    artifacts: center?.sessions.slice(0, 32).flatMap((session) => session.events.slice(0, 200))
+      .filter((event) => event.kind === "artifact").slice(0, 64).map((event) => ({
+        name: metadataLabel(event.artifactName, "Artefato informado"),
+        observedAt: observedTime(event.timestamp),
+        state: event.state,
+      })) ?? [],
+  };
+}
+type Evidence = ReturnType<typeof createReferenceSettingsEvidence>;
+type Navigate = ReferenceSettingsProps["onNavigate"];
+
+function Badge({ children, positive = false }: { children: ReactNode; positive?: boolean }) {
+  return <span className={"ref-badge" + (positive ? " ref-badge-positive" : "")}>{children}</span>;
+}
+
+function Section({ title, description, children, action }: { title: string; description?: string; children: ReactNode; action?: ReactNode }) {
+  return <section className="ref-section"><div className="ref-section-heading"><div><h2>{title}</h2>{description && <p>{description}</p>}</div>{action}</div><div className="ref-slab">{children}</div></section>;
+}
+
+function Row({ title, description, children, icon }: { title: string; description?: ReactNode; children?: ReactNode; icon?: GlyphName }) {
+  return <div className="ref-row">{icon && <span className="ref-row-icon"><Glyph name={icon} size={20} /></span>}<div className="ref-row-copy"><strong>{title}</strong>{description && <p>{description}</p>}</div>{children && <div className="ref-row-control">{children}</div>}</div>;
+}
+
+function Unavailable({ label, reason }: { label: string; reason: string }) {
+  const id = useId();
+  return <div className="ref-unavailable-control"><button type="button" className="button button-secondary" disabled aria-describedby={id}>{label}</button><small id={id}>{reason}</small></div>;
+}
+
+function UnavailableSwitch({ label, reason }: { label: string; reason: string }) {
+  const id = useId();
+  return <div className="ref-unavailable-control"><button type="button" className="preference-switch ref-disabled-switch" role="switch" aria-checked={false} aria-label={label} disabled aria-describedby={id}><span /></button><small id={id}>{reason}</small></div>;
+}
+
+function UnavailableSelect({ label, value = "Não disponível" }: { label: string; value?: string }) {
+  return <select aria-label={label} className="workbench-select" disabled value=""><option value="">{value}</option></select>;
+}
+
+function LinkButton({ children, to, onNavigate, icon = "arrow" }: { children: ReactNode; to: View; onNavigate: Navigate; icon?: GlyphName }) {
+  return <button type="button" className="button button-secondary" onClick={() => onNavigate(to)}>{children}<Glyph name={icon} size={16} /></button>;
+}
+
+function Notice({ children, title = "Disponibilidade neste Desktop" }: { title?: string; children: ReactNode }) {
+  return <aside className="ref-notice"><Glyph name="shield" size={19} /><div><strong>{title}</strong><p>{children}</p></div></aside>;
+}
+
+function CommandCard({ id }: { id: CommandId }) {
+  const item = REFERENCE_QUICK_COMMANDS[id];
+  const [state, setState] = useState<CopyOutcome | "idle" | "copying">("idle");
+  const active = useRef<AbortController | null>(null);
+  useEffect(() => () => { active.current?.abort(); active.current = null; }, []);
+  async function copy() {
+    if (active.current) return;
+    const controller = new AbortController();
+    active.current = controller;
+    setState("copying");
+    let write: ((text: string) => Promise<void>) | undefined;
+    try {
+      const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard;
+      write = clipboard && typeof clipboard.writeText === "function" ? clipboard.writeText.bind(clipboard) : undefined;
+    } catch { /* A denied clipboard API must leave a usable manual-copy path. */ }
+    const outcome = await copyReferenceCommand(id, write, controller.signal);
+    if (active.current !== controller) return;
+    active.current = null;
+    if (outcome !== "cancelled") setState(outcome);
+  }
+  return <article className="ref-command-card"><h3>{item.label}</h3><p>{item.description}</p><div className="ref-command-line"><code>{item.command}</code><button className="button button-secondary" type="button" onClick={() => void copy()} disabled={state === "copying"} aria-label={"Copiar " + item.label}>{state === "copying" ? "Copiando…" : state === "copied" ? "Copiado" : "Copiar"}</button></div>
+    <span className="ref-copy-status" role="status">{state === "copied" ? "Comando copiado. Nenhum comando foi executado." : state === "unavailable" ? "Não foi possível copiar. Selecione o comando e copie manualmente." : state === "uncertain" ? "Não foi possível confirmar a cópia. Confira a área de transferência ou copie manualmente." : ""}</span>
+  </article>;
+}
+
+const providerStateLabels: Record<ProviderConnection["state"], string> = {
+  connected: "Handshake MCP confirmado", registered: "MCP registrado", detected: "Cliente detectado",
+  needs_attention: "MCP requer atenção", not_installed: "Cliente não encontrado",
+};
+
+function Accounts({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  const accounts = [
+    { id: "claude-code", name: "Claude", mark: "CL", description: "A autenticação do Claude Code continua sob controle do próprio agente." },
+    { id: "codex", name: "Codex", mark: "CX", description: "Seu cliente Codex administra contas e credenciais; o Simplicio não importa tokens." },
+    { id: "gemini", name: "Gemini", mark: "GE", description: "O login do Gemini CLI não é reutilizado automaticamente como uma conta do Desktop." },
+    { id: "opencode", name: "OpenCode", mark: "OC", description: "Contas, modelos e chaves permanecem na configuração do OpenCode." },
+  ];
+  return <>
+    <Notice title="Contas do provedor são separadas da conta Simplicio">Registro MCP, cliente instalado e autenticação do provedor são evidências diferentes. Nenhuma credencial será solicitada, importada ou armazenada aqui.</Notice>
+    {accounts.map((account) => {
+      const provider = evidence.providers.find((item) => item.id === account.id);
+      return <section className="ref-account-card" key={account.id}><div className="ref-account-heading"><span className={"ref-monogram ref-monogram-" + account.id}>{account.mark}</span><div><h2>{account.name}</h2><p>{account.description}</p></div></div>
+        <Row title="Contas neste dispositivo" description="O inventário atual não informa contas gerenciadas deste provedor."><Unavailable label={"Adicionar conta " + account.name} reason="Gerenciamento de contas ainda indisponível." /></Row>
+        <div className="ref-account-default"><div><strong>Autenticação no cliente</strong><p>Identidade e sessão não consultadas pelo Desktop.</p></div><Badge>Não verificada</Badge></div>
+        <div className="ref-account-evidence"><span>{provider ? providerStateLabels[provider.state] : "Cliente não informado nesta consulta"}</span><button type="button" className="text-button" onClick={() => onNavigate("agents")}>Ver agente e IDE</button></div>
+      </section>;
+    })}
+    <Section title="Outros provedores" description="Integrações adicionais continuam pertencendo ao cliente de IA."><Row title="MiniMax e provedores personalizados" description="Cookies de sessão e chaves de API não são coletados nesta tela."><Unavailable label="Configurar provedor" reason="Falta um contrato seguro de autenticação." /></Row></Section>
+    <LinkButton to="settings" onNavigate={onNavigate}>Abrir conta Simplicio</LinkButton>
+  </>;
+}
+
+const reviewServices = [
+  { name: "GitHub", mark: "GH", description: "Pull requests, issues e revisão de código." },
+  { name: "GitLab", mark: "GL", description: "Merge requests, issues e projetos GitLab." },
+  { name: "Bitbucket", mark: "BB", description: "Repositórios e pull requests do Bitbucket." },
+  { name: "Azure DevOps", mark: "AZ", description: "Código-fonte, work items e revisões." },
+  { name: "Gitea", mark: "GT", description: "Repositórios e revisão em servidores Gitea." },
+];
+const taskServices = [
+  { name: "Linear", mark: "LI", description: "Issues, equipes e contexto de tarefas." },
+  { name: "Jira", mark: "JI", description: "Projetos e tarefas do Jira." },
+];
+
+function ServiceCards({ services }: { services: typeof reviewServices }) {
+  return <div className="ref-service-stack">{services.map((service) => <article className="ref-service-card" key={service.name}><div className="ref-service-top"><span className="ref-monogram">{service.mark}</span><div><h3>{service.name}</h3><p>{service.description}</p></div><Badge>Não verificado</Badge></div><div className="ref-service-bottom"><p>O Runtime ainda não fornece ao Desktop uma consulta de conta e um fluxo de conexão para este serviço.</p><Unavailable label={"Conectar " + service.name} reason="Conexão nativa indisponível." /></div></article>)}</div>;
+}
+
+function Integrations({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice>Esta é a área de serviços externos. O estado de GitHub, Linear ou Jira não é inferido de um agente conectado ao MCP.</Notice>
+    <Section title="Revisão e código-fonte" description="Provedores para acompanhar repositórios e revisões."><ServiceCards services={reviewServices} /></Section>
+    <Section title="Provedores de tarefas" description="Contas e permissões precisam ser verificadas pelo serviço."><ServiceCards services={taskServices} /></Section>
+    <div className="ref-action-row"><LinkButton to="task-sources" onNavigate={onNavigate}>Ver fontes de tarefas</LinkButton><LinkButton to="providers" onNavigate={onNavigate}>Configurar integrações MCP</LinkButton></div>
+  </>;
+}
+
+function Orchestration({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Simplicio Loop" description="Os agentes executam dentro da autoridade do Runtime, não de uma preferência visual.">
+      <Row title="Execução governada" icon="automation" description="Planos, consentimento e evidências continuam no fluxo do Runtime."><LinkButton to="bot" onNavigate={onNavigate}>Abrir Bot Center</LinkButton></Row>
+      <Row title="Paralelismo sob demanda" description="O limite de paralelismo não foi consultado nesta tela. A capacidade disponível e a admissão de agentes dependem das políticas do Runtime."><Badge>Limite não consultado</Badge></Row>
+      <Row title="Agente e modelo padrão" description="Nenhum modelo é selecionado automaticamente por esta tela."><UnavailableSelect label="Agente e modelo padrão" value="Gerenciado no Runtime" /></Row>
+    </Section>
+    <Section title="Perfis informados" description="Inventário da última consulta, sem inferir trabalho em execução.">
+      {evidence.bots.length ? evidence.bots.map((bot, index) => <Row key={index} title={bot.name} description={bot.profile + " · " + bot.model} icon="teams"><Badge>{({ disabled: "Desativado", idle: "Ocioso", active: "Ativo no registro", busy: "Ocupado no registro", degraded: "Degradado", blocked: "Bloqueado" })[bot.lifecycle]}</Badge></Row>) : <Row title="Sem inventário de agentes nesta consulta" description="Abra o Bot Center para consultar a disponibilidade do Agent Plane." />}
+    </Section>
+    <Section title="Autonomia e aprovação"><Row title="Aprovar ações automaticamente" description="A política do Runtime não pode ser ampliada por uma opção da interface."><UnavailableSwitch label="Aprovar ações automaticamente" reason="Aprovações não são alteradas aqui." /></Row><Row title="Recuperação de tarefas" description="Retomada, interrupção e cancelamento exigem uma sessão e uma ação oferecida pelo Runtime."><LinkButton to="activity" onNavigate={onNavigate}>Ver atividade</LinkButton></Row></Section>
+  </>;
+}
+
+function Computer({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  const computer = evidence.computer;
+  const state = computer ? ({ bot_control: "Controle do bot informado", human_control: "Controle humano informado", paused: "Pausado no registro", blocked: "Bloqueado no registro" })[computer.state] : "Sessão não informada";
+  return <>
+    <div className="ref-status-banner"><Glyph name="monitor" size={25} /><div><h2>{computer?.available ? "Controle informado pelo Runtime" : "Controle do computador não confirmado"}</h2><p>{state}. Permissões do sistema são verificadas separadamente.</p></div><Badge>{computer?.available ? "Registro disponível" : "Não verificado"}</Badge></div>
+    <Section title="Permissões necessárias"><Row title="Acessibilidade" icon="shield" description="Inspeção de interfaces e ações em janelas. O Desktop ainda não consulta essa permissão."><Badge>Não consultada</Badge></Row><Row title="Capturas de tela" icon="monitor" description="Captura de janelas para inspeção visual. Nenhuma captura é feita por esta tela."><Badge>Não consultada</Badge></Row><Row title="Acesso do sistema" description="Revise os requisitos antes de permitir automação de aplicativos."><LinkButton to="permissions" onNavigate={onNavigate}>Ver permissões</LinkButton></Row></Section>
+    <Section title="Ferramentas de Computer Use"><Row title="Skill e sessão" description="Um nome no inventário não comprova skill instalada, permissões concedidas ou controle ativo."><LinkButton to="models" onNavigate={onNavigate}>Ver ferramentas e skills</LinkButton></Row><Row title="Controlar o computador" description="Ações só aparecem no Bot Center quando uma sessão real as autoriza."><LinkButton to="bot" onNavigate={onNavigate}>Abrir controle no Bot Center</LinkButton></Row></Section>
+  </>;
+}
+
+function Voice({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice title="Áudio não conectado nesta versão do Desktop">Não há contrato nativo de captura e transcrição exposto a esta tela. Nenhum microfone é aberto e nenhum modelo é baixado.</Notice>
+    <Section title="Ditado"><Row title="Ativar ditado por voz" description="Transcrever fala para o campo de texto em foco."><UnavailableSwitch label="Ativar ditado por voz" reason="Captura de áudio indisponível." /></Row><Row title="Modo de ditado" description="Alternar a gravação ou manter uma tecla pressionada."><div className="ref-disabled-segments" role="group" aria-label="Modo de ditado"><button disabled type="button">Alternar</button><button disabled type="button">Manter pressionado</button></div></Row><Row title="Microfone" description="Nenhum dispositivo foi consultado."><UnavailableSelect label="Microfone" value="Dispositivos não consultados" /></Row></Section>
+    <Section title="Modelo de voz"><Row title="Reconhecimento de fala" description="Instalação, tamanho e compatibilidade precisam ser fornecidos pelo Runtime."><UnavailableSelect label="Modelo de voz" value="Inventário não disponível" /></Row><Row title="Idioma e processamento local" description="Nenhum idioma, provedor ou modo offline é presumido pelo Desktop."><Badge>Não configurável</Badge></Row></Section>
+    <LinkButton to="permissions" onNavigate={onNavigate}>Ver permissões de microfone</LinkButton>
+  </>;
+}
+
+function Mobile({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice title="Pareamento ainda indisponível">O Desktop não possui um contrato de Simplicio Mobile, relay ou tokens de pareamento. Não é gerado QR code de demonstração.</Notice>
+    <Section title="Parear um dispositivo" description="A conexão precisa de identidade, expiração e revogação verificáveis.">
+      <div className="ref-pairing-layout"><div className="ref-pairing-steps"><div><span>1</span><p><strong>Aplicativo compatível</strong>Um cliente mobile precisa ser publicado e identificado pelo Runtime.</p></div><div><span>2</span><p><strong>Canal autorizado</strong>LAN ou relay devem oferecer um transporte autenticado.</p></div><div><span>3</span><p><strong>Confirmação do dispositivo</strong>O código só pode existir com validade e revogação reais.</p></div></div><div className="ref-pairing-empty"><Glyph name="lock" size={36} /><strong>Pareamento não disponível</strong><span>Nenhum código emitido</span></div></div>
+      <Row title="Conexão" description="Nenhum endereço local ou servidor é descoberto nesta tela."><UnavailableSelect label="Conexão mobile" value="LAN / relay indisponíveis" /></Row><Row title="Código de pareamento" description="O código deve ser pessoal, temporário e revogável."><Unavailable label="Gerar QR code" reason="Falta o contrato de pareamento." /></Row>
+    </Section>
+    <Section title="Dispositivos pareados"><Row title="Inventário não disponível" description="Isso não confirma a ausência de dispositivos pareados em outros clientes." /><Row title="Ao sair do aplicativo mobile" description="Restauração de terminal e tamanho da sessão dependem do cliente mobile."><UnavailableSelect label="Comportamento ao sair do mobile" /></Row></Section>
+    <LinkButton to="servers" onNavigate={onNavigate}>Ver servidores Simplicio</LinkButton>
+  </>;
+}
+
+function General({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Aplicativo"><Row title="Simplicio" icon="settings" description="Configurações locais da interface e identidade do aplicativo."><LinkButton to="settings" onNavigate={onNavigate}>Minha conta</LinkButton></Row><Row title="Aparência e navegação" description="Tema branco, densidade e atalhos de projeto são ajustados na tela Aparência."><LinkButton to="general" onNavigate={onNavigate}>Ajustar aparência</LinkButton></Row><Row title="Ao iniciar" description="A lembrança do último projeto é uma preferência local já disponível."><LinkButton to="general" onNavigate={onNavigate}>Preferências de início</LinkButton></Row></Section>
+    <Section title="Ambiente"><Row title="Runtime" description={"Versão informada: " + evidence.runtimeVersion}><Badge>{evidence.runtimeState}</Badge></Row><Row title="Inicializar junto com o sistema" description="Nenhum serviço de inicialização automática é alterado pelo Desktop."><UnavailableSwitch label="Inicializar junto com o sistema" reason="Ação nativa indisponível." /></Row><Row title="Atualizações do Desktop" description="Use Check for Updates… no menu. A consulta procura um pacote compatível; a instalação continua manual."><Badge>Consulta de metadados</Badge></Row></Section>
+  </>;
+}
+
+function Artifacts({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Artefatos informados" description="Somente nomes e datas fornecidos pelo Agent Plane. O Desktop não lê o conteúdo dos arquivos.">
+      {evidence.artifacts.length ? <div className="ref-table-wrap"><table className="ref-table"><caption>Metadados da última consulta</caption><thead><tr><th>Artefato</th><th>Registro</th><th>Estado reportado</th></tr></thead><tbody>{evidence.artifacts.map((artifact, index) => <tr key={index}><td><Glyph name="folder" size={17} />{artifact.name}</td><td>{artifact.observedAt}</td><td>{artifact.state === "complete" ? "Concluído no registro" : artifact.state === "streaming" ? "Em produção no registro" : "Bloqueado"}</td></tr>)}</tbody></table></div> : <div className="ref-empty"><Glyph name="folder" size={30} /><h3>Nenhum artefato informado nesta consulta</h3><p>A ausência de metadados não significa que seus arquivos foram removidos.</p></div>}
+      <Row title="Abrir ou exportar arquivos" description="O inventário não fornece um contrato de acesso verificado aos arquivos."><Unavailable label="Exportar artefatos" reason="Acesso nativo ainda indisponível." /></Row>
+    </Section>
+    <div className="ref-link-grid"><LinkButton to="bot" onNavigate={onNavigate}>Ver sessões no Bot Center</LinkButton><LinkButton to="tokens" onNavigate={onNavigate}>Abrir relatório de tokens</LinkButton><LinkButton to="activity" onNavigate={onNavigate}>Ver atividade do Runtime</LinkButton></div>
+  </>;
+}
+
+function Skills({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Skills informadas pelo Runtime" description="Este é um inventário de nomes, não uma autorização para compartilhar arquivos.">
+      {evidence.skills.length ? evidence.skills.map((skill, index) => <Row key={index} title={skill} icon="spark" description="Conteúdo e instruções da skill não são expostos nesta tela."><Badge>Informada</Badge></Row>) : <Row title="Inventário ainda não disponível" description="O Agent Plane não informou skills para esta consulta." />}
+    </Section>
+    <Section title="Compartilhamento"><Row title="Compartilhar entre projetos" description="Destino, licença, conteúdo e revisão precisam de um plano explícito."><UnavailableSwitch label="Compartilhar skills automaticamente" reason="Nenhum compartilhamento automático." /></Row><Row title="Publicar uma skill" description="Sem envio de conteúdo, prompts ou configurações a serviços externos."><Unavailable label="Compartilhar skill" reason="Publicação não disponível no Desktop." /></Row></Section>
+    <div className="ref-action-row"><LinkButton to="plugins" onNavigate={onNavigate}>Ver pacotes de plugins</LinkButton><LinkButton to="models" onNavigate={onNavigate}>Ver modelos e ferramentas</LinkButton></div>
+  </>;
+}
+
+function Git({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Projetos e repositórios"><Row title="Pastas locais" icon="folder" description="Adicione uma pasta existente pelo seletor nativo. Um atalho local não cria worktree nem clona repositórios."><LinkButton to="home" onNavigate={onNavigate}>Abrir projetos</LinkButton></Row><Row title="Repositório padrão" description="O contexto de cada projeto é escolhido explicitamente; nenhuma pasta é inferida aqui."><UnavailableSelect label="Repositório padrão" value="Selecione no projeto" /></Row></Section>
+    <Section title="Revisão e alterações"><Row title="Status, diff e branches" description="Esta versão não oferece comandos Git mutantes nesta tela."><Unavailable label="Abrir revisão Git" reason="Contrato de revisão ainda indisponível." /></Row><Row title="Commit e push automático" description="Nenhuma alteração de repositório é autorizada ao visitar configurações."><UnavailableSwitch label="Commit e push automático" reason="Operação não disponível." /></Row></Section>
+    <Section title="Serviços de código-fonte"><Row title="GitHub, GitLab e outros hosts" description="Login no Simplicio não autentica um serviço Git."><LinkButton to="integrations" onNavigate={onNavigate}>Ver integrações de serviços</LinkButton></Row></Section>
+  </>;
+}
+
+function TaskSources({ onNavigate }: { onNavigate: Navigate }) {
+  const services = [reviewServices[0], reviewServices[1], ...taskServices];
+  return <>
+    <Section title="Configurar origem das tarefas" description="Autenticação, consulta e visibilidade devem ser verificadas por provedor.">
+      <div className="ref-source-list">{services.map((service) => <details className="ref-source-details" key={service.name}><summary><span className="ref-monogram">{service.mark}</span><span><strong>{service.name}</strong><small>{service.description}</small></span><Badge>Consulta indisponível</Badge><Glyph name="chevron" size={16} /></summary><div className="ref-source-body"><p>O Desktop ainda não recebe tarefas deste serviço. Mostrar uma categoria não estabelece conexão nem importa issues.</p><Row title={"Mostrar tarefas de " + service.name} description="Nenhuma preferência sem efeito é salva."><UnavailableSwitch label={"Mostrar tarefas de " + service.name} reason="Falta a consulta do provedor." /></Row><LinkButton to="integrations" onNavigate={onNavigate}>Ver conexão do serviço</LinkButton></div></details>)}</div>
+    </Section>
+    <Notice title="Nenhuma tarefa importada automaticamente">Ações de leitura, criação e edição de issues continuarão separadas. Os projetos e a atividade já disponíveis podem ser consultados sem conectar um serviço.</Notice>
+    <LinkButton to="activity" onNavigate={onNavigate}>Ver atividade disponível</LinkButton>
+  </>;
+}
+
+function Terminal({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Terminal local"><div className="ref-terminal-intro"><span className="ref-terminal-symbol" aria-hidden="true">&gt;_</span><div><h3>O Simplicio CLI continua no seu terminal</h3><p>Este painel não inicia um shell, não executa comandos e não lê histórico do terminal.</p></div></div><Row title="Terminal integrado" description="Uma sessão precisa de processo supervisionado, entrada/saída e cancelamento verificáveis."><Unavailable label="Abrir terminal integrado" reason="Sessão PTY não exposta ao Desktop." /></Row><Row title="Shell padrão" description="O shell do sistema não foi consultado."><UnavailableSelect label="Shell padrão" value="Não consultado" /></Row></Section>
+    <Section title="Consultar o Runtime"><CommandCard id="version" /><CommandCard id="plan" /></Section>
+    <LinkButton to="quick-commands" onNavigate={onNavigate}>Ver todos os comandos de consulta</LinkButton>
+  </>;
+}
+
+function QuickCommands() {
+  return <>
+    <Notice title="Copiar não executa">Os comandos abaixo são fixos e documentados. Cole no seu terminal quando quiser executá-los. A saída permanece no terminal; esta tela não a coleta.</Notice>
+    <Section title="Consultas do Simplicio">{(Object.keys(REFERENCE_QUICK_COMMANDS) as CommandId[]).map((id) => <CommandCard key={id} id={id} />)}</Section>
+    <Section title="Comandos personalizados"><Row title="Adicionar atalho de execução" description="Comandos arbitrários não são armazenados nem executados pela interface."><Unavailable label="Adicionar comando" reason="Execução personalizada indisponível." /></Row></Section>
+  </>;
+}
+
+function Browser({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Navegação por agentes"><Row title="Automação de navegador" description="O Desktop não inicia sessões de browser nem pressupõe acesso aos seus logins."><UnavailableSwitch label="Automação de navegador" reason="Contrato de sessão não disponível." /></Row>
+      <div className="ref-browser-steps"><article><span>1</span><div><h3>Runtime e ferramentas</h3><p>Consulte o inventário; disponibilidade de ferramentas não confirma uma sessão de navegador.</p><LinkButton to="models" onNavigate={onNavigate}>Ver ferramentas</LinkButton></div></article><article><span>2</span><div><h3>Controle e permissões</h3><p>Uma sessão de Computer Use depende de autoridade explícita e acesso do sistema.</p><LinkButton to="computer-use" onNavigate={onNavigate}>Ver uso do computador</LinkButton></div></article><article><span>3</span><div><h3>Sessão autenticada</h3><p>Nenhum cookie, perfil ou senha é importado por esta tela.</p><Unavailable label="Importar cookies" reason="Importação não disponível." /></div></article></div>
+    </Section>
+    <Section title="Preferências do navegador"><Row title="Página inicial" description="Sem navegador integrado, nenhum endereço é salvo como preferência."><UnavailableSelect label="Página inicial do navegador" /></Row><Row title="Mecanismo de busca" description="O Desktop não modifica as configurações do seu navegador."><UnavailableSelect label="Mecanismo de busca" /></Row><Row title="Zoom padrão" description="Um valor só terá efeito após existir uma sessão de browser."><UnavailableSelect label="Zoom padrão do navegador" /></Row><Row title="Abrir links dentro do app" description="Login e releases usam os fluxos externos já oferecidos pelo Desktop."><UnavailableSwitch label="Abrir links dentro do app" reason="Navegador integrado indisponível." /></Row></Section>
+  </>;
+}
+
+function Emulator({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Dispositivos de desenvolvimento"><div className="ref-device-grid">{["Android", "iOS"].map((platform) => <article key={platform} className="ref-device-card"><Glyph name="monitor" size={31} /><h3>{platform}</h3><Badge>Inventário não consultado</Badge><p>Nenhum SDK, simulador ou imagem de dispositivo foi detectado por esta tela.</p><Unavailable label={"Iniciar emulador " + platform} reason="Inicialização nativa indisponível." /></article>)}</div></Section>
+    <Section title="Ambiente de teste"><Row title="Dispositivo padrão" description="A lista precisa ser fornecida por uma consulta nativa."><UnavailableSelect label="Dispositivo de emulação" value="Nenhum inventário disponível" /></Row><Row title="Capturar tela e inspecionar" description="Permissões e alvo precisam ser identificados antes de qualquer captura."><LinkButton to="computer-use" onNavigate={onNavigate}>Ver uso do computador</LinkButton></Row></Section>
+  </>;
+}
+
+function Floating({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Espaço de trabalho"><div className="ref-window-layout" aria-label="Organização da janela principal"><span>Projetos</span><div><strong>Simplicio</strong><p>Uma janela principal, com navegação e contexto do projeto.</p></div></div><Row title="Abrir janela flutuante" description="Criação de janelas, foco e encerramento ainda não possuem um contrato nesta tela."><Unavailable label="Abrir janela flutuante" reason="Nova janela nativa indisponível." /></Row><Row title="Manter sempre à frente" description="Nenhuma preferência sem efeito é aplicada à janela atual."><UnavailableSwitch label="Manter janela sempre à frente" reason="Ação de janela indisponível." /></Row></Section>
+    <Section title="Navegação disponível"><Row title="Lateral e densidade" description="Organize a janela principal com as preferências locais existentes."><LinkButton to="general" onNavigate={onNavigate}>Ajustar aparência</LinkButton></Row><Row title="Controle por teclado" description="Alternar a lateral, buscar e navegar sem sair do teclado."><LinkButton to="shortcuts" onNavigate={onNavigate}>Ver atalhos</LinkButton></Row></Section>
+  </>;
+}
+
+function Input({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Navegação por teclado"><Row title="Percorrer controles" description="Use Tab e Shift + Tab para avançar e voltar entre controles disponíveis."><kbd>Tab</kbd></Row><Row title="Confirmar uma ação" description="Enter ou Espaço ativa o controle em foco."><kbd>Enter / Espaço</kbd></Row><Row title="Busca do aplicativo" description="A busca de navegação e projetos respeita os atalhos do Desktop."><LinkButton to="shortcuts" onNavigate={onNavigate}>Abrir atalhos</LinkButton></Row></Section>
+    <Section title="Edição"><Row title="Editor de código padrão" description="Integrações MCP não alteram o editor padrão do sistema."><UnavailableSelect label="Editor padrão" value="Não configurável nesta tela" /></Row><Row title="Autoformatação" description="Formatação automática exige um editor e uma configuração de projeto."><UnavailableSwitch label="Formatar automaticamente" reason="Editor integrado indisponível." /></Row><Row title="Ditado" description="Disponibilidade de microfone e transcrição é tratada separadamente."><LinkButton to="voice" onNavigate={onNavigate}>Ver configurações de voz</LinkButton></Row></Section>
+  </>;
+}
+
+function Notifications({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice title="Entrega de notificações não verificada">O Desktop ainda não consulta a permissão de notificações do sistema. Esta tela não afirma que a entrega está ativa nem que o sistema a bloqueou.</Notice>
+    <Section title="Notificações nativas"><Row title="Ativar notificações" description="Alertas de eventos em segundo plano dependem de entrega nativa."><UnavailableSwitch label="Ativar notificações" reason="Entrega nativa indisponível." /></Row><Row title="Conclusão de tarefa" description="Avisar quando um agente concluir uma execução."><UnavailableSwitch label="Notificar conclusão de tarefa" reason="Assinatura de eventos indisponível." /></Row><Row title="Campainha do terminal" description="Avisar quando uma sessão de terminal emitir um alerta."><UnavailableSwitch label="Campainha do terminal" reason="Terminal integrado indisponível." /></Row><Row title="Som da notificação" description="Nenhum som é escolhido ou reproduzido nesta tela."><UnavailableSelect label="Som da notificação" /></Row><Row title="Silenciar enquanto a janela estiver em foco" description="A preferência só poderá ser aplicada quando houver entrega nativa."><UnavailableSwitch label="Silenciar notificações em foco" reason="Preferência não aplicada." /></Row><Row title="Testar entrega" description="Não será exibida uma confirmação simulada."><Unavailable label="Enviar notificação de teste" reason="Teste nativo não disponível." /></Row></Section>
+    <LinkButton to="activity" onNavigate={onNavigate}>Consultar atividade no app</LinkButton>
+  </>;
+}
+
+function Hosts({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Hosts SSH" action={<Unavailable label="Adicionar host SSH" reason="Conexão remota indisponível." />}><div className="ref-empty"><Glyph name="monitor" size={29} /><h3>Inventário remoto não disponível</h3><p>O Desktop não lê chaves SSH, não importa sua configuração e não abre conexões nesta tela.</p></div></Section>
+    <Section title="Identidade e acesso"><Row title="Autenticação" icon="lock" description="Chaves privadas devem permanecer no mecanismo de autenticação do host. Não há campo de senha ou chave aqui."><Badge>Sem coleta de credenciais</Badge></Row><Row title="Verificação do host" description="Uma futura conexão precisa verificar identidade do servidor e obter consentimento antes de executar ações."><Unavailable label="Testar conexão SSH" reason="Transporte SSH não exposto." /></Row><Row title="Workspaces remotos" description="Um projeto local não é convertido automaticamente em workspace remoto."><LinkButton to="home" onNavigate={onNavigate}>Ver projetos locais</LinkButton></Row></Section>
+  </>;
+}
+
+function Servers({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Runtime deste computador"><div className="ref-status-banner ref-status-banner-inner"><Glyph name="monitor" size={25} /><div><h3>Simplicio Runtime</h3><p>{evidence.runtimeVersion} · {evidence.transport}</p></div><Badge>{evidence.runtimeState}</Badge></div><Row title="Conexões MCP" description="Clientes locais, registro e handshake são apresentados separadamente."><LinkButton to="providers" onNavigate={onNavigate}>Ver clientes MCP</LinkButton></Row></Section>
+    <Section title="Servidores remotos" description="Nenhum endereço, sessão ou autenticação de servidor remoto foi consultado."><Row title="Adicionar servidor Simplicio" description="Exige descoberta, identidade, transporte autenticado e verificação de compatibilidade."><Unavailable label="Adicionar servidor" reason="Contrato remoto indisponível." /></Row><Row title="Credenciais por servidor" description="Não são herdadas da conta Simplicio nem copiadas dos agentes."><Badge>Não coletadas</Badge></Row><Row title="Conexões SSH" description="Hosts e credenciais permanecem separados do Runtime local."><LinkButton to="hosts" onNavigate={onNavigate}>Ver hosts SSH</LinkButton></Row></Section>
+  </>;
+}
+
+const permissionRows = [
+  ["Microfone", "Áudio, ditado e transcrição.", "Solicitar microfone"],
+  ["Câmera", "Captura de imagem e dispositivos de vídeo.", "Solicitar câmera"],
+  ["Gravação de tela", "Capturas de janelas e inspeção visual.", "Revisar gravação de tela"],
+  ["Acessibilidade", "Inspeção e operação de interfaces.", "Revisar acessibilidade"],
+  ["Acesso a arquivos e disco", "Leitura de pastas além do contexto selecionado.", "Revisar acesso a arquivos"],
+  ["Automação", "Interação entre aplicativos e eventos do sistema.", "Revisar automação"],
+  ["Rede local", "Conexão a serviços e dispositivos na rede.", "Revisar rede local"],
+  ["USB e Bluetooth", "Dispositivos físicos e ferramentas de desenvolvimento.", "Revisar dispositivos"],
+] as const;
+
+function Permissions({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice title="Permissões pertencem ao sistema operacional">O snapshot atual não contém uma consulta nativa de permissões. “Não consultada” não significa permissão negada nem concedida. Abrir esta página não solicita acessos.</Notice>
+    <Section title="Acesso deste aplicativo"><div className="ref-permission-list">{permissionRows.map(([name, description, action]) => <Row key={name} title={name} description={description} icon="shield"><Badge>Não consultada</Badge><Unavailable label={action} reason="Consulta e abertura nativa indisponíveis." /></Row>)}</div></Section>
+    <details className="ref-help-details"><summary>Como revisar manualmente</summary><p>No macOS, revise Privacidade e Segurança nos Ajustes do Sistema. No Windows, consulte Privacidade e segurança nas Configurações. No Linux, verifique as permissões do ambiente gráfico e do empacotamento utilizado. Conceda somente os acessos necessários à ação desejada.</p></details>
+    <LinkButton to="computer-use" onNavigate={onNavigate}>Voltar ao uso do computador</LinkButton>
+  </>;
+}
+
+function Privacy({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Section title="Dados visíveis nestas configurações"><Row title="Credenciais e contas" icon="lock" description="Esta tela não solicita tokens, cookies, senhas nem chaves privadas."><Badge>Sem campos de segredo</Badge></Row><Row title="Contexto do Runtime" description="São apresentados estados e metadados limitados. Prompts, corpos de arquivos e configurações não são exportados aqui."><Badge>Somente metadados</Badge></Row><Row title="Projetos e preferências visuais" description="Atalhos de pastas e preferências existentes ficam no armazenamento local do Desktop."><LinkButton to="general" onNavigate={onNavigate}>Ver preferências locais</LinkButton></Row></Section>
+    <Section title="Telemetria"><Row title="Telemetria do Runtime" description="O snapshot desta versão não informa uma política configurável de telemetria. Não é possível inferir o estado do Runtime a partir desta tela."><Badge>Estado não informado</Badge></Row><Row title="Alterar envio de telemetria" description="Uma configuração sem efeito não será salva."><UnavailableSwitch label="Alterar envio de telemetria" reason="Contrato de configuração indisponível." /></Row></Section>
+    <Section title="Compartilhamento e exportação"><Row title="Exportar diagnósticos" description="A exportação precisa de revisão e redação dos dados antes de qualquer envio."><LinkButton to="diagnostics" onNavigate={onNavigate}>Revisar diagnósticos</LinkButton></Row><Row title="Apagar todos os dados" description="Nenhum cache, credencial ou arquivo do usuário é removido por estas configurações."><Unavailable label="Apagar dados" reason="Não há exclusão em massa neste painel." /></Row></Section>
+  </>;
+}
+
+function Advanced({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  return <>
+    <Section title="Compatibilidade"><Row title="Runtime informado" description={evidence.runtimeVersion + " · " + evidence.transport}><LinkButton to="diagnostics" onNavigate={onNavigate}>Abrir diagnóstico</LinkButton></Row><Row title="Compatibilidade HTTP/1.1" description="O protocolo de rede não é alterado por uma preferência sem contrato nativo."><UnavailableSwitch label="Compatibilidade HTTP/1.1" reason="Configuração de transporte indisponível." /></Row></Section>
+    <Section title="Rede"><Row title="Proxy HTTP" description="Nenhum proxy ou variável de ambiente é lido ou salvo aqui."><Badge>Não consultado</Badge></Row><details className="ref-help-details ref-help-inset"><summary>Configuração de proxy</summary><p>Um proxy pode conter credenciais e mudar o destino do tráfego. O Desktop ainda não oferece um plano validado para essa mudança, por isso não coleta um endereço ou senha.</p><Unavailable label="Salvar proxy" reason="Aplicação de proxy não disponível." /></details></Section>
+    <Section title="Consulta segura"><CommandCard id="version" /><CommandCard id="plan" /></Section>
+  </>;
+}
+
+function Experimental({ onNavigate }: { onNavigate: Navigate }) {
+  return <>
+    <Notice title="Experimental não significa habilitado">As superfícies abaixo dependem de contratos específicos. Nenhum recurso é ativado por visitar esta página e nenhum consentimento é ampliado.</Notice>
+    <div className="ref-feature-grid">{[
+      { title: "Plugins", description: "Catálogo de pacotes e limites de instalação por cliente.", icon: "apps", to: "plugins" },
+      { title: "Simplicio Mobile", description: "Pareamento, dispositivos e autenticação de transporte.", icon: "monitor", to: "mobile" },
+      { title: "Compartilhar skills", description: "Inventário e compartilhamento com revisão explícita.", icon: "spark", to: "share-skills" },
+      { title: "Emulador mobile", description: "Dispositivos de desenvolvimento e consultas nativas.", icon: "monitor", to: "emulator" },
+    ].map((feature) => <article className="ref-feature-card" key={feature.to}><Glyph name={feature.icon as GlyphName} size={23} /><h2>{feature.title}</h2><p>{feature.description}</p><button type="button" className="text-button" onClick={() => onNavigate(feature.to as View)}>Ver disponibilidade<Glyph name="arrow" size={16} /></button></article>)}</div>
+  </>;
+}
+
+const pluginPackages = [
+  { id: "simplicio", name: "Simplicio", description: "Runtime, MCP, ferramentas e skills para agentes compatíveis.", category: "Runtime e MCP" },
+  { id: "simplicio-loop", name: "Simplicio Loop", description: "Fluxos de tarefas e orquestração governada.", category: "Orquestração" },
+  { id: "simplicio-prompt", name: "Simplicio Prompt", description: "Preparação de contexto e contratos de prompt.", category: "Contexto" },
+  { id: "simplicio-sprint", name: "Simplicio Sprint", description: "Compatibilidade com fluxos de sprint do ecossistema.", category: "Fluxos" },
+  { id: "simplicio-hermes", name: "Simplicio Hermes", description: "Pacote de integração nativa com Hermes.", category: "Integrações" },
+];
+
+function Plugins({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Navigate }) {
+  const [query, setQuery] = useState("");
+  const [tab, setTab] = useState<"catalog" | "reported">("catalog");
+  const packages = pluginPackages.filter((plugin) => searchMatches(plugin.name + " " + plugin.description + " " + plugin.category, query));
+  const skills = evidence.skills.filter((skill) => searchMatches(skill, query));
+  return <>
+    <Notice title="Pacote instalado e MCP registrado são estados diferentes">O reparo de integrações configura MCP e hooks. Ele não comprova a instalação, atualização ou ativação de cada pacote nativo no seu agente ou IDE.</Notice>
+    <Section title="Pacotes e inventário" description="O catálogo público não é uma lista de pacotes instalados nesta máquina.">
+      <div className="ref-plugin-toolbar"><div className="segmented-control" role="group" aria-label="Origem do inventário de plugins"><button type="button" aria-pressed={tab === "catalog"} className={tab === "catalog" ? "active" : ""} onClick={() => setTab("catalog")}>Catálogo público</button><button type="button" aria-pressed={tab === "reported"} className={tab === "reported" ? "active" : ""} onClick={() => setTab("reported")}>Skills informadas</button></div><label className="ref-search"><Glyph name="search" size={17} /><input aria-label="Buscar plugins e skills" type="search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Buscar pacote ou categoria" maxLength={120} /></label></div>
+      {tab === "catalog" ? <div className="ref-plugin-grid">{packages.map((plugin) => <article className="ref-plugin-card" key={plugin.id}><div className="ref-plugin-title"><span className="ref-monogram"><Glyph name="apps" size={22} /></span><div><h3>{plugin.name}</h3><span>Ecossistema Simplicio</span></div></div><p>{plugin.description}</p><div className="ref-plugin-tags"><Badge>{plugin.category}</Badge><Badge>Instalação não verificada</Badge></div><Unavailable label={"Instalar " + plugin.name} reason="Falta um plano nativo por cliente." /></article>)}</div> : <div className="ref-reported-skills">{skills.map((skill, index) => <Row key={index} title={skill} icon="spark" description="Nome informado pelo Agent Plane; não comprova instalação do pacote."><Badge>Somente leitura</Badge></Row>)}</div>}
+      {!(tab === "catalog" ? packages.length : skills.length) && <div className="ref-empty"><Glyph name="search" size={24} /><h3>{query ? "Nenhum resultado neste filtro" : "Nenhuma skill informada nesta consulta"}</h3><p>{query ? "Tente outro nome ou categoria." : "O Desktop não preenche o inventário com pacotes de demonstração."}</p>{query && <button className="button button-secondary" type="button" onClick={() => setQuery("")}>Limpar busca</button>}</div>}
+    </Section>
+    <Section title="Instalação e verificação"><Row title="Configurar clientes MCP" description="Abra o plano existente, revise os alvos e confirme antes de aplicar."><LinkButton to="providers" onNavigate={onNavigate}>Revisar plano MCP</LinkButton></Row><CommandCard id="plugins" /></Section>
+    <details className="ref-help-details"><summary>Fontes e desenvolvimento</summary><p>Os pacotes são documentados no repositório público wesleysimplicio/simplicio. O instalador de terminal tenta instalar pacotes nos hosts detectados; isso é mais amplo que o reparo MCP. Nenhuma fonte, credencial ou pacote é adicionado ao abrir este painel.</p></details>
+  </>;
+}
+
+function Body({ view, evidence, onNavigate }: { view: ReferenceSettingsView; evidence: Evidence; onNavigate: Navigate }): ReactNode {
+  switch (view) {
+    case "provider-accounts": return <Accounts evidence={evidence} onNavigate={onNavigate} />;
+    case "orchestration": return <Orchestration evidence={evidence} onNavigate={onNavigate} />;
+    case "computer-use": return <Computer evidence={evidence} onNavigate={onNavigate} />;
+    case "voice": return <Voice onNavigate={onNavigate} />;
+    case "general-settings": return <General evidence={evidence} onNavigate={onNavigate} />;
+    case "integrations": return <Integrations onNavigate={onNavigate} />;
+    case "mobile": return <Mobile onNavigate={onNavigate} />;
+    case "artifacts": return <Artifacts evidence={evidence} onNavigate={onNavigate} />;
+    case "share-skills": return <Skills evidence={evidence} onNavigate={onNavigate} />;
+    case "git": return <Git onNavigate={onNavigate} />;
+    case "task-sources": return <TaskSources onNavigate={onNavigate} />;
+    case "terminal": return <Terminal onNavigate={onNavigate} />;
+    case "quick-commands": return <QuickCommands />;
+    case "browser": return <Browser onNavigate={onNavigate} />;
+    case "emulator": return <Emulator onNavigate={onNavigate} />;
+    case "floating": return <Floating onNavigate={onNavigate} />;
+    case "input": return <Input onNavigate={onNavigate} />;
+    case "notifications": return <Notifications onNavigate={onNavigate} />;
+    case "hosts": return <Hosts onNavigate={onNavigate} />;
+    case "servers": return <Servers evidence={evidence} onNavigate={onNavigate} />;
+    case "permissions": return <Permissions onNavigate={onNavigate} />;
+    case "privacy": return <Privacy onNavigate={onNavigate} />;
+    case "advanced": return <Advanced evidence={evidence} onNavigate={onNavigate} />;
+    case "experimental": return <Experimental onNavigate={onNavigate} />;
+    case "plugins": return <Plugins evidence={evidence} onNavigate={onNavigate} />;
+  }
+}
+
+export function ReferenceSettingsScreen({ view, snapshot, onNavigate, onRefresh, busy = false }: ReferenceSettingsProps) {
+  const screen = REFERENCE_SCREENS.find((item) => item.id === view)!;
+  const evidence = createReferenceSettingsEvidence(snapshot);
+  return <div className="page reference-settings-page" data-settings-view={view}>
+    <header className="ref-page-heading"><div><span className="ref-eyebrow">{screen.group}</span><h1>{screen.label}</h1><p>{screen.description}</p></div>{onRefresh && <button type="button" className="button button-secondary" onClick={onRefresh} disabled={busy} aria-label="Atualizar consulta do Runtime"><Glyph name="refresh" size={16} />{busy ? "Consultando…" : "Atualizar consulta"}</button>}</header>
+    {snapshot.source === "preview" && <div className="ref-preview-note" role="note"><Glyph name="attention" size={17} /><span>Prévia visual. Instalação, contas, permissões e conexões deste computador não foram verificadas.</span></div>}
+    <Body key={view} view={view} evidence={evidence} onNavigate={onNavigate} />
+    <footer className="ref-evidence-footer"><Glyph name="lock" size={15} /><p>{evidence.source === "runtime" ? "Metadados da consulta ao Runtime: " + evidence.observedAt + ". Abrir esta tela não renova a consulta nem autoriza ações." : "Nenhum estado da prévia é usado como comprovação de conexão ou instalação."}</p></footer>
+  </div>;
+}

--- a/apps/desktop/src/screens/SetupScreen.tsx
+++ b/apps/desktop/src/screens/SetupScreen.tsx
@@ -1,16 +1,19 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { planDesktopIntegrations, refreshDesktopSnapshot } from "../bridge";
 import { Brand, Glyph } from "../components/Brand";
 import type { DesktopSnapshot } from "../contracts";
 import { integrationTargetsVerified, type IntegrationPlan } from "../integration_setup";
+import type { InstallFailureRecovery } from "../install_failures";
 import { canConfigureRuntime, setupStages, type SetupPhase, type SetupStep } from "../setup_flow";
 
-export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onApply, onFinish, onDiagnostics }: {
+export function SetupScreen({ snapshot, busy, applicationError, applicationRecovery, onSnapshot, onApply, onVerificationFailure, onFinish, onDiagnostics }: {
   snapshot: DesktopSnapshot;
   busy: boolean;
   applicationError: string | null;
+  applicationRecovery?: InstallFailureRecovery;
   onSnapshot: (snapshot: DesktopSnapshot) => void;
   onApply: (digest: string) => Promise<boolean>;
+  onVerificationFailure?: () => void;
   onFinish: () => void;
   onDiagnostics: () => void;
 }) {
@@ -23,14 +26,47 @@ export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onAp
   const [showDetails, setShowDetails] = useState(false);
   const [failure, setFailure] = useState("");
   const operationLock = useRef(false);
+  const content = useRef<HTMLElement>(null);
+  const headingElement = useRef<HTMLHeadingElement>(null);
+  const detailsElement = useRef<HTMLElement>(null);
+  const reviewHeading = useRef<HTMLHeadingElement>(null);
   const pending = ["checking", "planning", "installing", "verifying"].includes(phase);
   const locked = busy || pending;
   const preview = snapshot.source === "preview";
+  const recovery = phase === "failed" && failedStep === 4 && !preview ? "refresh"
+    : applicationRecovery ?? (phase === "failed" && failedStep === 3 && !preview ? "reconcile" : undefined);
+  const reviewBlocked = recovery !== undefined && recovery !== "review";
+  const recoveryGuidance = recovery === "wait"
+    ? "Não inicie outra aplicação enquanto a instalação estiver em andamento. Consulte o diagnóstico para acompanhar o estado."
+    : recovery === "refresh"
+      ? "Atualize somente o diagnóstico para conferir o resultado. Uma consulta de estado não reinstala o Simplicio nem autoriza outra aplicação."
+      : "Novas aplicações estão bloqueadas nesta sessão. Consulte o diagnóstico para esclarecer o resultado; atualizar ou reiniciar o app não confirma a conclusão.";
   const steps = setupStages(phase, failedStep);
   const completed = steps.filter((step) => step.state === "complete").length;
+  const currentStage = steps.find((step) => step.state === "running" || step.state === "failed");
+
+  useEffect(() => {
+    if (applicationRecovery === "refresh" && phase === "failed" && failedStep === 3) {
+      setApplicationConfirmed(true);
+      setFailedStep(4);
+    }
+  }, [applicationRecovery, phase, failedStep]);
+
+  useEffect(() => { if (reviewBlocked) setConfirmed(false); }, [reviewBlocked]);
+
+  useEffect(() => {
+    content.current?.scrollTo({ top: 0 });
+    if (phase === "review" || phase === "complete" || phase === "failed") {
+      headingElement.current?.focus({ preventScroll: true });
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (showDetails) detailsElement.current?.scrollIntoView({ block: "nearest" });
+  }, [showDetails]);
 
   async function prepare() {
-    if (operationLock.current || busy) return;
+    if (operationLock.current || busy || reviewBlocked) return;
     operationLock.current = true;
     setPlan(null); setConfirmed(false); setFailure(""); setPhase("checking");
     setApplicationConfirmed(false); setVerifiedPlan(null);
@@ -52,7 +88,7 @@ export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onAp
   }
 
   async function apply() {
-    if (operationLock.current || busy || phase !== "review" || !plan || !confirmed) return;
+    if (operationLock.current || busy || reviewBlocked || phase !== "review" || !plan || !confirmed) return;
     operationLock.current = true;
     const reviewed = plan;
     const digest = reviewed.planDigest;
@@ -72,6 +108,7 @@ export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onAp
       setPhase("complete");
     } catch {
       setFailedStep(currentStep); setPhase("failed");
+      if (currentStep === 4 && !preview) onVerificationFailure?.();
       setFailure(currentStep === 3 ? "A instalação não foi confirmada. Pode haver alterações parciais. Revise um novo plano antes de tentar novamente."
         : preview ? "A demonstração não confirmou os destinos do plano revisado. Nenhum arquivo foi alterado."
           : "O plano foi aplicado, mas a verificação final falhou. Os destinos do plano revisado não foram confirmados sem mudanças pendentes. Consulte o diagnóstico; nenhuma reinstalação foi iniciada.");
@@ -87,40 +124,54 @@ export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onAp
 
   return <div className={`setup-layout ${phase === "welcome" ? "setup-intro" : ""}`}>
     <header className="entry-header"><Brand /><span className="setup-context">{preview ? "Demonstração · sem instalação real" : "Instalação guiada"}</span></header>
-    <main className="setup-main">
+    {phase !== "welcome" && <div className="setup-status-header">
+      <div className="setup-status-inner">
+        <div className="setup-progress-caption" role="status" aria-atomic="true">
+          <span className={"setup-current-stage" + (phase === "failed" ? " is-failed" : "")}>{pending ? <span className="setup-spinner" aria-hidden="true" /> : <Glyph name={phase === "failed" ? "attention" : phase === "complete" ? "check" : "shield"} size={17} />}
+            {currentStage?.label ?? (phase === "review" ? "Aguardando sua confirmação" : "Configuração verificada")}
+          </span>
+          <span>{completed} de 4 etapas concluídas</span>
+        </div>
+        <progress className="setup-progress" value={completed} max={4} aria-label="Etapas da configuração concluídas" />
+      </div>
+    </div>}
+    <main className="setup-main" ref={content}>
       {phase === "welcome" ? <div className="setup-welcome">
         <img src="/icon.png" width="72" height="72" alt="" />
         <span className="setup-wordmark">SIMPLICIO</span>
         <h1>{heading}</h1>
         <p>Seu Runtime e seus apps,<br />trabalhando juntos.</p>
-        <button className="button entry-primary" type="button" disabled={busy} onClick={() => void prepare()}>Configurar Simplicio<Glyph name="arrow" size={18} /></button>
+        <button className="button entry-primary" type="button" disabled={busy || reviewBlocked} onClick={() => void prepare()}>Configurar Simplicio<Glyph name="arrow" size={18} /></button>
+        {reviewBlocked && <>
+          <div className="setup-failure setup-recovery-note" role="alert"><strong>{applicationError || (recovery === "refresh" ? "A aplicação já foi confirmada pelo Runtime." : recovery === "wait" ? "Aguarde a instalação em andamento." : "O resultado da instalação ainda precisa ser esclarecido.")}</strong><p>{recoveryGuidance}</p></div>
+          <button className="button button-secondary" type="button" disabled={busy} onClick={onDiagnostics}>{recovery === "refresh" ? "Atualizar diagnóstico" : "Abrir diagnóstico"}</button>
+        </>}
         <button className="text-button" type="button" disabled={busy} onClick={onFinish}>Agora não</button>
         <span className="entry-caption">Primeiro, vamos conferir o que já existe. Nenhum arquivo será alterado sem sua confirmação.</span>
-      </div> : <>
+      </div> : <div className="setup-body">
         <div className={`setup-heading ${phase === "failed" ? "is-failed" : ""}`}>
           <span className="eyebrow">{phase === "complete" ? "Próximo passo: abrir seus clientes" : "Configure uma vez. Use nos seus apps."}</span>
-          <h1 aria-live="polite">{heading}</h1>
+          <h1 ref={headingElement} tabIndex={-1}>{heading}</h1>
           <p>{phase === "review" ? `${plan?.changes.filter((row) => row.changed).length ?? 0} alterações propostas. Revise os destinos abaixo antes de aplicar.`
             : phase === "complete" ? "Abra uma nova sessão nos clientes para confirmar o handshake MCP. Registro não significa conexão ativa."
               : "O Runtime que acompanha o app gerencia a instalação local e o registro nos clientes detectados."}</p>
         </div>
-        <div className="setup-progress-caption"><span>{completed} de 4 etapas concluídas</span><span>{phase === "review" ? "Aguardando sua confirmação" : phase === "failed" ? "Revisão necessária" : phase === "complete" ? "Verificação recebida" : "Em andamento"}</span></div>
-        <progress className="setup-progress" value={completed} max={4} aria-label="Etapas da configuração concluídas" />
         <ol className="setup-steps" aria-label="Etapas da instalação">{steps.map((step, index) => <li key={step.label} data-state={step.state} aria-current={step.state === "running" ? "step" : undefined}>
           <span className="setup-step-icon" aria-hidden="true">{step.state === "running" ? <span className="setup-spinner" /> : step.state === "complete" ? <Glyph name="check" size={16} /> : step.state === "failed" ? <Glyph name="close" size={16} /> : index + 1}</span>
           <div><strong>{step.label}</strong><p>{step.detail}</p></div>
           <span className="setup-step-status">{({ pending: "Pendente", running: "Em andamento", complete: "Concluída", failed: "Falhou" })[step.state]}</span>
         </li>)}</ol>
         {phase === "review" && plan && <section className="setup-review" aria-label="Plano de instalação">
-          <h2>O que será configurado</h2>
+          <h2 ref={reviewHeading} tabIndex={-1}>O que será configurado</h2>
           <ul>{plan.changes.map((row, index) => <li key={`${row.label}-${index}`}><span>{row.label}</span><strong>{row.changed ? row.exists ? "Atualizar" : "Criar" : "Já configurado"}</strong></li>)}</ul>
           {plan.changes.length === 0 && <p>Nenhuma mudança foi proposta pelo Runtime.</p>}
           <p>MCP e hooks dos clientes detectados, com backups. Plugins de marketplace e permissões dependem de cada host. Este fluxo não altera o PATH nem inicia um serviço global.</p>
-          <label className="setup-consent"><input type="checkbox" checked={confirmed} disabled={locked} onChange={(event) => setConfirmed(event.target.checked)} />Autorizo o Runtime a aplicar este plano de instalação e registro.</label>
+          <label className="setup-consent"><input type="checkbox" checked={confirmed} disabled={locked || reviewBlocked} onChange={(event) => setConfirmed(event.target.checked)} />Autorizo o Runtime a aplicar este plano de instalação e registro.</label>
         </section>}
-        {phase === "failed" && <div className="setup-failure" role="alert"><strong>{failedStep === 3 && applicationError ? applicationError : failure}</strong><p>Revisar novamente apenas prepara um novo plano. Nenhuma instalação será repetida automaticamente.</p></div>}
+        {phase === "review" && reviewBlocked && <div className="setup-failure" role="alert"><strong>{applicationError || "A aplicação não está disponível neste estado."}</strong><p>{recoveryGuidance}</p></div>}
+        {phase === "failed" && <div className="setup-failure" role="alert"><strong>{applicationError && (failedStep === 3 || applicationRecovery === "refresh") ? applicationError : failure}</strong><p>{reviewBlocked ? recoveryGuidance : "Revisar novamente apenas prepara um novo plano. Nenhuma instalação será repetida automaticamente."}</p></div>}
         {phase === "complete" && <div className="setup-success" role="status"><Glyph name="check" size={20} /><p>{preview ? "Esta é uma demonstração. Nenhum arquivo foi alterado." : "O Runtime confirmou a aplicação, e uma nova leitura confirmou os destinos preexistentes ou alterados do plano revisado sem mudanças pendentes. A conexão de cada cliente ainda depende do handshake."}</p></div>}
-        {showDetails && <section className="setup-details" id="setup-details" aria-label="Detalhes da configuração">
+        {showDetails && <section ref={detailsElement} className="setup-details" id="setup-details" aria-label="Detalhes da configuração">
           <p>Origem: {preview ? "prévia no navegador" : "Runtime local"} · Versão {snapshot.runtime.version}</p>
           <p>Estado do Runtime: {snapshot.runtime.state}. Cada etapa só é concluída após a resposta correspondente; este painel não estima tempos ou downloads.</p>
           {plan && <p className="setup-digest">Plano revisado: <code>{plan.planDigest}</code></p>}
@@ -128,18 +179,23 @@ export function SetupScreen({ snapshot, busy, applicationError, onSnapshot, onAp
           {verifiedPlan && <p className="setup-digest">Plano após a aplicação: <code>{verifiedPlan.planDigest}</code></p>}
           <p>Senhas, tokens de autenticação, caminhos pessoais e conteúdo de arquivos não são exibidos neste painel.</p>
         </section>}
+      </div>}
+    </main>
+    {phase !== "welcome" && <div className="setup-actionbar"><div className="setup-footer-inner">
+        {pending && <p className="setup-pending-note">{phase === "installing" ? "Aguarde a resposta do Runtime. Esta operação não oferece cancelamento seguro depois de iniciada." : "Aguardando a resposta do Runtime local…"}</p>}
         <div className="setup-controls">
           <button className="text-button" type="button" aria-expanded={showDetails} aria-controls="setup-details" onClick={() => setShowDetails((value) => !value)}><Glyph name="chevron" size={14} />{showDetails ? "Ocultar detalhes" : "Mostrar detalhes"}</button>
-          <div>{phase === "review" && <button className="button button-primary" type="button" disabled={locked || !confirmed} onClick={() => void apply()}>{preview ? "Simular configuração" : "Instalar e conectar"}<Glyph name="arrow" size={16} /></button>}
-            {phase === "failed" && <button className="button button-primary" type="button" disabled={locked} onClick={() => void prepare()}>Revisar novamente</button>}
+          <div>{phase === "review" && <>
+            <button className="button button-secondary" type="button" onClick={() => { reviewHeading.current?.scrollIntoView({ block: "start" }); reviewHeading.current?.focus({ preventScroll: true }); }}>Revisar destinos</button>
+            <button className="button button-primary" type="button" disabled={locked || reviewBlocked || !confirmed} onClick={() => void apply()}>{preview ? "Simular configuração" : "Instalar e conectar"}<Glyph name="arrow" size={16} /></button>
+          </>}
+            {phase === "failed" && !reviewBlocked && <button className="button button-primary" type="button" disabled={locked} onClick={() => void prepare()}>Revisar novamente</button>}
             {phase === "complete" && <button className="button button-primary" type="button" onClick={onFinish}>Abrir Simplicio<Glyph name="arrow" size={16} /></button>}
-            {phase === "failed" && <button className="button button-secondary" type="button" disabled={locked} onClick={onDiagnostics}>Abrir diagnóstico</button>}
+            {(phase === "failed" || reviewBlocked) && <button className="button button-secondary" type="button" disabled={locked} onClick={onDiagnostics}>{recovery === "refresh" ? "Atualizar diagnóstico" : "Abrir diagnóstico"}</button>}
             {phase !== "complete" && <button className="button button-secondary" type="button" disabled={locked} onClick={onFinish}>Voltar ao app</button>}
           </div>
         </div>
-        {pending && <p className="setup-pending-note" role="status">{phase === "installing" ? "Aguarde a resposta do Runtime. Esta operação não oferece cancelamento seguro depois de iniciada." : "Aguardando a resposta do Runtime local…"}</p>}
-      </>}
-    </main>
+    </div></div>}
     <footer className="entry-footer"><Glyph name="shield" size={14} />Runtime local · Configuração revisada · Evidência verificável</footer>
   </div>;
 }

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { Glyph } from "../components/Brand";
+import { ContextSavings } from "../components/ContextSavings";
+import { TokenProjects } from "../components/TokenProjects";
 import { exportDesktopTokenReport, loadDesktopTokenReport } from "../bridge";
 import { TOKEN_PERIODS, tokenErrorMessage, tokenExportErrorMessage, type TokenPeriod, type TokenQuery, type TokenUsageReport } from "../token_usage";
 
 export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: string }) {
   const [period, setPeriod] = useState<TokenPeriod>("1m");
   const [repoPath, setRepoPath] = useState(initialRepoPath);
+  const [allowAutoSelect, setAllowAutoSelect] = useState(!initialRepoPath);
+  const [autoContext, setAutoContext] = useState(Boolean(initialRepoPath));
   const [sessionId, setSessionId] = useState("");
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
@@ -49,10 +53,10 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
     setExportError(null);
   }
 
-  function submit() {
+  function submit(path = repoPath) {
     if (exportLock.current) return;
     const query: TokenQuery = { timezoneOffsetSeconds: -new Date().getTimezoneOffset() * 60 };
-    if (repoPath.trim()) query.repoPath = repoPath.trim();
+    if (path.trim()) query.repoPath = path.trim();
     if (sessionId.trim()) query.sessionId = sessionId.trim();
     if (period === "custom") {
       query.fromEpoch = Math.floor(new Date(from).getTime() / 1000);
@@ -94,9 +98,13 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
       <section className="page-heading">
         <div><span className="eyebrow">Recibos do Runtime</span><h1>Relatório de tokens</h1><p>Uso registrado por período e sessão. Economia de contexto não é consumo faturado.</p></div>
       </section>
+      <TokenProjects repoPath={repoPath} allowAutoSelect={allowAutoSelect} onSelect={(path) => {
+        if (exportLock.current) return;
+        setAllowAutoSelect(false); setAutoContext(true); invalidate(); setRepoPath(path); submit(path);
+      }} />
       <form className="panel token-query" onSubmit={(event) => { event.preventDefault(); submit(); }}>
         <label><span id="token-period-label">Período</span><span className="token-select"><select aria-labelledby="token-period-label" value={period} disabled={exporting} onChange={(event) => { setPeriod(event.target.value as TokenPeriod); if (event.target.value === "custom") invalidate(); }}>{TOKEN_PERIODS.map(([id, label]) => <option value={id} key={id}>{label}</option>)}</select></span></label>
-        <label>Pasta do projeto (opcional)<input value={repoPath} maxLength={4096} disabled={exporting} onChange={(event) => { invalidate(); setRepoPath(event.target.value); }} placeholder="Vazio: pasta pessoal" autoComplete="off" spellCheck={false} /></label>
+        <label>Pasta do projeto (opcional)<input value={repoPath} maxLength={4096} disabled={exporting} onChange={(event) => { setAllowAutoSelect(false); setAutoContext(false); invalidate(); setRepoPath(event.target.value); }} placeholder="Vazio: pasta pessoal" autoComplete="off" spellCheck={false} /></label>
         <label>Sessão (opcional)<input value={sessionId} maxLength={256} disabled={exporting} onChange={(event) => { invalidate(); setSessionId(event.target.value); }} placeholder="Todas as sessões do ledger" autoComplete="off" /></label>
         {period === "custom" && <><label>Início<input type="datetime-local" value={from} required disabled={exporting} onChange={(event) => { invalidate(); setFrom(event.target.value); }} /></label><label>Fim (exclusivo)<input type="datetime-local" value={to} required disabled={exporting} onChange={(event) => { invalidate(); setTo(event.target.value); }} /></label></>}
         <button className="button button-primary" type="submit" disabled={busy || exporting}><Glyph name="refresh" size={17} />{busy ? "Consultando…" : "Consultar uso"}</button>
@@ -122,6 +130,7 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
           {exportError && <p role="alert">{exportError}</p>}
         </section>
       </>}
+      <ContextSavings repoPath={repoPath} autoLoad={autoContext} />
     </div>
   );
 }

--- a/apps/desktop/src/screens/WorkbenchHome.tsx
+++ b/apps/desktop/src/screens/WorkbenchHome.tsx
@@ -41,7 +41,7 @@ export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, o
       <div className="welcome-shortcuts"><span><kbd>⌘ / Ctrl K</kbd> Buscar</span><button type="button" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={14} />Todos os atalhos</button></div>
     </div>
     <section className="welcome-resources" aria-label="Acesso rápido">
-      <button type="button" onClick={() => onViewChange("agents")}><Glyph name="teams" size={20} /><span><strong>Agentes e IDEs</strong><small>{status.installed} detectados · {status.connected} MCP ativos</small></span><Glyph name="arrow" size={16} /></button>
+      <button type="button" onClick={() => onViewChange("agents")}><Glyph name="teams" size={20} /><span><strong>Agentes e IDEs</strong><small>{status.installed} detectados · {status.connected} MCP confirmados</small></span><Glyph name="arrow" size={16} /></button>
       <button type="button" onClick={() => onTokens()}><Glyph name="activity" size={20} /><span><strong>Tokens e economia</strong><small>Consulte uso, períodos e recibos</small></span><Glyph name="arrow" size={16} /></button>
       <button type="button" onClick={() => onViewChange("diagnostics")}><Glyph name="shield" size={20} /><span><strong>Runtime e diagnóstico</strong><small>{status.label} · v{snapshot.runtime.version || "—"}</small></span><Glyph name="arrow" size={16} /></button>
     </section>

--- a/apps/desktop/src/token_usage.ts
+++ b/apps/desktop/src/token_usage.ts
@@ -108,6 +108,7 @@ export function tokenExportErrorMessage(error: unknown): string {
 
 export function tokenErrorMessage(error: unknown): string {
   const reason = error instanceof Error ? error.message : String(error);
+  if (reason === "desktop_access_unverified") return "O Runtime não confirmou o acesso da conta nesta consulta. Verifique a conta e tente novamente; nenhuma assinatura foi considerada inativa.";
   if (reason.includes("token_ledger_unavailable")) return "Nenhum ledger de uso encontrado nesta pasta. Selecione o projeto que recebeu os eventos do Runtime; ausência de telemetria não significa consumo zero.";
   if (reason.includes("preview_no_runtime")) return "A demonstração não consulta seu uso. Abra o app instalado para ler os recibos do Runtime.";
   if (reason.includes("token_query_invalid")) return "Confira a pasta absoluta, a sessão e as datas. O início deve ser anterior ao fim.";

--- a/apps/desktop/src/workbench.css
+++ b/apps/desktop/src/workbench.css
@@ -24,13 +24,26 @@
   font-size: 13px;
 }
 .workbench.sidebar-collapsed { --sidebar-width: 60px; }
+.workbench.sidebar-overlay { --sidebar-width: 60px; position: relative; }
+.workbench-skip { position: fixed; top: 8px; left: 12px; z-index: 50; transform: translateY(-160%); padding: 12px 16px; background: white; border: 1px solid var(--green-dark); border-radius: 7px; color: var(--green-dark); text-decoration: none; }
+.workbench-skip:focus { transform: translateY(0); }
+.sidebar-scrim { position: absolute; inset: 0; z-index: 30; width: 100%; height: 100%; padding: 0; border: 0; background: #26332d4d; cursor: pointer; }
+.workbench.sidebar-overlay .sidebar { position: absolute; inset: 0 auto 0 0; z-index: 31; width: min(296px, calc(100% - 56px)); height: 100%; background: white; box-shadow: 12px 0 40px #17251d1f; }
+.workbench.sidebar-overlay .sidebar .nav-item { min-height: 44px; }
+.sidebar-close { margin-left: auto; flex-shrink: 0; min-width: 44px; min-height: 44px; }
 .workbench .sidebar {
   grid-column: 1;
   grid-row: 1;
   min-height: 0;
   padding: 0;
   overflow: hidden;
+  border-top: 0;
+  border-right: 1px solid var(--line-soft);
 }
+.workbench:not(.sidebar-collapsed) .sidebar .brand-copy { display: flex; }
+.workbench:not(.sidebar-collapsed) .nav-caption, .workbench:not(.sidebar-collapsed) .nav-item > span { display: block; }
+.workbench:not(.sidebar-collapsed) .nav-item > .project-nav-copy { display: grid; }
+.workbench:not(.sidebar-collapsed) .nav-item { justify-content: flex-start; }
 .workbench .sidebar-heading {
   display: flex;
   align-items: center;
@@ -87,7 +100,7 @@
 .icon-button:disabled { opacity: .32; cursor: default; }
 .toolbar-separator { width: 1px; height: 17px; background: var(--line); margin: 0 5px; }
 .workbench .topbar-path { flex: 1; display: flex; align-items: center; gap: 10px; font-size: 12px; color: var(--muted-soft); overflow: hidden; }
-.workbench .topbar-path strong { color: #48515b; min-width: 0; font-weight: 500; }
+.workbench .topbar-path strong { color: #48515b; min-width: 0; font-weight: 500; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .workbench .topbar-path > span { flex: 0 0 auto; }
 .workbench .topbar-actions { gap: 12px; }
 .workbench .profile-button { border-color: #d7e7de; background: #edf5f0; color: var(--green-dark); width: 28px; height: 28px; border-radius: 50%; }
@@ -114,9 +127,10 @@
 .workbench-status button:hover { color: var(--ink); background: #eff1f3; }
 .workbench-status .status-dot { height: 6px; width: 6px; box-shadow: none; }
 .status-version { color: var(--muted-soft); }
+.status-registrations { color: var(--muted-soft); }
 .status-spacer { flex: 1; }
 .status-host { display: flex; align-items: center; gap: 6px; white-space: nowrap; }
-.workbench .preview-badge { min-height: 19px; background: #fff8e7; color: #8e7028; border-color: #eadbad; font-size: 9px; }
+.workbench .preview-badge { display: inline-flex; min-height: 19px; background: #fff8e7; color: #8e7028; border-color: #eadbad; font-size: 9px; }
 .workbench-welcome { min-height: 100%; max-width: 960px; margin: 0 auto; padding: 40px 40px 22px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 36px; }
 .welcome-center { text-align: center; padding: 18px 0 6px; }
 .welcome-mark { height: 76px; width: 76px; object-fit: cover; border: 1px solid #e2e6e5; border-radius: 20px; display: block; margin: 0 auto 24px; box-shadow: 0 3px 14px #22372c0b; }
@@ -223,12 +237,20 @@
 .project-boundary p { max-width: 640px; font-size: 13px; color: var(--muted); line-height: 1.8; }
 .project-remove { margin-top: 40px; display: flex; flex-wrap: wrap; gap: 12px; }
 .project-remove p { width: 100%; margin: 0; font-size: 12px; color: var(--muted); }
-.project-dialog { width: min(500px,calc(100vw - 32px)); padding: 28px; border: 1px solid var(--line); border-radius: 16px; box-shadow: 0 20px 70px #17251d29; color: var(--ink); background: white; }
+.project-dialog { width: min(500px,calc(100vw - 32px)); max-height: calc(100dvh - 32px); overflow: auto; padding: 28px; border: 1px solid var(--line); border-radius: 16px; box-shadow: 0 20px 70px #17251d29; color: var(--ink); background: white; }
 .project-dialog::backdrop { background: #26332d4d; backdrop-filter: blur(2px); }
 .dialog-heading { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
 .project-emblem { height: 44px; width: 44px; display: grid; place-items: center; border: 1px solid #dce9e1; border-radius: 11px; background: #edf6f1; color: var(--green-dark); }
 .project-dialog h2 { font-size: 22px; letter-spacing: -.025em; margin: 0 0 10px; }
 .project-dialog p { font-size: 13px; line-height: 1.7; color: var(--muted); margin-bottom: 20px; }
+.project-dialog .button { min-height: 44px; border-radius: 8px; font-size: 12px; font-weight: 550; }
+.project-dialog .button-secondary { background: white; color: #454e58; border-color: #dce1e5; }
+.project-dialog .button-primary { background: #24694d; color: white; border-color: #24694d; }
+.project-dialog .project-picker { width: 100%; gap: 9px; }
+.project-dialog .project-path-alternative { display: flex; align-items: center; gap: 12px; margin: 18px 0; font-size: 11px; }
+.project-path-alternative::before, .project-path-alternative::after { content: ""; flex: 1; height: 1px; background: var(--line-soft); }
+.project-dialog .project-chosen-note { display: flex; align-items: flex-start; gap: 8px; margin: 12px 0 0; color: var(--green-dark); font-size: 11px; }
+.project-chosen-note > .glyph { flex: 0 0 auto; margin-top: 2px; }
 .workbench-field { display: flex; flex-direction: column; gap: 9px; font-size: 12px; color: #48554d; font-weight: 550; }
 .workbench-field input { width: 100%; min-width: 0; padding: 12px; border: 1px solid #ccd5ce; border-radius: 7px; color: var(--ink); background: white; font: 11px/1.5 var(--mono); }
 .project-dialog .field-hint { margin: 9px 0 0; font-size: 11px; }
@@ -283,11 +305,11 @@
   .preference-row > div:first-child { flex-basis: 60%; }
   .provider-row-detail { padding-left: 20px; }
   .provider-row-detail dl { grid-template-columns: minmax(0,1fr); }
-  .status-host { display: none; }
+  .status-host, .status-registrations { display: none; }
 }
 @media (max-width: 600px) {
   .workbench { --sidebar-width: 190px; }
-  .workbench.sidebar-collapsed { --sidebar-width: 52px; }
+  .workbench.sidebar-collapsed, .workbench.sidebar-overlay { --sidebar-width: 52px; }
   .workbench .sidebar .nav-item { font-size: 12px; }
   .workbench .page, .workbench-welcome { padding: 24px 16px; }
   .workbench .page-heading h1 { font-size: 24px; }
@@ -367,20 +389,32 @@
 .entry-footer { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 32px; font-size: 10px; line-height: 1.7; color: var(--muted); text-align: center; padding-top: 12px; }
 .entry-footer .glyph { flex: 0 0 auto; }
 .setup-context { color: var(--muted); font-size: 11px; text-align: right; line-height: 1.6; }
-.setup-main { width: min(620px, 100%); min-width: 0; flex: 1; margin: 0 auto; padding: 42px 0 32px; }
+.setup-layout { padding: 0; overflow: hidden; }
+.setup-layout > .entry-header { min-height: 72px; padding: 16px 32px; border-bottom: 1px solid var(--line-soft); }
+.setup-main { width: 100%; min-width: 0; min-height: 0; flex: 1; margin: 0; padding: 0; overflow: auto; overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: #cdd2d8 transparent; }
+.setup-body, .setup-status-inner, .setup-footer-inner { width: min(860px, 100%); margin: 0 auto; padding: 24px 40px; }
+.setup-status-header { flex: 0 0 auto; border-bottom: 1px solid var(--line-soft); background: white; }
+.setup-status-inner { padding-top: 19px; padding-bottom: 20px; }
+.setup-current-stage { display: inline-flex; align-items: center; gap: 10px; min-width: 0; color: var(--ink); font-weight: 500; }
+.setup-current-stage > .glyph { flex-shrink: 0; color: var(--green-dark); }
+.setup-current-stage.is-failed > .glyph { color: #943f32; }
+.setup-actionbar { flex: 0 0 auto; background: white; border-top: 1px solid var(--line); box-shadow: 0 -8px 22px #202e2604; }
+.setup-footer-inner { padding-top: 12px; padding-bottom: 12px; }
+.setup-layout > .entry-footer { min-height: 36px; padding: 6px 24px; background: #fafbfb; border-top: 1px solid var(--line-soft); }
 .setup-intro .setup-main { display: flex; align-items: center; }
-.setup-welcome { width: 100%; display: flex; flex-direction: column; align-items: center; text-align: center; }
+.setup-welcome { width: min(620px, 100%); margin: auto; padding: 40px 24px; display: flex; flex-direction: column; align-items: center; text-align: center; }
 .setup-welcome > img { border-radius: 18px; margin-bottom: 18px; }
-.setup-wordmark { font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif; color: #245c42; font-size: clamp(36px, 6vw, 58px); letter-spacing: .035em; font-weight: 550; margin-bottom: 22px; }
+.setup-wordmark { font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif; color: #245c42; font-size: clamp(48px, 8vw, 88px); line-height: 1.1; letter-spacing: .015em; font-weight: 550; margin-bottom: 24px; }
 .setup-welcome h1 { font-family: inherit; font-size: 18px; font-weight: 550; letter-spacing: -.025em; margin: 0 0 12px; color: var(--ink); }
 .setup-welcome > p { font-size: 16px; color: var(--muted); line-height: 1.7; margin: 0 0 30px; }
 .setup-welcome > .text-button { font-size: 12px; font-weight: 500; min-height: 44px; padding: 0 18px; margin-top: 7px; }
 .setup-welcome > .entry-caption { max-width: 390px; margin-top: 16px; }
 .setup-heading > .eyebrow { font-size: 10px; display: block; margin-bottom: 14px; color: var(--muted); letter-spacing: .08em; }
 .setup-heading h1 { text-align: left; font-size: clamp(29px, 3.5vw, 39px); margin: 0 0 14px; }
-.setup-heading > p { font-size: 13px; line-height: 1.8; margin: 0 0 28px; color: var(--muted); max-width: 560px; }
+.setup-heading > p { font-size: 13px; line-height: 1.8; margin: 0 0 20px; color: var(--muted); max-width: 640px; }
 .setup-heading.is-failed h1 { color: #943f32; }
-.setup-progress-caption { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-bottom: 11px; color: var(--muted); font-size: 11px; line-height: 1.6; }
+.setup-progress-caption { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-bottom: 13px; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.setup-progress-caption > span:last-child { white-space: nowrap; }
 .setup-progress { width: 100%; height: 4px; display: block; border: 0; border-radius: 6px; appearance: none; background: #edf0ee; accent-color: var(--green-dark); overflow: hidden; }
 .setup-progress::-webkit-progress-bar { background: #edf0ee; border-radius: 6px; }
 .setup-progress::-webkit-progress-value { background: #387c56; border-radius: 6px; }
@@ -410,6 +444,7 @@
 .setup-failure { background: #fff7f4; border: 1px solid #edd7cf; padding: 20px; border-radius: 10px; color: #8d4835; margin-bottom: 24px; }
 .setup-failure strong { font-size: 13px; font-weight: 550; line-height: 1.8; }
 .setup-failure p { font-size: 12px; line-height: 1.8; margin: 12px 0 0; }
+.setup-welcome .setup-recovery-note { text-align: left; margin: 22px 0 16px; }
 .setup-success { display: flex; align-items: flex-start; gap: 13px; padding: 18px 20px; background: #f2f8f3; border: 1px solid #dceade; border-radius: 10px; margin-bottom: 24px; color: var(--green-dark); }
 .setup-success > .glyph { flex: 0 0 auto; margin-top: 2px; }
 .setup-success p { font-size: 12px; line-height: 1.8; margin: 0; }
@@ -417,24 +452,29 @@
 .setup-details p { color: var(--muted); font-size: 11px; line-height: 1.8; margin: 0 0 10px; overflow-wrap: anywhere; }
 .setup-details p:last-child { margin-bottom: 0; }
 .setup-digest code { font-size: 10px; overflow-wrap: anywhere; }
-.setup-controls { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; padding-top: 18px; border-top: 1px solid var(--line-soft); }
+.setup-controls { display: flex; justify-content: space-between; align-items: center; gap: 16px; }
 .setup-controls > .text-button { min-height: 44px; flex: 0 0 auto; font-weight: 500; color: var(--muted); }
 .setup-controls > div { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
 .setup-layout .button-primary { background: #244f3a; color: white; border-color: #244f3a; font-size: 12px; font-weight: 500; }
 .setup-layout .button-primary:hover { background: #1b422e; }
 .setup-layout .button-secondary { font-size: 12px; font-weight: 500; }
-.setup-pending-note { color: var(--muted); font-size: 11px; line-height: 1.8; margin: 16px 0 0; }
+.setup-pending-note { color: var(--muted); font-size: 11px; line-height: 1.7; margin: 0 0 8px; }
 @media (max-width: 600px) {
-  .entry-flow, .setup-layout { padding: 18px 20px 14px; }
+  .entry-flow { padding: 18px 20px 14px; }
   .entry-header { gap: 16px; }
   .entry-login-card { padding: 22px; }
   .entry-footer { font-size: 9px; }
-  .setup-main { padding-top: 30px; }
+  .setup-layout > .entry-header { min-height: 60px; padding: 12px 20px; }
+  .setup-body { padding: 24px 20px; }
+  .setup-status-inner { padding: 14px 20px; }
+  .setup-footer-inner { padding: 10px 20px; }
+  .setup-progress-caption { font-size: 10px; gap: 12px; }
+  .setup-current-stage { gap: 7px; }
   .setup-steps > li { grid-template-columns: 24px minmax(0, 1fr); gap: 8px 12px; padding: 14px 10px; }
   .setup-step-status { grid-column: 2; text-align: left; }
   .setup-context { font-size: 10px; }
   .setup-review { padding: 18px; }
-  .setup-controls { flex-direction: column; align-items: stretch; gap: 8px; }
+  .setup-controls { flex-direction: column; align-items: stretch; gap: 4px; }
   .setup-controls > .text-button { align-self: flex-start; }
   .setup-controls > div { justify-content: flex-start; }
 }

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -1,15 +1,17 @@
 import type { DesktopSnapshot } from "./contracts";
 import { providerRegistry } from "./provider_registry";
+import { isReferenceSettingsView, REFERENCE_LABELS, type ReferenceSettingsView } from "./reference_screens";
 
-export type View = "home" | "project" | "agents" | "models" | "general" | "shortcuts" | "diagnostics" | "setup"
+export type View = ReferenceSettingsView | "home" | "project" | "agents" | "models" | "general" | "shortcuts" | "diagnostics" | "setup"
   | "today" | "chats" | "teams" | "automations" | "apps" | "bot" | "providers" | "tokens" | "activity" | "memory" | "settings";
 
 export const VIEW_LABELS: Record<View, string> = {
+  ...REFERENCE_LABELS,
   home: "Início", project: "Projeto", agents: "Agentes e IDEs", models: "Modelos e skills", setup: "Instalação guiada",
   general: "Aparência", shortcuts: "Atalhos", diagnostics: "Runtime e diagnóstico",
   providers: "Integrações MCP", tokens: "Relatório de tokens", activity: "Atividade",
-  memory: "Memória", settings: "Conta Simplicio", today: "Today", chats: "Chats",
-  teams: "Teams", automations: "Automations", apps: "Apps", bot: "Bot Center",
+  memory: "Memória", settings: "Conta Simplicio", today: "Hoje", chats: "Conversas",
+  teams: "Equipes", automations: "Automações", apps: "Aplicativos", bot: "Central de agentes",
 };
 
 export function isView(value: string | null): value is View {
@@ -17,7 +19,7 @@ export function isView(value: string | null): value is View {
 }
 
 export function isSettingsView(view: View): boolean {
-  return ["settings", "agents", "providers", "models", "general", "shortcuts", "diagnostics", "memory"].includes(view);
+  return isReferenceSettingsView(view) || ["settings", "agents", "providers", "models", "general", "shortcuts", "diagnostics", "memory"].includes(view);
 }
 
 export function searchMatches(text: string, query: string): boolean {

--- a/docs/desktop/DESIGN.md
+++ b/docs/desktop/DESIGN.md
@@ -42,6 +42,19 @@ Local projects are bookmarks, not agent worktrees. Native code validates and
 canonicalizes existing directories; opening a bookmark revalidates the path.
 Removal only removes the bookmark. Density, sidebar path visibility and the last
 project are local preferences, never authentication or execution authority.
+The native folder picker fills a canonical path for review; choosing a directory
+does not add the bookmark automatically. A complete path can still be entered
+manually, and confirmation revalidates it. Canceling the picker preserves the
+typed path and returns focus without reporting an error. Browser preview cannot
+open or validate local directories.
+
+Below 760px, expanded navigation overlays the workspace instead of squeezing it.
+Its search, scrollable destinations and fixed controls remain available; Escape,
+outside dismissal, keyboard focus containment and focus restoration are explicit.
+Settings destinations use `src/reference_screens.ts`, with grouped navigation and
+search across labels and descriptions. The status bar separates detected
+registrations from current, confirmed MCP handshakes; lack of a confirmed
+handshake is not proof of disconnection.
 
 Entry uses the supplied Claude references for a focused two-screen sequence:
 welcome, then a sign-in card. Only the supported browser-based Google login is
@@ -52,8 +65,14 @@ The guided installer follows the supplied Hermes references with real stages:
 Runtime/access check, read-only plan, confirmed installation, and final state
 verification. Progress advances only after each operation returns, with no
 simulated download percentage or duration. Applying requires explicit consent to
-the current digest. Failed operations show their stage, preserve uncertainty
-about partial changes and require a new review before retrying. Navigation is
+the current digest. The progress header and action footer stay visible while
+destinations and details scroll; reviewing destinations never checks consent.
+Failed operations show their stage and preserve uncertainty about partial
+changes. Only a changed plan or a process confirmed not started permits a new
+review and consent. Uncertain outcomes block reapplication in the current
+session; a confirmed receipt followed by failed verification offers a read-only
+diagnostic refresh, not reinstallation. Navigating away and back does not remove
+that guard, and restarting is not evidence of reconciliation. Navigation is
 locked during an operation that the backend cannot safely cancel. Completion
 confirms configuration, not a live MCP handshake in every client. Marketplace
 plugins and host permissions are not represented as automatically installed.

--- a/docs/desktop/QA-2026-08-31.md
+++ b/docs/desktop/QA-2026-08-31.md
@@ -1,0 +1,39 @@
+# Desktop reference implementation — local QA, 2026-08-31
+
+This is source/build evidence, not a release certificate. Base: `e66b59535052088da07bc362f4347ce5a7600cb1`; implementation branch: `fix/desktop-reference-finish-20260831`. Private reference images, credentials and local account data are not included.
+
+## Scope
+
+The white Simplicio workspace, guided setup, external login, native folder picker, update metadata dialog and reference settings are covered in [REFERENCE-COVERAGE.md](REFERENCE-COVERAGE.md). Unsupported Runtime capabilities are explicitly unavailable, not simulated as successful operations.
+
+Automatic folder discovery recognizes bounded local usage/context markers. Independent child processes isolate each search root; completed roots survive another root's timeout. Marker discovery is not proof of savings. Context reports validate ledger integrity and preserve estimated/mixed evidence, gross/net differences and the distinction between context savings and usage/billing.
+
+Read-only project/report commands use a fresh bounded Runtime access check. Unknown access does not mean an inactive subscription. Legacy all-history savings are not labeled as monthly measured savings. Installation preflight failures allow a new review only before an installer was started; uncertain post-start effects cannot be silently repeated.
+
+## Automated validation
+
+- Rust: `cargo test --release --offline --locked --lib`, **101 passed, 1 ignored**. Includes child-process deadlines/reaping, preservation of completed roots, Windows path projection, project ID interoperability, access checks and legacy evidence qualification.
+- Repository validation through Simplicio MCP: Python compileall and pytest, **260 passed plus 39 subtests**.
+- Frontend: **284 unit tests in 43 files passed**; TypeScript checks and Vite production build passed.
+- Browser: the final complete run passed **87 scenarios**, including explicit login from unknown/load failure, unknown/rejected login remaining gated, and recovery after a legacy logout. Earlier focused runs overlap this suite and are not additive totals.
+- Browser integration tests use mocked Tauri IPC. They establish UI behavior and contract handling, not an actual OAuth grant, native installation or a client MCP handshake.
+
+## Native QA boundaries
+
+The isolated macOS validation bundle uses `br.com.simpleti.simplicio.validation`. It does not replace the installed production application. Ad-hoc signing permits local QA only; it is not Developer ID signing or notarization.
+
+The staged arm64 Runtime digest before packaging and the bundled Runtime digest after ad-hoc sealing both equal `c6dca7c384aaedb0226f6ea93a0dbe259a175f999c070e6c8ef609af519e5130` (SHA-256). `codesign --verify --deep --strict` passed. The offline locked Tauri application build passed; existing unused-supervisor warnings remain.
+
+Earlier native checks in this implementation cycle established existing-session entry, native folder selection, a real qualified context report, and the native Check for Updates menu. They also exposed a filesystem call stuck during automatic discovery.
+
+After rebuilding with the isolated-root fix, the actual application entered the workspace using the existing session, found **27 folders**, automatically selected the newest candidate and rendered its real context report. The completed UI explicitly reported partial discovery, kept folder selection available, and displayed missing usage telemetry separately from context savings. A subsequent observed project selection rendered an estimated context report with low confidence and heuristic/unlabeled-method warnings. No private paths or account details are retained here. This proves a completed bounded local search, not exhaustive filesystem coverage or native Windows/Linux behavior. User interaction resumed in the validation window, so further automation clicks were stopped.
+
+## Not established by this change
+
+- No Windows/Linux execution or new installers, GitHub release, PyPI upload, notarization, SBOM or provenance publication.
+- No fresh OAuth login, global plugin installation or post-install handshake in every harness/IDE.
+- Registered configuration is not a confirmed live MCP connection.
+- Voice, Mobile pairing, SSH, integrated browser/terminal execution and other unsupported reference controls remain unavailable as documented.
+- Updates consult bounded public metadata and open the release page. Native download/extraction/signature verification/stage/swap/rollback are not implemented.
+- Installation-attempt protection is process-local, not durable across application restarts.
+- The existing `v3.8.39` published artifacts do not contain these changes. A future manual release needs a new patch version and the release runbook gates; immutable assets must not be overwritten. No GitHub Actions were used.

--- a/docs/desktop/REFERENCE-COVERAGE.md
+++ b/docs/desktop/REFERENCE-COVERAGE.md
@@ -1,0 +1,77 @@
+# Desktop: cobertura das referências
+
+Este mapa descreve as telas e os contratos presentes no código. Cobertura visual não significa equivalência funcional com outro produto, autorização para executar agentes ou validação nativa em todas as plataformas. Os screenshots privados e seus dados não fazem parte deste documento.
+
+## Correspondência visual
+
+- **Orca:** estrutura branca do workspace, projetos, navegação lateral pesquisável, grupos de preferências, inventários e relatórios. As seções têm conteúdo próprio, não apenas títulos diferentes.
+- **Hermes Agent Desktop:** instalação orientada por etapas, revisão do plano e indicação de progresso/resultado. O efeito continua limitado ao contrato de configuração do Runtime.
+- **Claude:** entrada simples, identidade Simplicio e login externo. A autenticação e o estado de acesso vêm do Runtime, não de uma simulação visual.
+- **Referência de extração/atualização:** o Desktop mostra etapas da consulta real de metadados. Não simula extração, instalação automática ou troca do aplicativo.
+
+## Telas e fluxos existentes
+
+Os identificadores abaixo são views internas; login é um estado de acesso e atualizações é um diálogo global, não uma rota de página.
+
+| Superfície | Caminho implementado e limite |
+| --- | --- |
+| Login / acesso | Login externo, nova consulta, estado da assinatura e saída pelo Runtime. Falha de autenticação não vira acesso ativo; login Simplicio não autentica contas de LLMs. |
+| `setup` | Revisão explícita do plano, aplicação e verificação posterior dos alvos revisados. Aplicar configuração não equivale a handshake confirmado nem a instalar todos os plugins nativos. |
+| `home`, `project` | Navegação, histórico, atalhos locais e seleção de projeto. O seletor nativo valida uma pasta existente; adicioná-la exige confirmação. Não clona repositórios nem inicia agentes. |
+| `agents`, `providers` | Inventário, filtros e estados separados de instalação, registro MCP e handshake. A visão de integrações oferece revisão/reparo; inventário não comprova sessão ativa no cliente. |
+| `settings`, `diagnostics` | Conta, atualização da consulta, saída e diagnóstico oferecidos pelo Runtime. Sem cadastrar credenciais de outros serviços. |
+| `tokens` | Consulta de uso por pasta, período e sessão; exportação local JSON/CSV do relatório consultado. Economia de contexto aparece separada do consumo registrado e de cobrança. |
+| `general`, `shortcuts`, `models`, `activity` | Preferências locais existentes, orientação de teclado, inventário e atividade do último snapshot. Metadados não renovam a consulta nem concedem autoridade. |
+| Check for Updates… | Menu e diálogo global consultam metadados públicos e procuram pacote Desktop compatível. A ação abre a página de releases para obter o instalador; instalação manual. Versão/pacote desconhecidos não produzem “atualizado”. |
+
+## Novas rotas de preferências
+
+Fonte canônica: [catálogo de navegação](../../apps/desktop/src/reference_screens.ts). O grupo e o título seguem esse catálogo; a implementação está em [ReferenceSettingsScreen](../../apps/desktop/src/screens/ReferenceSettingsScreen.tsx).
+
+| Grupo | Rota — tela | Capacidade disponível / limite explícito |
+| --- | --- | --- |
+| Capacidades | `provider-accounts` — Contas de IA | Cards de provedores e evidência MCP disponível; autenticação das contas não consultada. Sem campos de senha, chave ou cookie. |
+| Capacidades | `orchestration` — Orquestração | Perfis reportados e links ao Bot Center/atividade. Limite de paralelismo não consultado; não admite nem inicia agentes. |
+| Capacidades | `computer-use` — Uso do computador | Estado de sessão reportado e requisitos de permissão; esta tela não captura imagens nem controla aplicativos. |
+| Capacidades | `voice` — Voz | Seções de ditado, dispositivo e modelo; captura, transcrição e download de modelos indisponíveis. |
+| Configuração | `general-settings` — Geral | Links às preferências e conta existentes; inicialização automática nativa indisponível. |
+| Configuração | `integrations` — Integrações de serviços | Cards de serviços de código/tarefas e navegação; conectar contas e importar tarefas indisponíveis. |
+| Configuração | `mobile` — Simplicio Mobile | Requisitos de pareamento e dispositivos; sem QR fictício, token, relay ou cliente conectado presumido. |
+| Fluxos | `artifacts` — Artefatos | Metadados reportados e links aos relatórios; abrir/exportar os arquivos desse inventário indisponível. |
+| Fluxos | `share-skills` — Compartilhar skills | Nomes informados pelo Runtime; conteúdo, compartilhamento e publicação indisponíveis. |
+| Fluxos | `git` — Git e código-fonte | Links a projetos e serviços; criação de worktrees, revisão Git, commit e push indisponíveis nesta tela. |
+| Fluxos | `task-sources` — Fontes de tarefas | Seções expansíveis por teclado e links aos serviços; consultas de issues e preferências sem efeito indisponíveis. |
+| Fluxos | `terminal` — Terminal | Comandos fixos copiáveis para o terminal do usuário; sem PTY, execução ou leitura de histórico. |
+| Fluxos | `quick-commands` — Comandos rápidos | Cópia explícita de comandos documentados, com espera limitada; copiar não executa e não coleta a saída. |
+| Fluxos | `browser` — Navegador | Requisitos de sessão e links às ferramentas; navegador integrado, importação de cookies e automação indisponíveis. |
+| Fluxos | `emulator` — Emulador mobile | Seções Android/iOS; detecção de SDKs, inventário de dispositivos e inicialização indisponíveis. |
+| Fluxos | `floating` — Janela flutuante | Organização da janela e navegação existente; criar janela ou mantê-la à frente indisponível. |
+| Interface | `input` — Entrada e edição | Orientação de teclado e links a atalhos/voz; opções de editor sem contrato indisponíveis. |
+| Interface | `notifications` — Notificações | Atividade disponível e requisitos; permissão nativa não consultada, envio de teste indisponível. |
+| Hosts remotos | `hosts` — Hosts SSH | Requisitos e acesso aos projetos locais; não lê chaves, conecta SSH nem cria hosts. |
+| Hosts remotos | `servers` — Servidores Simplicio | Estado local reportado; descoberta, autenticação e conexão de servidores remotos indisponíveis. |
+| Privacidade e segurança | `permissions` — Permissões do sistema | Orientação por recurso; permissões não consultadas, não presumidas concedidas ou negadas. Solicitações nativas indisponíveis. |
+| Privacidade e segurança | `privacy` — Privacidade e telemetria | Escopo dos metadados e links a diagnóstico/preferências; não presume estado da telemetria nem oferece exclusão de dados. |
+| Avançado | `advanced` — Avançado | Evidência do Runtime e comandos copiáveis; alteração de proxy/rede indisponível. |
+| Experimental | `experimental` — Experimental | Cards com navegação para recursos relacionados, sem switches que finjam ativação. |
+| Experimental | `plugins` — Plugins | Catálogo pesquisável e inventário de skills reportadas, separados da instalação. Instalação/ativação automática dos plugins nativos de harnesses/IDEs indisponível nesta tela. |
+
+Controles sem contrato ficam desabilitados com explicação. Navegação, busca, filtros, expansão de seções, atualização explícita do snapshot e cópia de comandos têm ações implementadas. A prévia é identificada como tal; seus exemplos não comprovam conexão, instalação ou economia. As novas telas não fornecem execução de agentes, pareamento Mobile, controle do computador, voz, SSH ou instalação automática de plugins. A atualização não possui downloader nativo com extração, validação e troca automática do aplicativo (*stage/swap*).
+
+## Pastas automáticas e relatórios
+
+O relatório de tokens procura **candidatos**, separando dois marcadores:
+
+| Marcador dentro do projeto | Significado da descoberta |
+| --- | --- |
+| `.simplicio/token-usage.sqlite3` | Possível banco de uso; verifica somente tamanho/cabeçalho SQLite, não tabelas ou totais. |
+| `.simplicio/ledger/savings-events.jsonl` | Possível ledger de contexto; verifica somente um prefixo reconhecível, não a validade dos eventos. |
+
+- A busca usa `Projetos`, `Projects` e `Desktop` da pasta pessoal, quando acessíveis, além do repositório nativo configurado quando aceito. **Não percorre toda a pasta pessoal** nem aceita a raiz do sistema como repositório de varredura.
+- Limites globais: profundidade de 5 níveis, 4.000 diretórios, 40.000 entradas e 64 resultados. O orçamento de diretórios/entradas é dividido entre os locais. Cada local é lido num subprocesso independente: prazo cooperativo de 2 segundos durante a varredura e limite de captura de 3 segundos, com tentativa de encerramento/reap limitada. Uma chamada de filesystem presa não ocupa indefinidamente um worker do Desktop. Se o sistema não confirmar o término do filho, o handle é retido e novas capturas ficam bloqueadas; não se presume cancelamento concluído.
+- Resultados de locais concluídos são preservados quando outro local não responde. A lista informa os locais não concluídos, sem exigir que o usuário conceda permissões automaticamente. Os contadores de varredura referem-se às respostas concluídas, não à atividade desconhecida de um filho interrompido.
+- Não segue links simbólicos; exclui dependências, caches e saídas de build. Lê apenas prefixos dos marcadores (até 512 bytes; 100 no SQLite), não documentos do projeto. Limites, diretórios inacessíveis e outras omissões são apresentados como descoberta parcial.
+- A ordenação usa a modificação do marcador, não a data de uma sessão. Sem seleção prévia, pode selecionar o primeiro candidato e consultar os relatórios; uma escolha manual não é substituída. O seletor de pasta e o caminho manual continuam disponíveis para locais fora da busca.
+- **Marcador encontrado não prova uso ou economia.** Os números só vêm após a consulta e validação pelo Runtime. O relatório de contexto exige ledger íntegro/promovível; mantém a qualificação da evidência e separa contexto de uso. Falha, ausência de amostras ou dado indisponível não significam consumo zero nem cobrança confirmada.
+
+Contratos: [descoberta nativa](../../apps/desktop/src-tauri/src/project_usage.rs), [seleção de pastas](../../apps/desktop/src/components/TokenProjects.tsx), [relatório de uso](../../apps/desktop/src/screens/TokensScreen.tsx), [projeção de contexto](../../apps/desktop/src-tauri/src/context_report.rs), [montagem das telas](../../apps/desktop/src/App.tsx) e [manual de release](../RELEASE_RUNBOOK.md).

--- a/docs/desktop/RELEASE-CONTRACT.md
+++ b/docs/desktop/RELEASE-CONTRACT.md
@@ -5,6 +5,12 @@ artifacts. An update is actionable only when the Runtime/Release service
 returns a verified artifact, checksum and provenance; rollback is part of the
 same descriptor.
 
+This is the required automatic-update contract, not a claim that it is supplied
+by the current Runtime. The native `Check for Updates...` menu opens a separate
+read-only GitHub metadata dialog with a manual release-page link. It never
+upgrades metadata into a verified `desktop.release/v1` artifact or starts an
+installation. See [manual delivery and the updater gate](RELEASE.md).
+
 The Desktop never treats a version string as proof that an update is safe. In
 standalone/preview mode, update and rollback remain unavailable with a reason
 code.

--- a/docs/desktop/RELEASE.md
+++ b/docs/desktop/RELEASE.md
@@ -1,12 +1,25 @@
 # Desktop release and updater contract
 
-Desktop artifacts are published only through the closed-world release
-workflow. A release is eligible when the signed manifest, SHA256 digests,
-SBOM, provenance records, and component lock all match the immutable staged
-bytes. The workflow refuses a remote release whose tag or asset digests have
-drifted.
+## Current manual delivery
 
-The updater follows a stage-before-swap transaction:
+Follow [the local release runbook](../RELEASE_RUNBOOK.md). Publication is manual,
+not a GitHub Actions workflow. The Runtime's closed-world artifact manifest,
+signatures, SBOM and provenance remain mandatory; Desktop installers are separate
+companion assets, not additional members of that Runtime manifest. Record the
+Desktop source revision, target, installer digest and bundled Runtime identity
+separately. Never replace already-published bytes under an immutable version.
+
+`Check for Updates...` currently performs a read-only check of public GitHub
+release metadata and offers the release page for manual installation when a
+compatible package is listed. Progress reflects received metadata bytes, not an
+installer download. Metadata, a version string and an asset filename do not prove
+signature verification, installation, successful startup or rollback. The UI
+does not replace the app or Runtime in the background.
+
+## Required contract before enabling automatic installation
+
+The automatic updater is not implemented by the current metadata dialog. It must
+follow a stage-before-swap transaction before it can be enabled:
 
 1. download into an isolated staging directory;
 2. verify signature, checksum, provenance, and component membership;
@@ -14,9 +27,11 @@ The updater follows a stage-before-swap transaction:
 4. atomically switch the active sidecar;
 5. start the sidecar and restore the previous candidate if startup fails.
 
-The release acceptance suite must exercise both a successful fresh start and
-a failed-start rollback. The Desktop UI never presents an update as complete
-until the Runtime returns a healthy receipt.
+An automatic-updater acceptance suite must exercise both a successful fresh
+start and a failed-start rollback. The Desktop UI must never present an update
+as complete until the Runtime returns a healthy receipt.
+
+## Native bundle identity
 
 The Tauri bundle must include the exact verified Runtime release binary through
 `bundle.externalBin`. Before a native build, stage it at


### PR DESCRIPTION
## Implementação

- Workspace branco Simplicio, navegação e 25 telas de preferências correspondentes às referências Orca/Hermes/Claude. Controles sem contrato Runtime ficam explicitamente indisponíveis.
- Descoberta automática de projetos com marcadores de uso/contexto, isolamento por raiz em subprocessos limitados e preservação dos resultados quando outro local não responde.
- Relatório de contexto qualificado: integridade do ledger, evidência estimada/mista, bruto/líquido e separação entre histórico e consumo faturado. Sem promover histórico completo a economia mensal medida.
- Seletor nativo, diálogo de atualizações com metadados limitados, recuperação explícita de login quando acesso é desconhecido, instalação serializada e nova revisão após falhas anteriores ao início do instalador.
- Documentação de cobertura, QA e limites do fluxo manual de release.

## Verificação manual (sem GitHub Actions)

- 284 testes frontend / 43 arquivos; TypeScript e Vite build aprovados.
- 87 testes de interface aprovados (IPC Tauri simulado).
- 101 testes Rust aprovados / 1 ignorado, offline e locked.
- Simplicio validate: 260 testes Python + 39 subtests aprovados.
- Bundle macOS de validação reconstruído e assinatura ad-hoc verificada; SHA-256 do Runtime preservado antes/depois do empacotamento.
- Aplicativo real: sessão existente abriu workspace; 27 pastas descobertas; seleção automática e relatório real; aviso de descoberta parcial e qualificação de estimativas visíveis.

## Limites explícitos

Este PR não publica release nem substitui o app instalado. Não valida Windows/Linux, OAuth novo, instalação global de plugins ou handshake de todos os clientes. Atualização permanece manual; voz, Mobile, SSH e outras capacidades sem contrato não estão implementadas. Os artefatos publicados v3.8.39 não contêm este código; uma próxima release manual precisa de nova versão e dos gates do runbook, sem sobrescrever assets imutáveis. Não altera o Runtime privado nem o trabalho de autenticação/Mapper em outra sessão.

Evidência e cobertura detalhadas em docs/desktop/QA-2026-08-31.md e docs/desktop/REFERENCE-COVERAGE.md.
