### PR TITLE
Desktop: ocultar opcoes solicitadas [skip ci]

### DIFF
--- a/apps/desktop/e2e/hidden-settings.spec.ts
+++ b/apps/desktop/e2e/hidden-settings.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+const hidden = [
+  "Orquestração", "Uso do computador", "Voz", "Integrações de serviços", "Simplicio Mobile",
+  "Memória", "Compartilhar skills", "Git e código-fonte", "Fontes de tarefas", "Terminal", "Navegador",
+  "Emulador mobile", "Janela flutuante", "Atalhos", "Entrada e edição", "Notificações",
+  "Hosts SSH", "Servidores Simplicio", "Privacidade e telemetria", "Avançado", "Experimental", "Plugins",
+];
+
+test("requested settings are absent from categories and both search surfaces", async ({ page }, testInfo) => {
+  await page.goto("/?view=settings");
+  const sidebar = page.locator("#workbench-sidebar");
+  const categories = sidebar.getByRole("navigation");
+  for (const label of hidden) await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  for (const group of ["HOSTS REMOTOS", "EXPERIMENTAL"]) await expect(categories.getByText(group, { exact: true })).toHaveCount(0);
+  for (const label of ["Contas de IA", "Geral", "Artefatos", "Comandos rápidos", "Aparência", "Permissões do sistema", "Runtime e diagnóstico", "Integrações MCP", "Relatório de tokens"])
+    await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(1);
+  await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath("visible-settings.png") });
+  for (const label of hidden) {
+    await sidebar.getByRole("searchbox").fill(label);
+    await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
+  await page.goto("/");
+  await expect(page.getByRole("button", { name: "Todos os atalhos", exact: true })).toHaveCount(0);
+  for (const label of hidden) {
+    await sidebar.getByRole("searchbox").fill(label);
+    await expect(sidebar.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
+});
+
+test("visible reference pages do not expose links back to hidden destinations", async ({ page }) => {
+  for (const view of ["provider-accounts", "general-settings", "artifacts", "quick-commands", "permissions"]) {
+    await page.goto("/?view=" + view);
+    await expect(page.locator(".reference-settings-page")).toBeVisible();
+    await expect(page.getByRole("main").getByRole("button", { name: /Ver atalhos|Abrir atalhos|Abrir navegador|Abrir terminal|Configurar voz/ })).toHaveCount(0);
+  }
+});

--- a/apps/desktop/e2e/reference-navigation.spec.ts
+++ b/apps/desktop/e2e/reference-navigation.spec.ts
@@ -1,17 +1,20 @@
 import { expect, test } from "@playwright/test";
 import { REFERENCE_SCREENS } from "../src/reference_screens";
+import { isNavigationVisible } from "../src/workbench";
+
+const visibleScreens = REFERENCE_SCREENS.filter((screen) => isNavigationVisible(screen.id));
 
 test("every supplied-reference settings destination is searchable and reachable without losing navigation", async ({ page }, testInfo) => {
   await page.goto("/?view=settings");
   const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
   const categories = sidebar.getByRole("navigation", { name: "Categorias de configurações", exact: true });
   const search = sidebar.getByRole("searchbox", { name: "Buscar configurações", exact: true });
-  for (const screen of REFERENCE_SCREENS) await expect(categories.getByRole("button", { name: screen.label, exact: true })).toHaveCount(1);
+  for (const screen of visibleScreens) await expect(categories.getByRole("button", { name: screen.label, exact: true })).toHaveCount(1);
   expect(await page.locator(".sidebar-scroll").evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
   await expect(sidebar.getByRole("button", { name: "Voltar ao app", exact: true })).toBeInViewport();
-  await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toBeInViewport();
+  await expect(sidebar.getByRole("button", { name: "Configurações", exact: true })).toBeInViewport();
 
-  for (const screen of REFERENCE_SCREENS) {
+  for (const screen of visibleScreens) {
     await search.fill(screen.label);
     await categories.getByRole("button", { name: screen.label, exact: true }).click();
     await expect(page.getByRole("heading", { name: screen.label, exact: true, level: 1 })).toBeVisible();
@@ -20,7 +23,7 @@ test("every supplied-reference settings destination is searchable and reachable 
     await expect(search).toHaveValue("");
   }
   await expect(sidebar.getByRole("button", { name: "Voltar ao app", exact: true })).toBeInViewport();
-  await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toBeInViewport();
+  await expect(sidebar.getByRole("button", { name: "Configurações", exact: true })).toBeInViewport();
   await page.screenshot({ path: testInfo.outputPath("reference-settings-navigation.png") });
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
 });
@@ -31,18 +34,18 @@ test("reference navigation is discoverable by description and usable in a narrow
   await expect(page.getByRole("heading", { name: "Simplicio", exact: true, level: 1 })).toBeVisible();
   await page.keyboard.press("Control+k");
   const workspaceMenu = page.getByRole("dialog", { name: "Espaço de trabalho", exact: true });
-  await workspaceMenu.getByRole("searchbox").fill("pareamento");
-  const mobile = workspaceMenu.getByRole("button", { name: "Simplicio Mobile", exact: true });
+  await workspaceMenu.getByRole("searchbox").fill("comandos documentados");
+  const mobile = workspaceMenu.getByRole("button", { name: "Comandos rápidos", exact: true });
   await expect(mobile).toBeVisible();
   await mobile.click();
-  await expect(page.getByRole("heading", { name: "Simplicio Mobile", exact: true, level: 1 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Comandos rápidos", exact: true, level: 1 })).toBeVisible();
   await expect(page.getByRole("dialog")).toHaveCount(0);
 
   await page.getByRole("button", { name: "Expandir barra lateral", exact: true }).click();
   const settingsMenu = page.getByRole("dialog", { name: "Configurações", exact: true });
-  await settingsMenu.getByRole("searchbox").fill("Privacidade e telemetria");
-  await settingsMenu.getByRole("button", { name: "Privacidade e telemetria", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Privacidade e telemetria", exact: true, level: 1 })).toBeVisible();
+  await settingsMenu.getByRole("searchbox").fill("Permissões do sistema");
+  await settingsMenu.getByRole("button", { name: "Permissões do sistema", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Permissões do sistema", exact: true, level: 1 })).toBeVisible();
   await expect(page.getByRole("dialog")).toHaveCount(0);
   await page.screenshot({ path: testInfo.outputPath("reference-narrow-settings.png") });
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);

--- a/apps/desktop/e2e/reference-settings.spec.ts
+++ b/apps/desktop/e2e/reference-settings.spec.ts
@@ -143,7 +143,9 @@ test("read-only evidence is escaped and refresh never dispatches unsupported set
   await expect(panel).not.toContainText("private-person@example.test");
   await expect(panel).not.toContainText("private-configuration-body");
   const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
-  await sidebar.getByRole("button", { name: "Plugins", exact: true }).click();
+  // Hidden implementations remain testable by an explicit preview route, not navigation.
+  await expect(sidebar.getByRole("button", { name: "Plugins", exact: true })).toHaveCount(0);
+  await page.goto("/?view=plugins");
   await panel.getByRole("button", { name: "Skills informadas", exact: true }).click();
   await expect(panel.getByText("Skill de teste", { exact: true })).toBeVisible();
   await expect(panel.getByText(malicious, { exact: true })).toBeVisible();
@@ -187,8 +189,8 @@ test("leaving a pending copy ignores its completion and does not carry a spinner
   await copy.click();
   await expect(copy).toBeDisabled();
   const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
-  await sidebar.getByRole("button", { name: "Voz", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Voz", exact: true, level: 1 })).toBeVisible();
+  await sidebar.getByRole("button", { name: "Contas de IA", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Contas de IA", exact: true, level: 1 })).toBeVisible();
   await page.evaluate(() => (window as SettingsTestWindow).__referenceResolveCopy(0));
   await expect(page.locator(".reference-settings-page")).not.toContainText("Copiado");
   await sidebar.getByRole("button", { name: "Comandos rápidos", exact: true }).click();
@@ -205,6 +207,5 @@ test("task source details are keyboard-operable without saving a fake connection
   const details = page.locator(".ref-source-details").filter({ has: page.locator("summary").filter({ hasText: "Linear" }) });
   await expect(details).toHaveAttribute("open", "");
   await expect(details.getByRole("switch", { name: "Mostrar tarefas de Linear", exact: true })).toBeDisabled();
-  await details.getByRole("button", { name: "Ver conexão do serviço", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Integrações de serviços", exact: true, level: 1 })).toBeVisible();
+  await expect(details.getByRole("button", { name: "Ver conexão do serviço", exact: true })).toHaveCount(0);
 });

--- a/apps/desktop/e2e/reference-shell.spec.ts
+++ b/apps/desktop/e2e/reference-shell.spec.ts
@@ -21,7 +21,7 @@ test("narrow navigation overlays the workspace and keeps keyboard focus inside u
 
   await drawer.getByRole("button", { name: "Início do Simplicio", exact: true }).focus();
   await page.keyboard.press("Shift+Tab");
-  await expect(drawer.getByRole("button", { name: "Ver atalhos", exact: true })).toBeFocused();
+  await expect(drawer.getByRole("button", { name: "Configurações", exact: true })).toBeFocused();
   await page.keyboard.press("Tab");
   await expect(drawer.getByRole("button", { name: "Início do Simplicio", exact: true })).toBeFocused();
   await page.keyboard.press("Escape");

--- a/apps/desktop/e2e/workspace.spec.ts
+++ b/apps/desktop/e2e/workspace.spec.ts
@@ -33,8 +33,8 @@ test("workbench navigation, settings search, history and sidebar controls work",
   await page.keyboard.type("nenhum-resultadoteste");
   await expect(page.getByText("Nenhum resultado.")).toBeVisible();
   await page.getByRole("button", { name: "Limpar busca", exact: true }).click();
-  await page.getByRole("button", { name: "Atalhos", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Atalhos", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Comandos rápidos", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Comandos rápidos", exact: true })).toBeVisible();
 });
 
 test("provider inventory is searchable and never upgrades detected to connected", async ({ page }) => {

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
 import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
-import { isSettingsView, runtimeSummary, searchMatches, VIEW_LABELS, type LocalProject, type View, type WorkbenchState } from "../workbench";
+import { isNavigationVisible, isSettingsView, runtimeSummary, searchMatches, VIEW_LABELS, type LocalProject, type View, type WorkbenchState } from "../workbench";
 
 export type { View } from "../workbench";
 
@@ -24,7 +24,7 @@ const groupOrder: Record<string, number> = {
   CAPACIDADES: 0, CONFIGURAÇÃO: 1, FLUXOS: 2, INTERFACE: 3,
   "HOSTS REMOTOS": 4, "PRIVACIDADE E SEGURANÇA": 5, AVANÇADO: 6, EXPERIMENTAL: 7,
 };
-const settings: Destination[] = [
+const settings: Destination[] = ([
   { id: "agents", icon: "teams", group: "CAPACIDADES" },
   { id: "models", icon: "spark", group: "CAPACIDADES" },
   { id: "providers", icon: "providers", group: "CONFIGURAÇÃO" },
@@ -36,7 +36,7 @@ const settings: Destination[] = [
   { id: "shortcuts", icon: "keyboard", group: "INTERFACE" },
   { id: "diagnostics", icon: "monitor", group: "AVANÇADO" },
   ...REFERENCE_SCREENS.map(({ id, group, description }) => ({ id, group, description, icon: referenceIcons[id] })),
-];
+] satisfies Destination[]).filter((item) => isNavigationVisible(item.id));
 settings.sort((left, right) => (groupOrder[left.group ?? ""] ?? 100) - (groupOrder[right.group ?? ""] ?? 100));
 
 interface ShellProps {
@@ -237,7 +237,7 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
         </div>
         <div className="sidebar-bottom">
           <button className="nav-item" type="button" aria-label="Configurações" title="Configurações" onClick={() => selectView("settings")}><Glyph name="settings" size={18} />{!collapsed && <span>Configurações</span>}</button>
-          <button className="icon-button" type="button" aria-label="Ver atalhos" title="Atalhos" onClick={() => selectView("shortcuts")}><Glyph name="keyboard" size={18} /></button>
+          {isNavigationVisible("shortcuts") && <button className="icon-button" type="button" aria-label="Ver atalhos" title="Atalhos" onClick={() => selectView("shortcuts")}><Glyph name="keyboard" size={18} /></button>}
         </div>
       </aside>
 

--- a/apps/desktop/src/navigation_visibility.test.ts
+++ b/apps/desktop/src/navigation_visibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isNavigationVisible, isView, VIEW_LABELS, type View } from "./workbench";
+
+describe("requested navigation visibility", () => {
+  it("hides exactly the requested destinations without deleting routes", () => {
+    const hidden: View[] = [
+      "orchestration", "computer-use", "voice", "integrations", "mobile", "memory",
+      "share-skills", "git", "task-sources", "terminal", "browser", "emulator", "floating",
+      "shortcuts", "input", "notifications", "hosts", "servers", "privacy", "advanced", "experimental", "plugins",
+    ];
+    expect(Object.keys(VIEW_LABELS).filter((view) => isView(view) && !isNavigationVisible(view)).sort()).toEqual([...hidden].sort());
+    for (const view of hidden) expect(isView(view)).toBe(true);
+    for (const view of ["diagnostics", "general", "permissions", "quick-commands", "tokens", "providers"] as const)
+      expect(isNavigationVisible(view)).toBe(true);
+  });
+});

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
@@ -4,7 +4,7 @@ import { Glyph, type GlyphName } from "../components/Brand";
 import { providerRegistry } from "../provider_registry";
 import { createSettingsProjection } from "../settings_projection";
 import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
-import { searchMatches, type View } from "../workbench";
+import { isNavigationVisible, searchMatches, type View } from "../workbench";
 import "../reference_settings.css";
 
 export interface ReferenceSettingsProps {
@@ -125,6 +125,7 @@ function UnavailableSelect({ label, value = "Não disponível" }: { label: strin
 }
 
 function LinkButton({ children, to, onNavigate, icon = "arrow" }: { children: ReactNode; to: View; onNavigate: Navigate; icon?: GlyphName }) {
+  if (!isNavigationVisible(to)) return null;
   return <button type="button" className="button button-secondary" onClick={() => onNavigate(to)}>{children}<Glyph name={icon} size={16} /></button>;
 }
 

--- a/apps/desktop/src/screens/WorkbenchHome.tsx
+++ b/apps/desktop/src/screens/WorkbenchHome.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { openDesktopProject } from "../bridge";
-import { runtimeSummary, type LocalProject, type View } from "../workbench";
+import { isNavigationVisible, runtimeSummary, type LocalProject, type View } from "../workbench";
 
 export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, onRemoveProject, onTokens }:
   { snapshot: DesktopSnapshot; project?: LocalProject; onAddProject: () => void; onViewChange: (view: View) => void; onRemoveProject: () => void; onTokens: (path?: string) => void }) {
@@ -38,7 +38,7 @@ export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, o
       <h1>Simplicio</h1>
       <p>Seus projetos. Seus agentes.<br />Um Runtime para conectar tudo.</p>
       <div className="welcome-actions"><button className="button button-primary" type="button" onClick={onAddProject}><Glyph name="plus" size={18} />Adicionar projeto</button><button className="button button-secondary" type="button" onClick={() => onViewChange("providers")}><Glyph name="providers" size={18} />Ver integrações</button></div>
-      <div className="welcome-shortcuts"><span><kbd>⌘ / Ctrl K</kbd> Buscar</span><button type="button" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={14} />Todos os atalhos</button></div>
+      <div className="welcome-shortcuts"><span><kbd>⌘ / Ctrl K</kbd> Buscar</span>{isNavigationVisible("shortcuts") && <button type="button" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={14} />Todos os atalhos</button>}</div>
     </div>
     <section className="welcome-resources" aria-label="Acesso rápido">
       <button type="button" onClick={() => onViewChange("agents")}><Glyph name="teams" size={20} /><span><strong>Agentes e IDEs</strong><small>{status.installed} detectados · {status.connected} MCP confirmados</small></span><Glyph name="arrow" size={16} /></button>

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -5,6 +5,17 @@ import { isReferenceSettingsView, REFERENCE_LABELS, type ReferenceSettingsView }
 export type View = ReferenceSettingsView | "home" | "project" | "agents" | "models" | "general" | "shortcuts" | "diagnostics" | "setup"
   | "today" | "chats" | "teams" | "automations" | "apps" | "bot" | "providers" | "tokens" | "activity" | "memory" | "settings";
 
+/** Presentation policy only: retain implementations and direct preview routes. */
+const HIDDEN_NAVIGATION_VIEWS: ReadonlySet<View> = new Set<View>([
+  "orchestration", "computer-use", "voice", "integrations", "mobile",
+  "memory", "share-skills", "git", "task-sources", "terminal", "browser", "emulator", "floating",
+  "shortcuts", "input", "notifications", "hosts", "servers", "privacy", "advanced", "experimental", "plugins",
+]);
+
+export function isNavigationVisible(view: View): boolean {
+  return !HIDDEN_NAVIGATION_VIEWS.has(view);
+}
+
 export const VIEW_LABELS: Record<View, string> = {
   ...REFERENCE_LABELS,
   home: "Início", project: "Projeto", agents: "Agentes e IDEs", models: "Modelos e skills", setup: "Instalação guiada",

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   test: {
-    exclude: [...configDefaults.exclude, "e2e/**"],
+    exclude: [...configDefaults.exclude, "e2e/**", "src-tauri/target/**"],
   },
   clearScreen: false,
   server: {

--- a/docs/desktop/REFERENCE-COVERAGE.md
+++ b/docs/desktop/REFERENCE-COVERAGE.md
@@ -2,6 +2,14 @@
 
 Este mapa descreve as telas e os contratos presentes no código. Cobertura visual não significa equivalência funcional com outro produto, autorização para executar agentes ou validação nativa em todas as plataformas. Os screenshots privados e seus dados não fazem parte deste documento.
 
+## Visibilidade do produto
+
+Por decisão de produto, 22 destinos permanecem implementados, mas estão ocultos da lateral, das buscas de navegação e dos links entre telas: Orquestração, Uso do computador, Voz, Integrações de serviços, Simplicio Mobile, Memória, Compartilhar skills, Git e código-fonte, Fontes de tarefas, Terminal, Navegador, Emulador mobile, Janela flutuante, Atalhos, Entrada e edição, Notificações, Hosts SSH, Servidores Simplicio, Privacidade e telemetria, Avançado, Experimental e Plugins. Os grupos vazios Hosts Remotos e Experimental não aparecem.
+
+Runtime e diagnóstico continua visível no grupo Avançado. Aparência, Permissões do sistema, Comandos rápidos e as demais opções não solicitadas continuam disponíveis. Ocultar a página Atalhos não desativa os comandos de teclado. O catálogo abaixo documenta implementações, não a visibilidade atual; rotas explícitas de prévia continuam disponíveis para testes. A política está em `isNavigationVisible` de `workbench.ts`, sem alterações de autenticação, Runtime ou dados locais.
+
+Validação dessa política em 31/08/2026: 285 testes unitários, 89 cenários de interface (IPC simulado), TypeScript/Vite e build macOS de validação aprovados. O build local não é uma nova release publicada.
+
 ## Correspondência visual
 
 - **Orca:** estrutura branca do workspace, projetos, navegação lateral pesquisável, grupos de preferências, inventários e relatórios. As seções têm conteúdo próprio, não apenas títulos diferentes.


### PR DESCRIPTION
## Mudança solicitada

Oculta exatamente os 22 destinos indicados pelo usuário da lateral, da busca de configurações, da busca global e dos links internos. Hosts Remotos e Experimental deixam de aparecer como grupos vazios. Runtime e diagnóstico permanece visível no grupo Avançado; as demais opções não solicitadas continuam disponíveis.

Os componentes e as rotas explícitas de prévia foram preservados. Ocultar Atalhos não desliga os comandos de teclado. Não altera Runtime, autenticação, dados locais ou política de instalação.

Inclui regressões para lista exata, buscas, links internos e navegação adaptativa. O Vitest agora exclui src-tauri/target para não coletar testes de aplicativos apontados por antigos diretórios de staging de instaladores. As dependências locais foram sincronizadas com o lockfile existente, sem atualizá-lo.

Validação local via Simplicio MCP, sem GitHub Actions: 285 testes unitários, 89 cenários Playwright, TypeScript/Vite e build macOS offline/locked aprovados. Assinatura ad-hoc verificada e digest do Runtime preservado no bundle. A primeira tentativa foi interrompida após identificar dependências locais desatualizadas; a rodada completa após npm ci passou.

Bundle macOS apenas de validação; sem nova publicação de release ou substituição do aplicativo instalado. A janela já aberta precisa ser reaberta para carregar a UI nova.
