### PR TITLE
feat(hermes): run Runtime exclusively in Mapper-only

### DIFF
--- a/plugins/simplicio-hermes/.claude-plugin/plugin.json
+++ b/plugins/simplicio-hermes/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.1.0",
-  "description": "Hermes middleware adapter for deterministic Simplicio Runtime preparation and redacted provider receipts.",
+  "version": "0.3.0",
+  "description": "Authenticated Mapper-only context and provider cache telemetry for Hermes.",
   "author": "Wesley Simplicio",
   "license": "MIT",
   "homepage": "https://github.com/wesleysimplicio/simplicio/tree/master/plugins/simplicio-hermes",
@@ -9,6 +9,13 @@
     "type": "git",
     "url": "https://github.com/wesleysimplicio/simplicio"
   },
-  "keywords": ["hermes", "middleware", "runtime", "receipts"],
-  "skills": ["./skills/simplicio-hermes"]
+  "keywords": [
+    "hermes",
+    "middleware",
+    "runtime",
+    "receipts"
+  ],
+  "skills": [
+    "./skills/simplicio-hermes"
+  ]
 }

--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -1,29 +1,66 @@
-# Simplicio Hermes native adapter
+# Simplicio Hermes Mapper-only adapter
 
-`simplicio-hermes` ships a native Python plugin for current Hermes Agent and a
-thin JavaScript middleware adapter for compatible embedders. Both call the
-deterministic Runtime bridges `prepare_model_call` and `record_model_result`;
-neither calls an LLM, selects a model, activates fan-out, or duplicates
-Mapper/Runtime logic.
+The Hermes plugin uses Simplicio only for authenticated repository mapping and
+provider usage receipts. Native Hermes tools, terminal, edits, tests, approvals,
+model selection and execution remain owned by Hermes and each project.
 
-The native plugin registers `on_session_start`, `pre_llm_call`,
-`post_llm_call`, and `on_session_end`. `pre_llm_call` completes before Hermes
-enters its tool-calling loop and injects only the bounded Runtime context
-receipt. `post_llm_call` records the matching provider result receipt. Hermes'
-native `pre_llm_call` contract is context-only and fail-open, so the plugin does
-not claim that a Runtime failure can block the provider call.
+The Python adapter starts its own stdio Runtime with
+`SIMPLICIO_RUNTIME_MODE=mapper-only`. It verifies that initialization and the
+MCP tool catalogue confirm Mapper-only before calling a tool. Global settings,
+project settings, Codex and any shared HTTP Runtime remain unchanged. An older
+Runtime without Mapper-only support is declined; Hermes continues natively.
+
+## Mapping and prompt caching
+
+`on_session_start` starts a background map warmup. `pre_llm_call` prepares the
+full native Mapper artifacts using Runtime authentication. On Hermes versions
+with `register_middleware`, the `llm_request` middleware checks authentication
+and repository generation before every provider request and inserts the entire
+verified map into the provider's existing messages, system or instructions
+shape. This uses Hermes' supported middleware rather than changing its global
+hook output-spill limits.
+
+The map bytes are stable across session, turn and request IDs. They contain no
+per-request timestamps or local cache-hit flags. The adapter does not silently
+truncate the map or replace it with a receipt handle. Runtime's normal source
+selection limits and ignores still apply. Provider/model/tools, streaming,
+sampling and existing cache settings are preserved.
+
+Older Hermes versions retain the context-only pre-hook fallback. Their own hook
+output limits may spill large maps; use a Hermes version with request middleware
+for complete provider delivery. The plugin never disables host safeguards to
+work around an older host.
+
+A stable prefix makes provider prompt caching possible; a local Mapper cache
+hit does not prove an LLM cache hit. `post_api_request` records actual host
+usage/cache counters against the matching API request. Missing counters remain
+unknown. No synthetic model request or paid warmup is performed.
+
+## Login and availability
+
+Mapper requires login. Runtime owns the saved session and subscription-period
+verification; the plugin neither copies credentials nor opens login repeatedly.
+Missing login, confirmed inactive subscription, timeout, offline Runtime,
+unsupported Runtime or an invalid map simply omit Simplicio context. Hermes'
+native request and project tools continue. The plugin registers no native tool
+gate, edit wrapper, execution middleware, Loop or Fast integration.
+
+## Install and validate
 
 ```bash
 hermes plugins install wesleysimplicio/simplicio/plugins/simplicio-hermes --force --enable
 hermes plugins doctor simplicio-hermes --ci
 ```
 
-The official Simplicio installers run both commands automatically when `hermes`
-is detected. Restart a running Hermes CLI or gateway after installation so its
-plugin registry reloads.
+Use a Runtime build that advertises Mapper-only and restart Hermes after the
+plugin update. A source merge alone does not update the installed binary.
 
-The JavaScript adapter remains available through `index.mjs` for embedders that
-provide the richer `llm_request`/`llm_execution` middleware contract. A clean
-Hermes installation is verified through the native manifest parser and hook
-registration path; `hermes mcp test simplicio` alone is not treated as plugin
-proof.
+The JavaScript embedder adapter in `index.mjs` follows the same Mapper-only and
+best-effort policy. Its supplied bridge must expose `runtime_mode: "mapper-only"`
+from a verified Runtime handshake and implement the prepare/record methods.
+Legacy `best_effort` and `enforce` constructor options migrate to Mapper-only;
+they do not retain provider blocking. An explicit `maxContextBytes` budget may
+omit an oversized map, but never truncate it or block native work.
+
+Run `python3 -m pytest tests/test_hermes_native_plugin.py` at the repository root
+and `npm test --prefix plugins/simplicio-hermes` for the two adapters.

--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import hashlib
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ from pathlib import Path
 import queue
 import subprocess
 import threading
+import time
 import uuid
 from typing import Any
 
@@ -17,7 +19,17 @@ from typing import Any
 LOGGER = logging.getLogger(__name__)
 _PROTOCOL_VERSION = "2024-11-05"
 _DEFAULT_TIMEOUT_SECONDS = 20.0
-_MAX_CONTEXT_BYTES = 16_384
+_VERSION = "0.3.0"
+RUNTIME_MODE = "mapper-only"
+_MAPPER_TOOLS = frozenset({
+    "simplicio_map", "simplicio_context", "simplicio_read", "simplicio_file_read",
+    "simplicio_search", "simplicio_symbol", "simplicio_prepare_model_call",
+    "simplicio_record_model_result", "simplicio_provider_path_status",
+})
+_BRIDGE_TOOLS = frozenset({
+    "simplicio_prepare_model_call", "simplicio_record_model_result",
+    "simplicio_provider_path_status",
+})
 
 
 class SimplicioHermesError(RuntimeError):
@@ -50,20 +62,21 @@ class RuntimeMcpBridge:
         self._lock = threading.RLock()
         self._next_id = 1
 
-    def _readline(self) -> str:
+    def _readline(self, timeout: float | None = None) -> str:
         if self._process is None or self._process.stdout is None:
             raise SimplicioHermesError("Runtime MCP process is not available")
+        stream = self._process.stdout
         result: queue.Queue[str | BaseException] = queue.Queue(maxsize=1)
 
         def read() -> None:
             try:
-                result.put(self._process.stdout.readline())
+                result.put(stream.readline())
             except BaseException as error:  # pragma: no cover - defensive transport guard
                 result.put(error)
 
         threading.Thread(target=read, daemon=True).start()
         try:
-            value = result.get(timeout=self.timeout)
+            value = result.get(timeout=self.timeout if timeout is None else timeout)
         except queue.Empty as error:
             self.close()
             raise SimplicioHermesError("Runtime MCP response timed out") from error
@@ -84,15 +97,20 @@ class RuntimeMcpBridge:
         request_id = self._next_id
         self._next_id += 1
         self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        deadline = time.monotonic() + self.timeout
         while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self.close()
+                raise SimplicioHermesError("Runtime MCP response timed out")
             try:
-                response = json.loads(self._readline())
+                response = json.loads(self._readline(remaining))
             except json.JSONDecodeError as error:
                 raise SimplicioHermesError("Runtime MCP returned invalid JSON") from error
             if response.get("id") != request_id:
                 continue
             if "error" in response:
-                raise SimplicioHermesError(f"Runtime MCP {method} failed: {response['error']}")
+                raise SimplicioHermesError(f"Runtime MCP {method} failed")
             result = response.get("result")
             if not isinstance(result, dict):
                 raise SimplicioHermesError(f"Runtime MCP {method} returned no result")
@@ -102,31 +120,38 @@ class RuntimeMcpBridge:
         if self._process is not None and self._process.poll() is None:
             return
         binary = self.binary or _find_runtime()
+        # Scope the mode to this plugin-owned process. Never rewrite global,
+        # project, Codex, or shared HTTP Runtime configuration.
+        environment = os.environ.copy()
+        environment["SIMPLICIO_RUNTIME_MODE"] = RUNTIME_MODE
         self._process = subprocess.Popen(
             [str(binary), "serve", "--mcp", "--stdio", "--no-facade-mode"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            encoding="utf-8",
-            bufsize=1,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8", bufsize=1, env=environment,
         )
-        initialized = self._request(
-            "initialize",
-            {
-                "protocolVersion": _PROTOCOL_VERSION,
-                "capabilities": {},
-                "clientInfo": {"name": "simplicio-hermes", "version": "0.2.0"},
-            },
-        )
-        server_info = initialized.get("serverInfo", {})
-        if server_info.get("name") != "simplicio":
+        try:
+            initialized = self._request("initialize", {
+                "protocolVersion": _PROTOCOL_VERSION, "capabilities": {},
+                "clientInfo": {"name": "simplicio-hermes", "version": _VERSION},
+            })
+            if initialized.get("serverInfo", {}).get("name") != "simplicio":
+                raise SimplicioHermesError("unexpected Runtime MCP server identity")
+            mode = initialized.get("x-simplicio", {}).get("session_identity", {}).get("mode")
+            if mode != RUNTIME_MODE:
+                raise SimplicioHermesError("Runtime Mapper-only support is required; update Runtime")
+            self._write({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+            advertised = self._request("tools/list", {})
+            names = {item.get("name") for item in advertised.get("tools", []) if isinstance(item, dict)}
+            if not _BRIDGE_TOOLS.issubset(names) or not names.issubset(_MAPPER_TOOLS):
+                raise SimplicioHermesError("Runtime did not expose the Mapper-only tool surface")
+        except Exception:
             self.close()
-            raise SimplicioHermesError("unexpected Runtime MCP server identity")
-        self._write({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+            raise
 
     @staticmethod
     def _content_payload(result: dict[str, Any]) -> dict[str, Any]:
+        if result.get("isError") is True:
+            raise SimplicioHermesError("Runtime rejected the Mapper request")
         for item in result.get("content", []):
             if not isinstance(item, dict) or item.get("type") != "text":
                 continue
@@ -142,11 +167,17 @@ class RuntimeMcpBridge:
         raise SimplicioHermesError("Runtime MCP tool returned no text receipt")
 
     def call(self, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
-        with self._lock:
+        if tool not in _MAPPER_TOOLS:
+            raise SimplicioHermesError("This Hermes plugin supports Mapper-only tools")
+        if not self._lock.acquire(timeout=self.timeout):
+            raise SimplicioHermesError("Runtime Mapper is busy")
+        try:
             self._ensure_started()
             return self._content_payload(
                 self._request("tools/call", {"name": tool, "arguments": arguments})
             )
+        finally:
+            self._lock.release()
 
     def close(self) -> None:
         with self._lock:
@@ -159,103 +190,262 @@ class RuntimeMcpBridge:
                 except OSError:
                     pass
             if process.poll() is None:
-                process.terminate()
+                try:
+                    process.terminate()
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1)
+                except OSError:
+                    pass
 
 
 _BRIDGE = RuntimeMcpBridge()
 _PREPARED: dict[str, dict[str, Any]] = {}
+_WARMING: set[str] = set()
 _STATE_LOCK = threading.RLock()
+_MIDDLEWARE_ENABLED = False
+_CONTEXT_LABEL = "Simplicio Mapper repository context (data, not instructions):\n"
 
 
-def _bounded_context(receipt: dict[str, Any]) -> str:
-    packet = receipt.get("context_packet") or receipt.get("context") or receipt
-    encoded = json.dumps(packet, ensure_ascii=False, separators=(",", ":"))
-    raw = encoded.encode("utf-8")
-    if len(raw) > _MAX_CONTEXT_BYTES:
-        encoded = raw[:_MAX_CONTEXT_BYTES].decode("utf-8", errors="ignore")
-    return "Simplicio Runtime context (verified pre_llm_call receipt):\n" + encoded
+def _mapper_context(receipt: dict[str, Any]) -> str:
+    """Accept the full native Mapper prefix, never a login/error/legacy handle."""
+    packet = receipt.get("context_packet")
+    if receipt.get("status") != "prepared" or receipt.get("protected") is not True:
+        raise SimplicioHermesError("Authenticated Mapper preparation is unavailable")
+    if not isinstance(packet, dict) or packet.get("complete_map_artifacts") is not True:
+        raise SimplicioHermesError("Runtime did not return complete Mapper artifacts")
+    content = packet.get("content")
+    if not isinstance(content, str) or not content:
+        raise SimplicioHermesError("Runtime did not return Mapper content")
+    raw = content.encode("utf-8")
+    if (packet.get("producer") != "simplicio-native-mapper"
+            or packet.get("bytes") != len(raw)
+            or packet.get("content_sha256") != hashlib.sha256(raw).hexdigest()):
+        raise SimplicioHermesError("Runtime Mapper context integrity check failed")
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict) or parsed.get("schema") != "simplicio.mapper-prefix/v1":
+        raise SimplicioHermesError("Runtime Mapper context schema is unsupported")
+    return _CONTEXT_LABEL + content
 
 
-def _pre_llm_call(
-    session_id: str = "",
-    user_message: str = "",
-    model: str = "",
-    platform: str = "",
-    **kwargs: Any,
-) -> dict[str, str] | None:
-    host_session_id = session_id or str(uuid.uuid4())
-    turn_id = str(kwargs.get("turn_id") or uuid.uuid4())
-    api_request_id = str(kwargs.get("api_request_id") or uuid.uuid4())
-    provider = str(kwargs.get("provider") or platform or "unknown")
-    selected_model = str(model or kwargs.get("model") or "unknown")
-    arguments = {
-        "repo": str(kwargs.get("cwd") or os.getcwd()),
+def _arguments(session_id: str = "", user_message: str = "", model: str = "",
+               **kwargs: Any) -> dict[str, Any]:
+    return {
+        "repo": str(kwargs.get("cwd") or kwargs.get("repo") or os.getenv("TERMINAL_CWD") or os.getcwd()),
         "host": "hermes",
-        "host_session_id": host_session_id,
-        "turn_id": turn_id,
-        "api_request_id": api_request_id,
-        "provider": provider,
-        "model": selected_model,
-        "task": str(user_message),
+        "host_session_id": str(session_id or kwargs.get("host_session_id") or uuid.uuid4()),
+        "turn_id": str(kwargs.get("turn_id") or uuid.uuid4()),
+        "api_request_id": str(kwargs.get("api_request_id") or uuid.uuid4()),
+        "provider": str(kwargs.get("provider") or "unknown"),
+        "model": str(model or "unknown"),
+        # Task text is unnecessary for a full-project map and must not enter
+        # cache identity or per-request evidence.
         "protection_mode": "best_effort",
     }
+
+
+def _prepare(arguments: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    receipt = _BRIDGE.call("simplicio_prepare_model_call", arguments)
+    return receipt, _mapper_context(receipt)
+
+
+def _remember(arguments: dict[str, Any], receipt: dict[str, Any]) -> None:
+    compact = dict(receipt)
+    compact["context_packet"] = {
+        key: value for key, value in receipt["context_packet"].items() if key != "content"
+    }
+    compact["context_packet"]["content_omitted_from_receipt"] = True
+    with _STATE_LOCK:
+        # Bound abandoned/error-request state without storing project source.
+        if len(_PREPARED) >= 128:
+            _PREPARED.pop(next(iter(_PREPARED)))
+        _PREPARED[arguments["api_request_id"]] = {"arguments": arguments, "receipt": compact}
+
+
+def _warn(stage: str, error: Exception) -> None:
+    # Auth/MCP exception strings can contain upstream response bodies.
+    LOGGER.warning("Simplicio Mapper %s unavailable (%s); Hermes continues natively",
+                   stage, type(error).__name__)
+
+
+def _pre_llm_call(session_id: str = "", user_message: str = "", model: str = "",
+                  **kwargs: Any) -> dict[str, str] | None:
+    arguments = _arguments(session_id, user_message, model, **kwargs)
     try:
-        receipt = _BRIDGE.call("simplicio_prepare_model_call", arguments)
-    except Exception as error:  # Hermes pre_llm_call is context-only and fail-open by contract.
-        LOGGER.warning("Simplicio pre_llm_call preparation failed: %s", error)
+        receipt, content = _prepare(arguments)
+        if _MIDDLEWARE_ENABLED:
+            # Hermes spills large pre_llm_call output. The supported request
+            # middleware below delivers the map once at the provider boundary.
+            return None
+        _remember(arguments, receipt)
+        return {"context": content}
+    except Exception as error:
+        _warn("pre-hook", error)
         return None
-    with _STATE_LOCK:
-        _PREPARED[host_session_id] = {"arguments": arguments, "receipt": receipt}
-    return {"context": _bounded_context(receipt)}
 
 
-def _post_llm_call(
-    session_id: str = "",
-    model: str = "",
-    platform: str = "",
-    **kwargs: Any,
-) -> None:
+def _inject_context(request: dict[str, Any], content: str) -> dict[str, Any]:
+    """Add stable data using the provider's existing request shape."""
+    result = dict(request)
+    if "system" in request:  # Anthropic preserves native block cache settings.
+        system = request["system"]
+        if isinstance(system, str):
+            result["system"] = system if system.endswith(content) else system + "\n\n" + content
+        elif isinstance(system, list):
+            block = {"type": "text", "text": content}
+            result["system"] = system if block in system else [*system, block]
+        else:
+            raise SimplicioHermesError("Unsupported provider system shape")
+    elif isinstance(request.get("instructions"), str):  # Responses/Codex
+        instructions = request["instructions"]
+        result["instructions"] = instructions if instructions.endswith(content) else instructions + "\n\n" + content
+    else:
+        field = "messages" if isinstance(request.get("messages"), list) else "input"
+        payload = request.get(field)
+        if isinstance(payload, list):
+            block = {"role": "system", "content": content}
+            result[field] = payload if block in payload else [block, *payload]
+        elif field == "input" and isinstance(payload, str):
+            result[field] = payload if payload.startswith(content) else content + "\n\n" + payload
+        else:
+            raise SimplicioHermesError("Unsupported provider request shape")
+    return result
+
+
+def _llm_request(request: dict[str, Any], session_id: str = "", model: str = "",
+                 **kwargs: Any) -> dict[str, Any] | None:
+    arguments = _arguments(session_id, model=model or request.get("model", ""), **kwargs)
     with _STATE_LOCK:
-        prepared = _PREPARED.get(session_id)
-    if prepared is None:
-        return
+        _PREPARED.pop(arguments["api_request_id"], None)
+    try:
+        receipt, content = _prepare(arguments)
+        updated = _inject_context(request, content)
+        _remember(arguments, receipt)
+        return {"request": updated, "source": "simplicio-hermes", "reason": "mapper_context_prepared"}
+    except Exception as error:
+        _warn("request preparation", error)
+        return None
+
+
+def _token_usage(event: dict[str, Any]) -> dict[str, int]:
+    usage = event.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+    result = {}
+    aliases = {
+        "input_tokens": ("prompt_tokens", "input_tokens"),
+        "output_tokens": ("output_tokens", "completion_tokens"),
+        "cache_read_input_tokens": ("cache_read_input_tokens", "cache_read_tokens"),
+    }
+    for target, names in aliases.items():
+        for source in (event, usage):
+            for name in names:
+                value = source.get(name)
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                    result[target] = value
+                    break
+            if target in result:
+                break
+    if "cache_read_input_tokens" not in result:
+        for key in ("input_tokens_details", "prompt_tokens_details"):
+            details = usage.get(key)
+            cached = details.get("cached_tokens") if isinstance(details, dict) else None
+            if isinstance(cached, int) and not isinstance(cached, bool) and cached >= 0:
+                result["cache_read_input_tokens"] = cached
+                break
+    return result
+
+
+def _record(session_id: str = "", status: str = "completed", **kwargs: Any) -> None:
+    with _STATE_LOCK:
+        candidates = [
+            key for key, item in _PREPARED.items()
+            if item["arguments"]["host_session_id"] == session_id
+            and (not kwargs.get("api_request_id") or key == kwargs["api_request_id"])
+            and (not kwargs.get("turn_id") or item["arguments"]["turn_id"] == kwargs["turn_id"])
+        ]
+        if len(candidates) != 1:
+            return  # Never attribute ambiguous concurrent requests to each other.
+        prepared = _PREPARED.pop(candidates[0])
     original = prepared["arguments"]
     arguments = {
-        "repo": original["repo"],
-        "host": "hermes",
-        "host_session_id": original["host_session_id"],
-        "turn_id": original["turn_id"],
-        "api_request_id": original["api_request_id"],
-        "provider": str(kwargs.get("provider") or platform or original["provider"]),
-        "model": str(model or kwargs.get("model") or original["model"]),
-        "provider_request_id": str(kwargs.get("provider_request_id") or original["api_request_id"]),
-        "status": "completed",
-        "prepared_receipt": prepared["receipt"],
+        key: original[key] for key in (
+            "repo", "host", "host_session_id", "turn_id", "api_request_id", "provider", "model",
+        )
     }
+    arguments.update(status=status, prepared_receipt=prepared["receipt"])
+    arguments.update(_token_usage(kwargs))
+    response = kwargs.get("response")
+    if not isinstance(response, dict):
+        response = {}
+    body = response.get("body")
+    if not isinstance(body, dict):
+        body = {}
+    provider_id = kwargs.get("provider_request_id") or response.get("id") or body.get("id")
+    if isinstance(provider_id, str) and provider_id:
+        arguments["provider_request_id"] = provider_id
     try:
         _BRIDGE.call("simplicio_record_model_result", arguments)
     except Exception as error:
-        LOGGER.warning("Simplicio post_llm_call receipt failed: %s", error)
+        _warn("result recording", error)
 
 
-def _on_session_start(**_kwargs: Any) -> None:
-    return None
+def _post_llm_call(session_id: str = "", **kwargs: Any) -> None:
+    if not _MIDDLEWARE_ENABLED:
+        _record(session_id, **kwargs)
+
+
+def _post_api_request(session_id: str = "", **kwargs: Any) -> None:
+    _record(session_id, **kwargs)
+
+
+def _api_request_error(session_id: str = "", **kwargs: Any) -> None:
+    kwargs.pop("status", None)
+    _record(session_id, status="error", **kwargs)
+
+
+def _on_session_start(session_id: str = "", **kwargs: Any) -> None:
+    arguments = _arguments(session_id, **kwargs)
+    key = arguments["repo"]
+    with _STATE_LOCK:
+        if key in _WARMING:
+            return
+        _WARMING.add(key)
+
+    def warm() -> None:
+        try:
+            _prepare(arguments)  # Authentication remains owned by Runtime.
+        except Exception as error:
+            _warn("session mapping", error)
+        finally:
+            with _STATE_LOCK:
+                _WARMING.discard(key)
+    threading.Thread(target=warm, name="simplicio-mapper-warmup", daemon=True).start()
 
 
 def _on_session_end(session_id: str = "", **_kwargs: Any) -> None:
     with _STATE_LOCK:
-        _PREPARED.pop(session_id, None)
+        for key in [key for key, item in _PREPARED.items()
+                    if item["arguments"]["host_session_id"] == session_id]:
+            _PREPARED.pop(key, None)
 
 
 def register(ctx: Any) -> None:
-    """Register the native Hermes lifecycle hooks."""
+    """Only Mapper preparation/telemetry; no tool gates or execution wrappers."""
+    global _MIDDLEWARE_ENABLED
+    _MIDDLEWARE_ENABLED = callable(getattr(ctx, "register_middleware", None))
     ctx.register_hook("on_session_start", _on_session_start)
     ctx.register_hook("pre_llm_call", _pre_llm_call)
     ctx.register_hook("post_llm_call", _post_llm_call)
     ctx.register_hook("on_session_end", _on_session_end)
+    if _MIDDLEWARE_ENABLED:
+        ctx.register_middleware("llm_request", _llm_request)
+        ctx.register_hook("post_api_request", _post_api_request)
+        ctx.register_hook("api_request_error", _api_request_error)
 
 
 atexit.register(_BRIDGE.close)
 
 
-__all__ = ["RuntimeMcpBridge", "SimplicioHermesError", "register"]
+__all__ = ["RUNTIME_MODE", "RuntimeMcpBridge", "SimplicioHermesError", "register"]

--- a/plugins/simplicio-hermes/index.mjs
+++ b/plugins/simplicio-hermes/index.mjs
@@ -1,223 +1,191 @@
+import { createHash, randomUUID } from "node:crypto";
+
 const HOOK_NAMES = [
-  "on_session_start",
-  "llm_request",
-  "llm_execution",
-  "post_api_request",
-  "api_request_error",
+  "on_session_start", "llm_request", "llm_execution", "post_api_request", "api_request_error",
 ];
-
-const DEFAULT_MAX_CONTEXT_BYTES = 32 * 1024;
-
 export const HERMES_HOOKS = Object.freeze([...HOOK_NAMES]);
+export const RUNTIME_MODE = "mapper-only";
 
 export class HermesProtectionError extends Error {
-  constructor(reasonCode, cause) {
-    super(`Hermes protection blocked the provider request: ${reasonCode}`);
+  constructor(reasonCode) {
+    super(`Hermes Mapper preparation unavailable: ${reasonCode}`);
     this.name = "HermesProtectionError";
     this.reasonCode = reasonCode;
-    this.cause = cause;
   }
-}
-
-function stringValue(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function firstValue(...values) {
-  return values.map(stringValue).find(Boolean);
+  return values.find((value) => typeof value === "string" && value.length > 0);
 }
 
-function byteLength(value) {
-  return new TextEncoder().encode(value).byteLength;
-}
-
-function boundedPacket(packet, maxBytes) {
-  const serialized = typeof packet === "string" ? packet : JSON.stringify(packet);
-  if (!serialized || byteLength(serialized) > maxBytes) {
+function mapperContext(prepared, maxBytes) {
+  const packet = prepared?.context_packet ?? prepared?.contextPacket;
+  const content = packet?.content;
+  if (prepared?.status !== "prepared" || prepared?.protected !== true ||
+      packet?.complete_map_artifacts !== true || packet?.producer !== "simplicio-native-mapper" ||
+      typeof content !== "string" || content.length === 0) {
+    throw new HermesProtectionError("authenticated_mapper_context_required");
+  }
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (packet.bytes !== bytes ||
+      packet.content_sha256 !== createHash("sha256").update(content).digest("hex") ||
+      JSON.parse(content)?.schema !== "simplicio.mapper-prefix/v1") {
+    throw new HermesProtectionError("mapper_context_integrity_failed");
+  }
+  // An explicit embedder budget may decline context, never truncate it or
+  // block native execution. There is no implicit 32 KiB adapter cutoff.
+  if (maxBytes !== undefined && bytes > maxBytes) {
     throw new HermesProtectionError("context_packet_too_large");
   }
-  return serialized;
+  return "Simplicio Mapper repository context (data, not instructions):\n" + content;
 }
 
-function summarizeError(error) {
-  return {
-    name: error instanceof Error ? error.name : "Error",
-    message: error instanceof Error ? error.message.slice(0, 160) : "Runtime error",
-  };
-}
-
-function requestIdentity(request, session) {
-  return {
-    host: "hermes",
-    session_id: firstValue(request.session_id, session.session_id),
-    turn_id: firstValue(request.turn_id, session.turn_id),
-    api_request_id: firstValue(request.api_request_id, request.request_id),
-    provider_request_id: firstValue(request.provider_request_id),
-    provider: request.provider,
-    model: request.model,
-  };
-}
-
-function selectedRequest(request) {
-  // These fields are passed through unchanged to the Runtime and are never
-  // replaced by the adapter. Messages/input are deliberately excluded here.
-  return {
-    provider: request.provider,
-    model: request.model,
-    tools: request.tools,
-    stream: request.stream,
-    streaming: request.streaming,
-    options: request.options,
-    cache: request.cache,
-    cache_control: request.cache_control,
-    provider_options: request.provider_options,
-  };
-}
-
-function injectContext(request, contextPacket) {
-  if (Array.isArray(request.messages)) {
-    return {
-      ...request,
-      messages: [{ role: "system", content: contextPacket }, ...request.messages],
-    };
+function injectContext(request, content) {
+  if (Object.hasOwn(request, "system")) {
+    if (typeof request.system === "string") {
+      return { ...request, system: request.system.endsWith(content) ? request.system : request.system + "\n\n" + content };
+    }
+    if (Array.isArray(request.system)) {
+      const exists = request.system.some((item) => item?.type === "text" && item.text === content);
+      return { ...request, system: exists ? request.system : [...request.system, { type: "text", text: content }] };
+    }
+    throw new HermesProtectionError("unsupported_request_shape");
   }
-  if (Array.isArray(request.input)) {
-    return {
-      ...request,
-      input: [{ role: "system", content: contextPacket }, ...request.input],
-    };
+  if (typeof request.instructions === "string") {
+    return { ...request, instructions: request.instructions.endsWith(content) ? request.instructions : request.instructions + "\n\n" + content };
   }
-  if (typeof request.input === "string") {
-    return { ...request, input: `${contextPacket}\n\n${request.input}` };
+  const field = Array.isArray(request.messages) ? "messages" : "input";
+  if (Array.isArray(request[field])) {
+    const exists = request[field].some((item) => item?.role === "system" && item.content === content);
+    return { ...request, [field]: exists ? request[field] : [{ role: "system", content }, ...request[field]] };
   }
-  return { ...request, context_packet: contextPacket };
+  if (field === "input" && typeof request.input === "string") {
+    return { ...request, input: request.input.startsWith(content) ? request.input : content + "\n\n" + request.input };
+  }
+  throw new HermesProtectionError("unsupported_request_shape");
 }
 
-function eventUsage(event) {
-  return event.usage ?? event.response?.usage ?? event.result?.usage;
-}
-
-function eventCache(event) {
-  return event.cache ?? event.response?.cache ?? event.result?.cache;
-}
-
-function eventCost(event) {
-  return event.cost ?? event.response?.cost ?? event.result?.cost;
+function tokenUsage(event) {
+  const usage = event.usage ?? event.response?.usage ?? event.result?.usage ?? {};
+  const aliases = {
+    input_tokens: ["prompt_tokens", "input_tokens"],
+    output_tokens: ["output_tokens", "completion_tokens"],
+    cache_read_input_tokens: ["cache_read_input_tokens", "cache_read_tokens"],
+  };
+  const result = {};
+  for (const [target, names] of Object.entries(aliases)) {
+    for (const source of [event, usage]) {
+      const value = names.map((name) => source?.[name]).find((item) => Number.isSafeInteger(item) && item >= 0);
+      if (value !== undefined) { result[target] = value; break; }
+    }
+  }
+  if (result.cache_read_input_tokens === undefined) {
+    const value = usage.input_tokens_details?.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens;
+    if (Number.isSafeInteger(value) && value >= 0) result.cache_read_input_tokens = value;
+  }
+  return result;
 }
 
 /**
- * Hermes native middleware adapter. The injected runtime is the only source
- * of ContextPacket and ledger receipts; this package never invokes a model.
+ * Thin embedder adapter. Its bridge must advertise a verified Mapper-only
+ * Runtime; it never switches a shared Runtime or invokes a model itself.
  */
-export function createHermesPlugin({
-  runtime,
-  mode = "best_effort",
-  maxContextBytes = DEFAULT_MAX_CONTEXT_BYTES,
-} = {}) {
-  if (mode !== "best_effort" && mode !== "enforce") {
-    throw new TypeError("Hermes mode must be best_effort or enforce");
+export function createHermesPlugin({ runtime, mode = RUNTIME_MODE, maxContextBytes } = {}) {
+  // Migrate old protection-mode settings without retaining provider blocking.
+  if (![RUNTIME_MODE, "best_effort", "enforce"].includes(mode)) {
+    throw new TypeError("Hermes supports only mapper-only Runtime");
   }
-
   const runtimeBridge = runtime ?? {};
-  const session = { session_id: undefined, turn_id: undefined };
+  const session = {};
+  const pending = new Map();
   const state = {
-    context_path_active: false,
-    provider_path_active: false,
-    usage_collector_active: false,
-    last_reason_code: "session_not_started",
-    generation: undefined,
+    context_path_active: false, provider_path_active: false, usage_collector_active: false,
+    provider_cache_status: "unknown", last_reason_code: "session_not_started",
   };
 
   function status() {
-    const mcpAvailable = runtimeBridge.mcp_available === true || runtimeBridge.capabilities?.mcp_available === true;
-    const protectedRequest = state.context_path_active && state.provider_path_active && state.usage_collector_active;
     return {
-      host: "hermes",
-      plugin_installed: true,
-      plugin_enabled: true,
-      mcp_available: mcpAvailable,
-      context_path_active: state.context_path_active,
-      provider_path_active: state.provider_path_active,
-      usage_collector_active: state.usage_collector_active,
-      protected: protectedRequest,
-      mode,
-      generation: state.generation,
-      reason_code: protectedRequest ? "protected" : state.last_reason_code,
+      host: "hermes", plugin_installed: true, plugin_enabled: true,
+      mcp_available: runtimeBridge.mcp_available === true,
+      ...state, mode: RUNTIME_MODE, failure_policy: "best_effort",
+      protected: state.context_path_active && state.provider_path_active && state.usage_collector_active,
+      reason_code: state.last_reason_code,
     };
   }
 
-  function fail(reasonCode, cause) {
+  function failed(payload, reasonCode) {
     state.last_reason_code = reasonCode;
-    if (mode === "enforce") throw new HermesProtectionError(reasonCode, cause);
+    return { ...payload, simplicio: { protected: false, mode: RUNTIME_MODE, reason_code: reasonCode } };
   }
 
   async function prepare_model_call(request = {}) {
-    if (typeof runtimeBridge.prepare_model_call !== "function") {
-      fail("runtime_prepare_unavailable");
-      return { ...request, simplicio: { protected: false, reason_code: "runtime_prepare_unavailable" } };
+    state.context_path_active = state.provider_path_active = state.usage_collector_active = false;
+    state.provider_cache_status = "unknown";
+    if ((runtimeBridge.runtime_mode ?? runtimeBridge.capabilities?.runtime_mode) !== RUNTIME_MODE) {
+      return failed(request, "runtime_mapper_only_required");
     }
-
-    const identity = requestIdentity(request, session);
+    if (typeof runtimeBridge.prepare_model_call !== "function") {
+      return failed(request, "runtime_prepare_unavailable");
+    }
+    const identity = {
+      host: "hermes",
+      host_session_id: firstValue(request.session_id, session.session_id) ?? randomUUID(),
+      turn_id: firstValue(request.turn_id, session.turn_id) ?? randomUUID(),
+      api_request_id: firstValue(request.api_request_id, request.request_id) ?? randomUUID(),
+      provider: request.provider ?? "unknown", model: request.model ?? "unknown",
+    };
+    pending.delete(identity.api_request_id);
     try {
       const prepared = await runtimeBridge.prepare_model_call({
-        ...selectedRequest(request),
-        ...identity,
-        host_session_id: identity.session_id,
-        host_turn_id: identity.turn_id,
+        ...identity, repo: request.repo ?? request.cwd ?? process.cwd(), protection_mode: "best_effort",
       });
-      const packet = boundedPacket(prepared?.contextPacket ?? prepared?.context_packet, maxContextBytes);
-      state.context_path_active = true;
-      state.provider_path_active = true;
-      state.generation = firstValue(prepared.generation, prepared.map_generation);
+      const content = mapperContext(prepared, maxContextBytes);
+      const updated = injectContext(request, content);
+      const packet = prepared.context_packet ?? prepared.contextPacket;
+      const { content: omitted, ...packetMetadata } = packet;
+      if (pending.size >= 128) pending.delete(pending.keys().next().value);
+      pending.set(identity.api_request_id, {
+        identity, repo: request.repo ?? request.cwd ?? process.cwd(),
+        receipt: { ...prepared, context_packet: { ...packetMetadata, content_omitted_from_receipt: true } },
+      });
+      // Avoid a camelCase duplicate carrying source context into result receipts.
+      delete pending.get(identity.api_request_id).receipt.contextPacket;
+      state.context_path_active = state.provider_path_active = true;
       state.last_reason_code = "context_prepared";
-      return {
-        ...injectContext(request, packet),
-        simplicio: {
-          protected: true,
-          reason_code: "context_prepared",
-          generation: state.generation,
-          session_id: identity.session_id,
-          turn_id: identity.turn_id,
-        },
-      };
+      return { ...updated, simplicio: {
+        protected: true, mode: RUNTIME_MODE, reason_code: "context_prepared",
+        session_id: identity.host_session_id, turn_id: identity.turn_id,
+        api_request_id: identity.api_request_id, provider_cache_status: "unknown",
+      } };
     } catch (error) {
-      const reasonCode = error instanceof HermesProtectionError ? error.reasonCode : "runtime_prepare_failed";
-      fail(reasonCode, error);
-      return {
-        ...request,
-        simplicio: { protected: false, reason_code: reasonCode },
-      };
+      return failed(request, error instanceof HermesProtectionError ? error.reasonCode : "runtime_prepare_failed");
     }
   }
 
   async function record_model_result(event = {}) {
-    if (typeof runtimeBridge.record_model_result !== "function") {
-      fail("runtime_record_unavailable");
-      return { ...event, simplicio: { protected: false, reason_code: "runtime_record_unavailable" } };
+    const id = firstValue(event.api_request_id, event.request_id, event.simplicio?.api_request_id);
+    const prepared = pending.get(id);
+    if (!prepared || (event.session_id && event.session_id !== prepared.identity.host_session_id)) {
+      return failed(event, "request_not_prepared");
     }
-
-    const identity = requestIdentity(event, session);
+    pending.delete(id);
+    if (typeof runtimeBridge.record_model_result !== "function") {
+      return failed(event, "runtime_record_unavailable");
+    }
+    const providerId = firstValue(event.provider_request_id, event.response?.id, event.response?.body?.id, event.result?.id);
     try {
-      await runtimeBridge.record_model_result({
-        ...identity,
-        usage: eventUsage(event),
-        cache: eventCache(event),
-        cost: eventCost(event),
-        provider_request_id: firstValue(event.provider_request_id, event.response?.id, event.result?.id),
-        api_request_id: firstValue(event.api_request_id, event.request_id),
-        usage_source: event.usage_source ?? "hermes_post_api_request",
-        error: event.error ? summarizeError(event.error) : undefined,
+      const receipt = await runtimeBridge.record_model_result({
+        ...prepared.identity, repo: prepared.repo, prepared_receipt: prepared.receipt,
+        status: event.error ? "error" : "completed", ...tokenUsage(event),
+        ...(providerId ? { provider_request_id: providerId } : {}),
       });
       state.usage_collector_active = true;
+      state.provider_cache_status = receipt?.savings?.provider_cache_status ?? "unknown";
       state.last_reason_code = "receipt_recorded";
-      return {
-        ...event,
-        simplicio: { protected: state.context_path_active && state.provider_path_active, reason_code: "receipt_recorded" },
-      };
-    } catch (error) {
-      const reasonCode = "runtime_record_failed";
-      fail(reasonCode, error);
-      return { ...event, simplicio: { protected: false, reason_code: reasonCode } };
+      return { ...event, simplicio: { protected: true, mode: RUNTIME_MODE, reason_code: "receipt_recorded",
+        provider_cache_status: state.provider_cache_status } };
+    } catch {
+      return failed(event, "runtime_record_failed");
     }
   }
 
@@ -229,32 +197,14 @@ export function createHermesPlugin({
       return { ...context, simplicio: status() };
     },
     llm_request: prepare_model_call,
-    llm_execution(event = {}) {
-      const identity = requestIdentity(event, session);
-      return {
-        ...event,
-        simplicio: {
-          ...event.simplicio,
-          session_id: identity.session_id,
-          turn_id: identity.turn_id,
-          api_request_id: identity.api_request_id,
-          provider_request_id: identity.provider_request_id,
-          protected: state.context_path_active && state.provider_path_active,
-        },
-      };
-    },
+    llm_execution(event = {}) { return event; }, // Native execution remains untouched.
     post_api_request: record_model_result,
-    api_request_error: (event = {}) => record_model_result({ ...event, error: event.error ?? event }),
+    api_request_error: (event = {}) => record_model_result({ ...event, error: event.error ?? true }),
   };
 
   return Object.freeze({
-    name: "simplicio-hermes",
-    version: "0.1.0",
-    mode,
-    hooks,
-    status,
-    prepare_model_call,
-    record_model_result,
+    name: "simplicio-hermes", version: "0.3.0", mode: RUNTIME_MODE,
+    hooks, status, prepare_model_call, record_model_result,
   });
 }
 

--- a/plugins/simplicio-hermes/manifest.json
+++ b/plugins/simplicio-hermes/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "host": "hermes",
   "entry": "./index.mjs",
   "hooks": [
@@ -10,9 +10,14 @@
     "post_api_request",
     "api_request_error"
   ],
-  "modes": ["best_effort", "enforce"],
+  "modes": [
+    "mapper-only"
+  ],
   "runtime": {
     "prepare": "prepare_model_call",
-    "record": "record_model_result"
-  }
+    "record": "record_model_result",
+    "mode": "mapper-only",
+    "login_required": true
+  },
+  "failure_policy": "best_effort"
 }

--- a/plugins/simplicio-hermes/package.json
+++ b/plugins/simplicio-hermes/package.json
@@ -1,11 +1,15 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.1.0",
-  "description": "Native Hermes middleware adapter for deterministic Simplicio Runtime preparation and receipts.",
+  "version": "0.3.0",
+  "description": "Authenticated Mapper-only context and provider cache telemetry for Hermes.",
   "type": "module",
   "main": "./index.mjs",
   "exports": "./index.mjs",
-  "engines": { "node": ">=18" },
-  "scripts": { "test": "node --test ./test.mjs" },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test ./test.mjs"
+  },
   "license": "MIT"
 }

--- a/plugins/simplicio-hermes/plugin.yaml
+++ b/plugins/simplicio-hermes/plugin.yaml
@@ -1,9 +1,11 @@
 name: simplicio-hermes
-version: 0.2.0
-description: Simplicio Runtime context preparation and provider receipts for Hermes Agent.
+version: 0.3.0
+description: Authenticated Mapper-only context and provider cache telemetry for Hermes Agent.
 author: Wesley Simplicio
 provides_hooks:
   - on_session_start
   - pre_llm_call
   - post_llm_call
   - on_session_end
+  - post_api_request
+  - api_request_error

--- a/plugins/simplicio-hermes/skills/simplicio-hermes/SKILL.md
+++ b/plugins/simplicio-hermes/skills/simplicio-hermes/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: simplicio-hermes
-description: Integrate or validate the Simplicio middleware adapter for Hermes model calls and provider receipts.
+description: Integrate or validate the Hermes Mapper-only plugin, full-map request middleware, and provider cache receipts.
 ---
 
 # Simplicio Hermes
 
-Use the native middleware adapter to prepare Hermes model calls through the Simplicio Runtime and record redacted provider receipts.
+1. Verify the native plugin manifest and, for full provider delivery, Hermes request middleware registration.
+2. Start the plugin-owned Runtime in Mapper-only and verify its advertised mode and tool catalogue. Keep other clients' configuration unchanged.
+3. Require Runtime login for Mapper. On missing auth or unavailable Runtime, preserve the native Hermes request and tools.
+4. Prepare the full native map in the pre-hook and deliver its stable content through request middleware. Preserve provider, model, tools, streaming, and existing cache options.
+5. Record only matching request identifiers and real provider usage. Missing cache telemetry remains unknown; keep credentials, prompts and response bodies out of receipts.
+6. Run the native Python tests and this plugin's npm tests. Verify large maps, unavailable login, Runtime failure, native tool independence and request correlation.
 
-## Workflow
-
-1. Confirm the host loads the plugin manifest and middleware entry point.
-2. Preserve the caller request; add only Runtime preparation metadata.
-3. Keep preparation best-effort unless the host explicitly enables enforcement.
-4. Record redacted usage and cache metadata only; never store prompts, credentials, or response bodies.
-5. Run `npm test` in this plugin before delivery.
-
-The Runtime response is authoritative. Treat a missing or malformed response as degraded operation and never synthesize a successful preparation or receipt.
+Read the plugin README for legacy-host limitations and installation. Treat missing
+or malformed Runtime evidence as degraded operation; never synthesize a
+successful map or receipt. Hermes uses Mapper-only with best-effort delivery.

--- a/plugins/simplicio-hermes/test.mjs
+++ b/plugins/simplicio-hermes/test.mjs
@@ -1,117 +1,160 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { test } from "node:test";
-import { createHermesPlugin, HermesProtectionError, HERMES_HOOKS } from "./index.mjs";
+import { createHermesPlugin, HERMES_HOOKS, RUNTIME_MODE } from "./index.mjs";
 
 function runtimeFixture() {
   const calls = { prepare: [], record: [] };
+  const content = JSON.stringify({
+    schema: "simplicio.mapper-prefix/v1",
+    project_map: { files: Array(4000).fill("module_á.py") },
+    symbol_index: { symbols: ["complete_map_tail"] },
+  });
   return {
-    calls,
-    mcp_available: true,
+    calls, mcp_available: true, runtime_mode: RUNTIME_MODE,
     async prepare_model_call(input) {
       calls.prepare.push(input);
-      return { contextPacket: { generation: "g1", facts: ["bounded"] }, generation: "g1" };
+      return { status: "prepared", protected: true, api_request_id: input.api_request_id,
+        provider_cache_status: "unknown", context_packet: {
+          producer: "simplicio-native-mapper", complete_map_artifacts: true,
+          content, bytes: Buffer.byteLength(content),
+          content_sha256: createHash("sha256").update(content).digest("hex"),
+        } };
     },
     async record_model_result(input) {
       calls.record.push(input);
+      return { savings: { provider_cache_status: input.cache_read_input_tokens === undefined ? "unknown" : "reported" } };
     },
   };
 }
 
-test("registers every native request/receipt surface", () => {
+test("registers only Mapper preparation and receipt surfaces", () => {
   assert.deepEqual(HERMES_HOOKS, ["on_session_start", "llm_request", "llm_execution", "post_api_request", "api_request_error"]);
+  assert.equal(createHermesPlugin().mode, "mapper-only");
 });
 
-test("prepares every provider request and preserves provider identity/options", async () => {
+test("complete stable map reaches provider and keeps all native options", async () => {
   const runtime = runtimeFixture();
-  const plugin = createHermesPlugin({ runtime, mode: "enforce" });
-  plugin.hooks.on_session_start({ session_id: "s1", turn_id: "t1" });
+  const plugin = createHermesPlugin({ runtime });
   const request = {
-    provider: "openrouter",
-    model: "anthropic/claude-sonnet",
-    tools: [{ type: "function", name: "search" }],
-    stream: true,
+    provider: "openrouter", model: "model",
+    tools: [{ type: "function", name: "native_edit" }], stream: true,
     options: { temperature: 0.2, max_tokens: 300 },
     cache: { read: true, write: true },
     messages: [{ role: "user", content: "hello" }],
   };
-  const prepared = await plugin.hooks.llm_request(request);
-  assert.equal(prepared.provider, request.provider);
-  assert.equal(prepared.model, request.model);
-  assert.deepEqual(prepared.tools, request.tools);
-  assert.deepEqual(prepared.options, request.options);
-  assert.deepEqual(prepared.cache, request.cache);
-  assert.equal(prepared.messages[1].content, "hello");
-  assert.match(prepared.messages[0].content, /bounded/);
-  assert.deepEqual(runtime.calls.prepare[0], {
-    provider: request.provider,
-    model: request.model,
-    tools: request.tools,
-    stream: true,
-    streaming: undefined,
-    options: request.options,
-    cache: request.cache,
-    cache_control: undefined,
-    provider_options: undefined,
-    host: "hermes",
-    session_id: "s1",
-    turn_id: "t1",
-    api_request_id: undefined,
-    provider_request_id: undefined,
-    host_session_id: "s1",
-    host_turn_id: "t1",
-  });
-  assert.equal(plugin.status().protected, false);
+  const original = structuredClone(request);
+  const a = await plugin.hooks.llm_request({ ...request, api_request_id: "a", session_id: "s1" });
+  const b = await plugin.hooks.llm_request({ ...request, api_request_id: "b", session_id: "s2" });
+  assert.equal(a.messages[0].content, b.messages[0].content);
+  assert.ok(Buffer.byteLength(a.messages[0].content) > 32768);
+  assert.match(a.messages[0].content, /complete_map_tail/);
+  assert.deepEqual(request, original);
+  for (const field of ["provider", "model", "tools", "stream", "options", "cache"]) {
+    assert.deepEqual(a[field], request[field]);
+  }
+  assert.deepEqual(a.messages.slice(1), request.messages);
+  assert.equal(runtime.calls.prepare[0].protection_mode, "best_effort");
+  assert.equal(runtime.calls.prepare[0].host_session_id, "s1");
+  assert.equal(runtime.calls.prepare[0].messages, undefined);
+  assert.equal(runtime.calls.prepare[0].tools, undefined);
+  assert.equal(a.simplicio.provider_cache_status, "unknown");
 });
 
-test("records usage/cache/cost and correlates all request identifiers", async () => {
+for (const [field, value] of [
+  ["system", "native policy"],
+  ["system", [{ type: "text", text: "native policy", cache_control: { type: "ephemeral" } }]],
+  ["instructions", "native policy"],
+  ["input", [{ role: "user", content: "hello" }]],
+  ["input", "hello"],
+]) {
+  test(`preserves ${field} provider shape and includes complete map`, async () => {
+    const plugin = createHermesPlugin({ runtime: runtimeFixture() });
+    const result = await plugin.prepare_model_call({ [field]: value });
+    assert.match(JSON.stringify(result[field]), /complete_map_tail/);
+    if (Array.isArray(value) && field === "system") assert.deepEqual(result[field][0], value[0]);
+  });
+}
+
+test("unscoped full Runtime is never called", async () => {
   const runtime = runtimeFixture();
-  const plugin = createHermesPlugin({ runtime, mode: "best_effort" });
-  plugin.hooks.on_session_start({ session_id: "s1" });
-  await plugin.hooks.llm_request({ provider: "openai", model: "gpt-5", messages: [] });
-  const execution = plugin.hooks.llm_execution({ turn_id: "t2", api_request_id: "a2", provider_request_id: "p2" });
-  assert.equal(execution.simplicio.api_request_id, "a2");
-  await plugin.hooks.post_api_request({
-    session_id: "s1",
-    turn_id: "t2",
-    api_request_id: "a2",
-    provider_request_id: "p2",
-    usage: { input_tokens: 10, output_tokens: 4 },
-    cache: { read_tokens: 8, write_tokens: 2 },
-    cost: { usd: 0.01 },
-  });
-  assert.deepEqual(runtime.calls.record[0].usage, { input_tokens: 10, output_tokens: 4 });
-  assert.deepEqual(runtime.calls.record[0].cache, { read_tokens: 8, write_tokens: 2 });
-  assert.equal(runtime.calls.record[0].provider_request_id, "p2");
-  assert.equal(runtime.calls.record[0].api_request_id, "a2");
-  assert.equal(plugin.status().usage_collector_active, true);
+  runtime.runtime_mode = "full";
+  const plugin = createHermesPlugin({ runtime });
+  const original = { messages: [{ role: "user", content: "native work" }] };
+  const result = await plugin.prepare_model_call(original);
+  assert.deepEqual(result.messages, original.messages);
+  assert.equal(runtime.calls.prepare.length, 0);
+  assert.equal(result.simplicio.reason_code, "runtime_mapper_only_required");
 });
 
-test("enforce blocks a provider request when preparation fails", async () => {
-  const plugin = createHermesPlugin({
-    runtime: { async prepare_model_call() { throw new Error("offline"); } },
-    mode: "enforce",
-  });
-  await assert.rejects(
-    plugin.hooks.llm_request({ provider: "x", model: "y", messages: [] }),
-    (error) => error instanceof HermesProtectionError && error.reasonCode === "runtime_prepare_failed",
-  );
-  assert.equal(plugin.status().protected, false);
-});
-
-test("best_effort remains fail-open but exposes typed protection status", async () => {
-  let llmCalls = 0;
-  const plugin = createHermesPlugin({
-    runtime: { async prepare_model_call() { throw new Error("offline"); } },
-    mode: "best_effort",
-  });
-  const request = { provider: "x", model: "y", tools: [{ name: "keep" }], messages: [] };
+test("legacy enforce settings migrate without blocking native requests", async () => {
+  const runtime = runtimeFixture();
+  runtime.prepare_model_call = async () => { throw new Error("secret-token"); };
+  const plugin = createHermesPlugin({ runtime, mode: "enforce" });
+  const request = { provider: "p", model: "m", tools: [{ name: "native" }], messages: [] };
   const result = await plugin.hooks.llm_request(request);
-  llmCalls += 1;
-  assert.equal(llmCalls, 1);
-  assert.equal(result.provider, request.provider);
-  assert.equal(result.model, request.model);
   assert.deepEqual(result.tools, request.tools);
   assert.equal(result.simplicio.protected, false);
-  assert.equal(plugin.status().reason_code, "runtime_prepare_failed");
-  assert.doesNotMatch(JSON.stringify(plugin.status()), /offline|secret|hello/);
+  assert.equal(plugin.status().mode, "mapper-only");
+  assert.doesNotMatch(JSON.stringify(plugin.status()), /secret-token/);
+});
+
+test("missing login and corrupt map never become provider context", async () => {
+  for (const receipt of [
+    { status: "login_required", login_required: true },
+    { status: "degraded", protected: false },
+    { status: "prepared", protected: true, context_packet: { content: "old full-mode handle" } },
+  ]) {
+    const runtime = runtimeFixture();
+    runtime.prepare_model_call = async () => receipt;
+    const result = await createHermesPlugin({ runtime }).prepare_model_call({ messages: [] });
+    assert.deepEqual(result.messages, []);
+    assert.equal(result.simplicio.protected, false);
+  }
+});
+
+test("an explicit size budget omits the map without truncating or blocking", async () => {
+  const plugin = createHermesPlugin({ runtime: runtimeFixture(), mode: "enforce", maxContextBytes: 64 });
+  const result = await plugin.prepare_model_call({ messages: [] });
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.simplicio.reason_code, "context_packet_too_large");
+});
+
+test("records actual cache telemetry with matching request and no source bodies", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime });
+  for (const id of ["a", "b"]) await plugin.prepare_model_call({
+    messages: [], api_request_id: id, session_id: "s", turn_id: "t", provider: "p", model: "m",
+  });
+  await plugin.record_model_result({
+    session_id: "s", api_request_id: "a", response: { id: "provider-a" },
+    usage: { input_tokens: 20, prompt_tokens: 100, output_tokens: 4, cache_read_tokens: 80 },
+  });
+  const record = runtime.calls.record[0];
+  assert.equal(record.api_request_id, "a");
+  assert.equal(record.provider_request_id, "provider-a");
+  assert.equal(record.cache_read_input_tokens, 80);
+  assert.equal(record.input_tokens, 100);
+  assert.doesNotMatch(JSON.stringify(record), /complete_map_tail/);
+  assert.equal(plugin.status().provider_cache_status, "reported");
+  await plugin.record_model_result({ session_id: "s", api_request_id: "b" });
+  assert.equal(runtime.calls.record[1].cache_read_input_tokens, undefined);
+  assert.equal(runtime.calls.record[1].provider_request_id, undefined);
+  assert.equal(plugin.status().provider_cache_status, "unknown");
+});
+
+test("result recording failure never interrupts completed native work", async () => {
+  const runtime = runtimeFixture();
+  runtime.record_model_result = async () => { throw new Error("offline"); };
+  const plugin = createHermesPlugin({ runtime, mode: "enforce" });
+  await plugin.prepare_model_call({ messages: [], api_request_id: "a" });
+  const event = { api_request_id: "a", result: { text: "native answer" } };
+  const result = await plugin.record_model_result(event);
+  assert.deepEqual(result.result, event.result);
+  assert.equal(result.simplicio.reason_code, "runtime_record_failed");
+});
+
+test("execution is always the host's original event", () => {
+  const event = { execute: () => "native" };
+  assert.equal(createHermesPlugin().hooks.llm_execution(event), event);
 });

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import io
 import json
+import threading
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 
 ROOT = Path(__file__).parents[1]
@@ -18,75 +23,367 @@ def load_adapter() -> ModuleType:
     return module
 
 
-class FakeContext:
-    def __init__(self) -> None:
-        self.hooks = {}
+def mapper_receipt(arguments=None, content=None):
+    arguments = arguments or {}
+    content = content or json.dumps({
+        "schema": "simplicio.mapper-prefix/v1",
+        "project_map": {"files": ["module_á.py"] * 4000},
+        "symbol_index": {"symbols": ["complete_map_tail"]},
+    }, ensure_ascii=False, separators=(",", ":"))
+    return {
+        "status": "prepared", "protected": True,
+        "api_request_id": arguments.get("api_request_id", "request"),
+        "host_session_id": arguments.get("host_session_id", "session"),
+        "provider_cache_status": "unknown",
+        "context_packet": {
+            "schema": "simplicio.context-packet/v1",
+            "producer": "simplicio-native-mapper",
+            "complete_map_artifacts": True,
+            "content": content,
+            "bytes": len(content.encode("utf-8")),
+            "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        },
+    }
 
-    def register_hook(self, name, callback) -> None:
+
+class FakeContext:
+    def __init__(self):
+        self.hooks = {}
+        self.middleware = {}
+
+    def register_hook(self, name, callback):
         self.hooks[name] = callback
+
+    def register_middleware(self, name, callback):
+        self.middleware[name] = callback
 
 
 class FakeBridge:
-    def __init__(self) -> None:
+    def __init__(self):
         self.calls = []
+        self.failure = None
 
     def call(self, tool, arguments):
         self.calls.append((tool, arguments))
+        if self.failure:
+            raise self.failure
         if tool == "simplicio_prepare_model_call":
-            return {"context_packet": {"summary": "bounded context", "digest": "abc123"}}
+            return mapper_receipt(arguments)
         return {"status": "recorded"}
 
 
-def test_hermes_manifest_and_package_entrypoint_are_installable() -> None:
-    package_manifest = (
-        ROOT / "plugins" / "simplicio-hermes" / "plugin.yaml"
-    ).read_text(encoding="utf-8")
-
-    assert "name: simplicio-hermes" in package_manifest
-    assert "  - pre_llm_call" in package_manifest
-    assert "  - post_llm_call" in package_manifest
-    assert (ROOT / "plugins" / "simplicio-hermes" / "__init__.py").is_file()
-
-
-def test_hermes_pre_llm_hook_prepares_context_and_post_hook_records_receipt() -> None:
+def setup_plugin():
     adapter = load_adapter()
     bridge = FakeBridge()
     adapter._BRIDGE = bridge
-    adapter._PREPARED.clear()
     context = FakeContext()
     adapter.register(context)
+    return adapter, bridge, context
 
+
+def test_native_plugin_only_registers_mapper_context_and_telemetry():
+    _, _, context = setup_plugin()
+    assert set(context.middleware) == {"llm_request"}
     assert set(context.hooks) == {
-        "on_session_start",
-        "pre_llm_call",
-        "post_llm_call",
-        "on_session_end",
+        "on_session_start", "pre_llm_call", "post_llm_call", "on_session_end",
+        "post_api_request", "api_request_error",
     }
+    manifest = (ADAPTER.parent / "plugin.yaml").read_text()
+    assert "name: simplicio-hermes" in manifest
+    assert "post_api_request" in manifest
 
-    result = context.hooks["pre_llm_call"](
-        session_id="session-1",
-        user_message="Map this repository",
-        model="hermes-model",
-        platform="openrouter",
-        cwd=str(ROOT),
+
+def test_full_mapper_prefix_is_stable_and_provider_options_are_preserved():
+    _, bridge, context = setup_plugin()
+    request = {
+        "model": "model", "messages": [{"role": "system", "content": "native policy"},
+                                     {"role": "user", "content": "hello"}],
+        "tools": [{"type": "function", "name": "native_edit"}],
+        "stream": True, "temperature": 0.4,
+        "cache_control": {"type": "ephemeral"},
+    }
+    original = json.loads(json.dumps(request))
+    results = []
+    for number in (1, 2):
+        result = context.middleware["llm_request"](
+            request=request, session_id=f"session-{number}", turn_id=f"turn-{number}",
+            api_request_id=f"api-{number}", model="model", provider="provider",
+            cwd=str(ROOT),
+        )
+        results.append(result["request"])
+    assert results[0] == results[1]
+    assert request == original
+    assert len(results[0]["messages"][0]["content"].encode()) > 16384
+    assert "complete_map_tail" in results[0]["messages"][0]["content"]
+    assert results[0]["messages"][1:] == request["messages"]
+    for field in ("model", "tools", "stream", "temperature", "cache_control"):
+        assert results[0][field] == request[field]
+    assert [call[0] for call in bridge.calls] == ["simplicio_prepare_model_call"] * 2
+
+
+@pytest.mark.parametrize("field,value", [
+    ("system", "native policy"),
+    ("system", [{"type": "text", "text": "native policy", "cache_control": {"type": "ephemeral"}}]),
+    ("instructions", "native policy"),
+    ("input", [{"role": "user", "content": "hello"}]),
+    ("input", "hello"),
+])
+def test_all_provider_request_shapes_receive_the_complete_map(field, value):
+    _, _, context = setup_plugin()
+    request = {field: value, "model": "model"}
+    output = context.middleware["llm_request"](
+        request=request, session_id="s", turn_id="t", api_request_id="r",
+        provider="p", model="model", cwd=str(ROOT),
+    )["request"]
+    assert "complete_map_tail" in json.dumps(output[field])
+    assert request[field] == value
+    if field == "system" and isinstance(value, list):
+        assert output[field][0] == value[0]
+
+
+@pytest.mark.parametrize("receipt", [
+    {"status": "login_required", "login_required": True},
+    {"status": "degraded", "protected": False},
+    {"status": "prepared", "context_packet": {"content": "old full-mode handle"}},
+    mapper_receipt(content="tampered"),
+])
+def test_auth_errors_legacy_runtime_and_invalid_map_never_reach_provider(receipt):
+    adapter, bridge, context = setup_plugin()
+    if receipt.get("context_packet", {}).get("content") == "tampered":
+        receipt["context_packet"]["content_sha256"] = "0" * 64
+    bridge.call = lambda *_: receipt
+    request = {"messages": [{"role": "user", "content": "native work"}]}
+    assert context.middleware["llm_request"](
+        request=request, session_id="s", model="model", provider="p", cwd=str(ROOT),
+    ) is None
+    assert request["messages"][0]["content"] == "native work"
+    assert not adapter._PREPARED
+
+
+def test_runtime_outage_does_not_block_requests_or_leak_raw_errors(caplog):
+    _, bridge, context = setup_plugin()
+    bridge.failure = RuntimeError("secret-refresh-token")
+    assert context.middleware["llm_request"](
+        request={"messages": []}, session_id="s", model="model", cwd=str(ROOT),
+    ) is None
+    assert "secret-refresh-token" not in caplog.text
+
+
+def test_post_api_records_real_cache_usage_and_correlates_concurrent_requests():
+    adapter, bridge, context = setup_plugin()
+    for request in ("a", "b"):
+        context.middleware["llm_request"](
+            request={"messages": []}, session_id="s", turn_id="t", api_request_id=request,
+            model="model", provider="p", cwd=str(ROOT),
+        )
+    context.hooks["post_api_request"](
+        session_id="s", turn_id="t", api_request_id="a", model="model", provider="p",
+        response={"body": {"id": "provider-a"}},
+        usage={"input_tokens": 100, "output_tokens": 5, "cache_read_tokens": 80},
     )
-    assert result is not None
-    assert "bounded context" in result["context"]
-    prepare_tool, prepare_args = bridge.calls[0]
-    assert prepare_tool == "simplicio_prepare_model_call"
-    assert prepare_args["host"] == "hermes"
-    assert prepare_args["host_session_id"] == "session-1"
-    assert prepare_args["task"] == "Map this repository"
-
-    context.hooks["post_llm_call"](
-        session_id="session-1",
-        model="hermes-model",
-        platform="openrouter",
-        provider_request_id="provider-1",
+    tool, args = bridge.calls[-1]
+    assert tool == "simplicio_record_model_result"
+    assert args["api_request_id"] == "a"
+    assert args["provider_request_id"] == "provider-a"
+    assert args["cache_read_input_tokens"] == 80
+    assert args["input_tokens"] == 100 and args["output_tokens"] == 5
+    assert "complete_map_tail" not in json.dumps(args)
+    assert len(adapter._PREPARED) == 1
+    context.hooks["post_api_request"](
+        session_id="s", turn_id="t", api_request_id="b", model="model", provider="p",
     )
-    record_tool, record_args = bridge.calls[1]
-    assert record_tool == "simplicio_record_model_result"
-    assert record_args["prepared_receipt"]["context_packet"]["digest"] == "abc123"
-    assert record_args["provider_request_id"] == "provider-1"
+    assert "cache_read_input_tokens" not in bridge.calls[-1][1]
+    assert "provider_request_id" not in bridge.calls[-1][1]
+    assert not adapter._PREPARED
 
-    json.dumps(record_args)
+
+def test_pre_hook_maps_but_middleware_avoids_duplicate_spilled_context():
+    _, bridge, context = setup_plugin()
+    assert context.hooks["pre_llm_call"](
+        session_id="s", turn_id="t", model="model", cwd=str(ROOT),
+    ) is None
+    assert bridge.calls[0][0] == "simplicio_prepare_model_call"
+
+
+def test_session_start_warms_authenticated_mapper_without_waiting():
+    _, bridge, context = setup_plugin()
+    entered, release = threading.Event(), threading.Event()
+
+    def slow_call(*args):
+        entered.set()
+        assert release.wait(2)
+        return mapper_receipt()
+    bridge.call = slow_call
+    context.hooks["on_session_start"](session_id="s", cwd=str(ROOT))
+    try:
+        assert entered.wait(1)
+    finally:
+        release.set()
+
+
+def test_legacy_host_still_gets_complete_context_without_requiring_middleware():
+    adapter = load_adapter()
+    adapter._BRIDGE = FakeBridge()
+    hooks = {}
+    class LegacyContext:
+        def register_hook(self, name, callback):
+            hooks[name] = callback
+    adapter.register(LegacyContext())
+    result = hooks["pre_llm_call"](session_id="s", model="model", cwd=str(ROOT))
+    assert "complete_map_tail" in result["context"]
+    assert len(result["context"].encode()) > 16384
+    hooks["post_llm_call"](session_id="s")
+    assert adapter._BRIDGE.calls[-1][0] == "simplicio_record_model_result"
+
+
+def test_mcp_error_receipts_are_not_successful_context():
+    adapter = load_adapter()
+    with pytest.raises(adapter.SimplicioHermesError):
+        adapter.RuntimeMcpBridge._content_payload({
+            "isError": True, "content": [{"type": "text", "text": json.dumps(mapper_receipt())}],
+        })
+
+
+def test_mapper_process_is_scoped_and_checks_server_mode(monkeypatch):
+    adapter = load_adapter()
+    monkeypatch.setenv("SIMPLICIO_RUNTIME_MODE", "full")
+    spawned = {}
+    class Process:
+        stdin = io.StringIO()
+        def poll(self):
+            return None
+    def spawn(*args, **kwargs):
+        spawned.update(kwargs)
+        return Process()
+    monkeypatch.setattr(adapter.subprocess, "Popen", spawn)
+    bridge = adapter.RuntimeMcpBridge(binary=Path("/verified/simplicio"))
+    requests = []
+    def response(method, params):
+        requests.append(method)
+        if method == "initialize":
+            return {"serverInfo": {"name": "simplicio"},
+                    "x-simplicio": {"session_identity": {"mode": "mapper-only"}}}
+        return {"tools": [{"name": name} for name in adapter._MAPPER_TOOLS]}
+    monkeypatch.setattr(bridge, "_request", response)
+    bridge._ensure_started()
+    assert spawned["env"]["SIMPLICIO_RUNTIME_MODE"] == "mapper-only"
+    assert adapter.os.environ["SIMPLICIO_RUNTIME_MODE"] == "full"
+    assert requests == ["initialize", "tools/list"]
+
+
+@pytest.mark.parametrize("mode,extra", [("full", None), ("mapper-only", "simplicio_exec")])
+def test_incompatible_mcp_server_is_closed_before_any_tool_call(monkeypatch, mode, extra):
+    adapter = load_adapter()
+    class Process:
+        stdin = io.StringIO()
+        def poll(self):
+            return None
+    monkeypatch.setattr(adapter.subprocess, "Popen", lambda *a, **k: Process())
+    bridge = adapter.RuntimeMcpBridge(binary=Path("/verified/simplicio"))
+    closed = []
+    monkeypatch.setattr(bridge, "close", lambda: closed.append(True))
+    def response(method, params):
+        if method == "initialize":
+            return {"serverInfo": {"name": "simplicio"},
+                    "x-simplicio": {"session_identity": {"mode": mode}}}
+        names = list(adapter._MAPPER_TOOLS) + ([extra] if extra else [])
+        return {"tools": [{"name": name} for name in names]}
+    monkeypatch.setattr(bridge, "_request", response)
+    with pytest.raises(adapter.SimplicioHermesError):
+        bridge._ensure_started()
+    assert closed
+
+
+def test_disabled_modules_cannot_be_called_even_through_public_bridge(monkeypatch):
+    adapter = load_adapter()
+    bridge = adapter.RuntimeMcpBridge()
+    started = []
+    monkeypatch.setattr(bridge, "_ensure_started", lambda: started.append(True))
+    with pytest.raises(adapter.SimplicioHermesError):
+        bridge.call("simplicio_exec", {"command": "edit something"})
+    assert not started
+
+
+def test_canonical_hermes_usage_keeps_total_prompt_and_cache_buckets():
+    adapter = load_adapter()
+    assert adapter._token_usage({"usage": {
+        "input_tokens": 20, "prompt_tokens": 100, "output_tokens": 4,
+        "cache_read_tokens": 80,
+    }}) == {"input_tokens": 100, "output_tokens": 4, "cache_read_input_tokens": 80}
+    assert adapter._token_usage({"usage": {"input_tokens_details": {"cached_tokens": 0}}}) == {
+        "cache_read_input_tokens": 0,
+    }
+    assert adapter._token_usage({"usage": {"cache_read_tokens": True}}) == {}
+
+
+def test_stdio_transport_enforces_mode_and_rejects_login_errors(tmp_path, monkeypatch):
+    import os
+    import sys
+    adapter = load_adapter()
+    marker = tmp_path / "authenticated"
+    program = tmp_path / "fake-runtime"
+    receipt = mapper_receipt()
+    script = (
+        "#!" + sys.executable + "\n"
+        "import json, os, pathlib, sys\n"
+        "assert os.environ['SIMPLICIO_RUNTIME_MODE'] == 'mapper-only'\n"
+        "tools = " + repr(sorted(adapter._MAPPER_TOOLS)) + "\n"
+        "receipt = " + repr(receipt) + "\n"
+        "marker = pathlib.Path(" + repr(str(marker)) + ")\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    if 'id' not in request: continue\n"
+        "    method = request['method']\n"
+        "    if method == 'initialize':\n"
+        "        result = {'serverInfo': {'name': 'simplicio'}, 'x-simplicio': {'session_identity': {'mode': 'mapper-only'}}}\n"
+        "    elif method == 'tools/list': result = {'tools': [{'name': name} for name in tools]}\n"
+        "    else:\n"
+        "        payload = receipt if marker.exists() else {'status': 'login_required'}\n"
+        "        result = {'isError': not marker.exists(), 'content': [{'type': 'text', 'text': json.dumps(payload)}]}\n"
+        "    print(json.dumps({'jsonrpc': '2.0', 'id': request['id'], 'result': result}), flush=True)\n"
+    )
+    program.write_text(script, encoding="utf-8")
+    program.chmod(0o755)
+    if os.name == "nt":
+        pytest.skip("POSIX test fixture executable")
+    monkeypatch.setenv("SIMPLICIO_RUNTIME_MODE", "full")
+    bridge = adapter.RuntimeMcpBridge(binary=program, timeout=2)
+    try:
+        with pytest.raises(adapter.SimplicioHermesError):
+            bridge.call("simplicio_prepare_model_call", {"repo": str(tmp_path)})
+        marker.touch()
+        response = bridge.call("simplicio_prepare_model_call", {"repo": str(tmp_path)})
+        assert "complete_map_tail" in adapter._mapper_context(response)
+        assert os.environ["SIMPLICIO_RUNTIME_MODE"] == "full"
+    finally:
+        bridge.close()
+
+
+def test_against_actual_hermes_request_middleware_when_source_is_available(monkeypatch):
+    import os
+    import sys
+    source = os.getenv("HERMES_SOURCE")
+    if not source:
+        pytest.skip("set HERMES_SOURCE for installed-host contract verification")
+    module_path = Path(source) / "hermes_cli" / "middleware.py"
+    spec = importlib.util.spec_from_file_location("verified_hermes_middleware", module_path)
+    assert spec and spec.loader
+    host = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, host)
+    spec.loader.exec_module(host)
+    _, _, context = setup_plugin()
+    monkeypatch.setattr(host, "_has_middleware", lambda kind: kind in context.middleware)
+    monkeypatch.setattr(host, "_invoke_middleware",
+                        lambda kind, **kwargs: [context.middleware[kind](**kwargs)])
+    request = {"model": "model", "messages": [{"role": "user", "content": "hello"}],
+               "tools": [{"name": "native_edit"}], "stream": True}
+    result = host.apply_llm_request_middleware(
+        request, session_id="s", turn_id="t", api_request_id="a", model="model",
+        provider="p", cwd=str(ROOT),
+    )
+    assert result.changed is True
+    assert result.original_payload == request
+    assert "complete_map_tail" in result.payload["messages"][0]["content"]
+    assert len(result.payload["messages"][0]["content"].encode()) > 32768
+    assert result.payload["tools"] == request["tools"]
+    assert result.payload["stream"] is True


### PR DESCRIPTION
The Hermes integration must not make native project work depend on the full Simplicio stack.

This PR makes the plugin use an isolated, authenticated Mapper-only Runtime. It checks the advertised mode and tool catalogue before calling tools, while leaving shared Runtime instances, Codex and project configuration unchanged. Runtime or login failures omit Simplicio context and allow Hermes to continue with its native tools.

Session/pre-LLM hooks start the full native map. Hermes request middleware sends its complete, verified, stable prefix through the existing provider request shape; it avoids the host's pre-hook spill path without changing global limits. Per-request result hooks correlate real usage and cache counters, keep missing telemetry unknown and omit source bodies from receipts. The JavaScript adapter follows the same policy, including migration of legacy enforcement settings.

Validation:
- 29 Python checks passed, including a real stdio transport fixture and the installed Hermes request-middleware implementation.
- 14 JavaScript adapter tests passed.
- Native provider/model/tools, streaming and existing cache settings are preserved; large maps, login errors, offline Runtime and request correlation are covered.
- The repository-wide source-policy scan has two existing Desktop findings, reproduced on unchanged master: apps/desktop/src-tauri/src/project_usage.rs and apps/desktop/src/screens/ReferenceSettingsScreen.test.tsx. This PR does not modify those files.

Compatibility: requires a Runtime build advertising Mapper-only. Older runtimes are declined without blocking native work. Older Hermes versions without request middleware retain the pre-hook fallback and may still spill large maps. A stable prefix does not guarantee a provider cache hit. No binary installation, model call or release is performed by this PR.
