### PR TITLE
Desktop: relatórios consolidados com gráficos e correções de fluxos [skip ci]

### DIFF
--- a/apps/desktop/e2e/consolidated-reports.spec.ts
+++ b/apps/desktop/e2e/consolidated-reports.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+async function mockReports(page: Page, mode: "ready" | "missing" | "invalid" | "partial" | "stale" | "unreported" = "ready", delay = 0) {
+  await page.addInitScript(({ snapshot, mode, delay }) => {
+    const calls: Array<{ command: string; args: Record<string, any> }> = [];
+    const projects = ["aulas", "runtime"].map((name, i) => ({ id: `project-${String(i).repeat(64)}`, name, path: `/tmp/${name}`, evidenceType: "usage", lastModifiedEpoch: 1788180000 }));
+    Object.assign(window, { __reportCalls: calls, __TAURI_INTERNALS__: { invoke: async (command: string, args: Record<string, any> = {}) => {
+      calls.push({ command, args });
+      if (command === "desktop_snapshot") return snapshot;
+      if (command === "desktop_usage_projects") return { schema: "simplicio.desktop-project-usage/v1", projects, candidateCount: 2, partial: mode === "partial", reasons: mode === "partial" ? ["deadline"] : [], directoriesVisited: 2,
+        roots: [{ name: "Projetos", path: "/tmp" }], scope: { kind: "conventional_roots_and_configured_repo" } };
+      if (command === "desktop_token_report") throw "token_ledger_unavailable";
+      if (command === "desktop_context_report") throw "context_ledger_unavailable";
+      if (command === "desktop_consolidated_token_report") {
+        await new Promise(resolve => setTimeout(resolve, delay));
+        const request = args.request;
+        const hash = `sha256:${"a".repeat(64)}`;
+        const totals = { sample_count: 2, input_tokens: 100, cached_input_tokens: 20, output_tokens: 40, reasoning_tokens: 10, paid_remote_tokens: 150, total_tokens: 150, missing_usage_events: 0, receipt_count: 2 };
+        if (mode === "unreported") Object.assign(totals, { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_tokens: 0, paid_remote_tokens: 0, total_tokens: 0, missing_usage_events: 2 });
+        const entries = request.repoPaths.map((path: string, i: number) => ({ id: `p-${i}`, path, name: path.split("/").pop(), status: mode === "missing" ? "missing" : mode === "partial" && i === 1 ? "timeout" : "ready", totals: mode === "missing" || mode === "partial" && i === 1 ? null : totals, reportHash: mode === "missing" || mode === "partial" && i === 1 ? null : hash }));
+        const count = entries.filter((p: any) => p.status === "ready").length;
+        return { schema: "simplicio.desktop-consolidated-tokens/v1", source: "runtime", ...request, generatedAtEpoch: request.toEpoch,
+          projects: entries, totals: count ? Object.fromEntries(Object.entries(totals).map(([key, value]) => [key, value * count])) : null,
+          reportHash: mode === "invalid" || mode === "stale" && calls.filter(c => c.command === command).length > 1 ? "unverified" : hash };
+      }
+      throw `Unexpected test command: ${command}`;
+    } } });
+  }, { snapshot: { ...createDemoSnapshot("active"), source: "runtime" }, mode, delay });
+}
+
+test("consolidates all discovered projects and all five requested intervals with accessible charts", async ({ page }) => {
+  await mockReports(page);
+  await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByLabel("Totais consolidados")).toContainText("300");
+  await expect(report.getByRole("img", { name: "Composição dos tokens registrados" })).toBeVisible();
+  for (const label of ["7 dias", "30 dias", "3 meses", "6 meses", "12 meses"]) {
+    await report.getByRole("button", { name: label, exact: true }).click();
+    await expect(report.getByLabel("Totais consolidados")).toContainText("300");
+    await expect(report.getByRole("button", { name: label, exact: true })).toHaveAttribute("aria-pressed", "true");
+  }
+  const calls = await page.evaluate(() => (window as any).__reportCalls.filter((c: any) => c.command === "desktop_consolidated_token_report"));
+  expect(calls).toHaveLength(6);
+  for (const call of calls) expect(call.args.request.repoPaths).toEqual(["/tmp/aulas", "/tmp/runtime"]);
+  expect(calls[1].args.request.toEpoch - calls[1].args.request.fromEpoch).toBe(7 * 86400);
+  expect(calls[2].args.request.toEpoch - calls[2].args.request.fromEpoch).toBe(30 * 86400);
+  await page.screenshot({ path: "/tmp/simplicio-consolidated-report.png", fullPage: true });
+  await report.locator(".consolidated-charts").scrollIntoViewIfNeeded();
+  await page.screenshot({ path: "/tmp/simplicio-consolidated-charts.png" });
+});
+
+test("preserves partial results and identifies timed out projects", async ({ page }) => {
+  await mockReports(page, "partial"); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report).toContainText("Cobertura parcial");
+  await expect(report.getByLabel("Totais consolidados")).toContainText("150");
+  await expect(report.getByRole("table")).toContainText("Sem resposta");
+});
+
+test("missing ledgers do not produce charts or a false zero", async ({ page }) => {
+  await mockReports(page, "missing"); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report).toContainText("Ausência de telemetria não significa consumo zero");
+  await expect(report.getByRole("img")).toHaveCount(0);
+  await expect(report.getByLabel("Totais consolidados")).toContainText("—");
+});
+
+test("keeps known event and receipt counts when all events lack token usage", async ({ page }) => {
+  await mockReports(page, "unreported"); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  const metrics = report.getByLabel("Totais consolidados");
+  await expect(metrics.getByRole("article").filter({ hasText: "Tokens registrados" })).toContainText("—");
+  await expect(metrics.getByRole("article").filter({ hasText: "Eventos registrados" })).toContainText("4");
+  await expect(metrics.getByRole("article").filter({ hasText: "Recibos" })).toContainText("4");
+  await expect(report.getByRole("img")).toHaveCount(0);
+  await expect(report).toContainText("Cobertura parcial");
+});
+
+test("rejects malformed reports without showing their totals", async ({ page }) => {
+  await mockReports(page, "invalid"); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByRole("alert")).toContainText("Não foi possível validar");
+  await expect(report.getByLabel("Totais consolidados")).toHaveCount(0);
+});
+
+test("blocks duplicate refresh and filter changes while a batch is pending", async ({ page }) => {
+  await mockReports(page, "ready", 600); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByRole("button", { name: "7 dias", exact: true })).toBeDisabled();
+  await expect(report.getByRole("button", { name: "Atualizar consolidado" })).toBeDisabled();
+  await expect(report.getByLabel("Totais consolidados")).toBeVisible();
+  const count = await page.evaluate(() => (window as any).__reportCalls.filter((c: any) => c.command === "desktop_consolidated_token_report").length);
+  expect(count).toBe(1);
+});
+
+test("charts and project table remain usable at narrow viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await mockReports(page); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByRole("table")).toBeVisible();
+  expect(await report.evaluate(element => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+});
+
+test("adds a manually queried project to the consolidated scope without losing discovered projects", async ({ page }) => {
+  await mockReports(page); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByLabel("Totais consolidados")).toContainText("300");
+  await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/third");
+  await page.getByRole("button", { name: "Consultar uso", exact: true }).click();
+  await expect(report.getByLabel("Totais consolidados")).toContainText("450");
+  await expect(report.getByRole("table")).toContainText("/tmp/third");
+});
+
+test("never leaves old totals or charts under a changed period when the next response fails", async ({ page }) => {
+  await mockReports(page, "stale", 200); await page.goto("/?view=tokens");
+  const report = page.getByRole("region", { name: "Relatório consolidado", exact: true });
+  await expect(report.getByLabel("Totais consolidados")).toContainText("300");
+  await report.getByRole("button", { name: "7 dias", exact: true }).click();
+  await expect(report.getByLabel("Totais consolidados")).toHaveCount(0);
+  await expect(report.getByRole("alert")).toBeVisible();
+  await expect(report.getByRole("img")).toHaveCount(0);
+});

--- a/apps/desktop/e2e/runtime-integration.spec.ts
+++ b/apps/desktop/e2e/runtime-integration.spec.ts
@@ -92,26 +92,27 @@ test("token reports use filtered queries and send only a native report digest fo
   await mockNativeBridge(page);
   await page.goto("/");
   await page.getByRole("button", { name: "Relatório de tokens", exact: true }).click();
-  await expect(page.locator(".token-metric").first()).toContainText("137");
+  const individual = page.getByRole("region", { name: "Relatório individual", exact: true });
+  await expect(individual.locator(".token-metric").first()).toContainText("137");
   await page.getByRole("combobox", { name: "Período", exact: true }).selectOption("7d");
   await page.getByLabel("Sessão (opcional)").fill("session-test");
   await page.getByLabel("Pasta do projeto (opcional)").fill("/tmp/project with spaces");
   await page.getByRole("button", { name: "Consultar uso" }).click();
-  await expect(page.locator(".token-metric").first()).toContainText("137");
+  await expect(individual.locator(".token-metric").first()).toContainText("137");
   await page.screenshot({ path: testInfo.outputPath("token-report.png"), fullPage: true });
   const requests = await calls(page, "desktop_token_report");
   expect(requests.at(-1)?.args.request).toMatchObject({ sessionId: "session-test", repoPath: "/tmp/project with spaces" });
   await page.getByRole("button", { name: "Exportar JSON" }).dblclick();
-  await expect(page.getByRole("status")).toContainText("Exportado para /Downloads/simplicio-token-usage.json");
+  await expect(individual.getByRole("status")).toContainText("Exportado para /Downloads/simplicio-token-usage.json");
   await page.getByRole("button", { name: "Exportar CSV" }).click();
-  await expect(page.getByRole("status")).toContainText("Exportado para /Downloads/simplicio-token-usage.csv");
+  await expect(individual.getByRole("status")).toContainText("Exportado para /Downloads/simplicio-token-usage.csv");
   expect(await calls(page, "desktop_export_token_report")).toEqual(["json", "csv"].map((format) => ({
     command: "desktop_export_token_report", args: { reportHash: `sha256:${"a".repeat(64)}`, format },
   })));
   await page.getByLabel("Pasta do projeto (opcional)").fill("/missing");
   await page.getByRole("button", { name: "Consultar uso" }).click();
-  await expect(page.getByRole("alert")).toContainText("não significa consumo zero");
-  await expect(page.locator(".token-metric")).toHaveCount(0);
+  await expect(individual.getByRole("alert")).toContainText("não significa consumo zero");
+  await expect(individual.locator(".token-metric")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Exportar JSON" })).toHaveCount(0);
   await expect(page.getByText(/Exportado para/)).toHaveCount(0);
 });

--- a/apps/desktop/e2e/settings-return.spec.ts
+++ b/apps/desktop/e2e/settings-return.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+import { emptyWorkbench, WORKBENCH_KEY } from "../src/workbench";
+
+type SettingsTestWindow = Window & {
+  __settingsCalls: Array<{ command: string; args: Record<string, unknown> }>;
+};
+const project = { id: "project-" + "a".repeat(64), name: "Projeto A", path: "/tmp/Project A" };
+
+test.use({ timezoneId: "UTC" });
+
+async function nativeSettings(page: Page) {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  snapshot.generatedAt = "unix:1704110400";
+  const workbench = { ...emptyWorkbench(), projects: [project], selectedProjectId: project.id };
+  await page.addInitScript(({ snapshot, workbench, storageKey }) => {
+    window.localStorage.setItem(storageKey, JSON.stringify(workbench));
+    const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
+    Object.assign(window, {
+      isTauri: true,
+      __settingsCalls: calls,
+      __TAURI_INTERNALS__: {
+        transformCallback: () => 1,
+        unregisterCallback: () => undefined,
+        metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          calls.push({ command, args });
+          if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+          // No auto-selected discovery candidate may hide a lost report scope.
+          if (command === "desktop_usage_projects") return {
+            schema: "simplicio.desktop-project-usage/v1", projects: [], candidateCount: 0,
+            partial: false, reasons: [], directoriesVisited: 0, roots: [],
+            scope: { kind: "conventional_roots_and_configured_repo" },
+          };
+          if (command === "desktop_token_report") throw "token_ledger_unavailable";
+          if (command === "desktop_context_report") throw "context_ledger_unavailable";
+          if (command === "desktop_consolidated_token_report") throw "consolidated_report_unavailable";
+          if (command === "plugin:event|listen") return 1;
+          if (command === "plugin:event|unlisten") return;
+          throw "unexpected_settings_test_command";
+        },
+      },
+    });
+  }, { snapshot, workbench, storageKey: WORKBENCH_KEY });
+}
+
+async function tokenCalls(page: Page) {
+  return page.evaluate(() => (window as SettingsTestWindow).__settingsCalls.filter((call) => call.command === "desktop_token_report"));
+}
+
+test("returning from settings preserves Project A and its token report repository (mocked IPC)", async ({ page }) => {
+  await nativeSettings(page);
+  await page.goto("/?view=project");
+  await expect(page.getByRole("heading", { name: project.name, exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Configurações", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Conta Simplicio", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+  await expect(page.getByRole("heading", { name: project.name, exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: /Consultar tokens/ }).click();
+  const report = page.getByRole("region", { name: "Relatório individual", exact: true });
+  const repository = report.getByLabel("Pasta do projeto (opcional)");
+  await expect(repository).toHaveValue(project.path);
+  await expect.poll(async () => (await tokenCalls(page)).length).toBeGreaterThan(0);
+  await report.getByRole("button", { name: "Consultar uso", exact: true }).click();
+  await expect(report.getByRole("button", { name: "Consultar uso", exact: true })).toBeEnabled();
+  expect((await tokenCalls(page)).at(-1)?.args).toMatchObject({ request: { repoPath: project.path } });
+
+  await page.getByRole("button", { name: "Configurações", exact: true }).click();
+  await page.getByRole("button", { name: "Runtime e diagnóstico", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Runtime e diagnóstico", exact: true })).toBeVisible();
+  const beforeReturn = (await tokenCalls(page)).length;
+  await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Relatório de tokens", exact: true })).toBeVisible();
+  await expect(repository).toHaveValue(project.path);
+  await expect.poll(async () => (await tokenCalls(page)).length).toBeGreaterThan(beforeReturn);
+  expect((await tokenCalls(page)).at(-1)?.args).toMatchObject({ request: { repoPath: project.path } });
+});
+
+test("diagnostics renders the native Unix snapshot date without Invalid Date (mocked IPC)", async ({ page }) => {
+  await nativeSettings(page);
+  await page.goto("/?view=diagnostics");
+  await expect(page.getByRole("heading", { name: "Runtime e diagnóstico", exact: true })).toBeVisible();
+  const timestamp = page.locator(".preference-row").filter({ has: page.getByText("Leitura do snapshot", { exact: true }) });
+  await expect(timestamp).toContainText("01/01/2024, 12:00:00");
+  await expect(timestamp).not.toContainText("Invalid Date");
+  await expect(timestamp).not.toContainText("unix:");
+});

--- a/apps/desktop/src-tauri/src/consolidated_tokens.rs
+++ b/apps/desktop/src-tauri/src/consolidated_tokens.rs
@@ -1,0 +1,1423 @@
+//! Bounded read-only token aggregation. Filesystem preflight runs only in the
+//! headless child; the Desktop owns every Runtime child directly. A preflight
+//! identity is an observation, not an atomic database lease or event-level dedup.
+use crate::desktop_queries;
+use crate::local_projects::canonical_local_text;
+use crate::runtime_process::{self, CaptureLimits, ChildState, FailureKind, ProcessFailure};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const SCHEMA: &str = "simplicio.desktop-consolidated-tokens/v1";
+const WORKER_SCHEMA: &str = "simplicio.desktop-token-preflight/v1";
+const WORKER_FLAG: &str = "--simplicio-token-preflight-worker-v1";
+const MAX_PROJECTS: usize = 96;
+const MAX_SAFE: u64 = 9_007_199_254_740_991;
+const BATCH_DEADLINE: Duration = Duration::from_secs(90);
+const PREFLIGHT_DEADLINE: Duration = Duration::from_secs(2);
+const REPORT_DEADLINE: Duration = Duration::from_secs(5);
+// runtime_process may spend up to 500ms settling its own child after timeout.
+const CLEANUP_RESERVE: Duration = Duration::from_millis(500);
+const PREFLIGHT_BYTES: usize = 64 * 1024;
+const REPORT_BYTES: usize = 256 * 1024;
+const STDERR_BYTES: usize = 16 * 1024;
+const TOTAL_KEYS: [&str; 9] = [
+    "sample_count",
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "paid_remote_tokens",
+    "total_tokens",
+    "missing_usage_events",
+    "receipt_count",
+];
+static BATCH_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Range {
+    from: u64,
+    to: u64,
+    offset: i64,
+}
+
+#[derive(Debug)]
+struct Request {
+    paths: Vec<String>,
+    range: Range,
+}
+
+fn only_keys(value: &Value, keys: &[&str]) -> bool {
+    value.as_object().is_some_and(|object| {
+        object.len() == keys.len() && object.keys().all(|key| keys.contains(&key.as_str()))
+    })
+}
+
+fn input_path(path: &str) -> bool {
+    !path.is_empty()
+        && path.trim() == path
+        && path.len() <= 4096
+        && canonical_local_text(path).is_ok_and(|rendered| rendered == path)
+}
+
+impl Request {
+    fn parse(value: &Value) -> Result<Self, String> {
+        let invalid = || "consolidated_query_invalid".to_string();
+        if !only_keys(
+            value,
+            &["repoPaths", "fromEpoch", "toEpoch", "timezoneOffsetSeconds"],
+        ) {
+            return Err(invalid());
+        }
+        let paths = value["repoPaths"].as_array().ok_or_else(invalid)?;
+        if paths.len() > MAX_PROJECTS {
+            return Err(invalid());
+        }
+        let mut unique = BTreeSet::new();
+        let paths = paths
+            .iter()
+            .map(|value| {
+                let path = value
+                    .as_str()
+                    .filter(|path| input_path(path))
+                    .ok_or_else(invalid)?;
+                if !unique.insert(path) {
+                    return Err(invalid());
+                }
+                Ok(path.to_string())
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let from = value["fromEpoch"]
+            .as_u64()
+            .filter(|n| *n <= MAX_SAFE)
+            .ok_or_else(invalid)?;
+        let to = value["toEpoch"]
+            .as_u64()
+            .filter(|n| *n <= MAX_SAFE)
+            .ok_or_else(invalid)?;
+        let offset = value["timezoneOffsetSeconds"]
+            .as_i64()
+            .filter(|n| (-86400..=86400).contains(n))
+            .ok_or_else(invalid)?;
+        if from >= to {
+            return Err(invalid());
+        }
+        Ok(Self {
+            paths,
+            range: Range { from, to, offset },
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Project {
+    id: String,
+    name: String,
+    path: String,
+}
+
+fn is_windows_drive(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+fn path_name(path: &str) -> &str {
+    let drive = is_windows_drive(path);
+    let trimmed = path.trim_end_matches(|c| c == '/' || (drive && c == '\\'));
+    trimmed
+        .rsplit(|c| c == '/' || (drive && c == '\\'))
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("Projeto")
+}
+
+impl Project {
+    fn for_path(path: &str) -> Self {
+        Self {
+            id: format!("project-{:x}", Sha256::digest(path.as_bytes())),
+            name: path_name(path).to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    fn value(&self) -> Value {
+        json!({"id": self.id, "name": self.name, "path": self.path})
+    }
+
+    fn parse(value: &Value) -> Option<Self> {
+        if !only_keys(value, &["id", "name", "path"]) {
+            return None;
+        }
+        let path = value["path"].as_str().filter(|path| canonical_path(path))?;
+        let project = Self::for_path(path);
+        (value["id"].as_str() == Some(&project.id)
+            && value["name"].as_str() == Some(&project.name)
+            && project.name.len() <= 4096)
+            .then_some(project)
+    }
+}
+
+// Pure text checks: never canonicalize/stat a caller path in the parent.
+fn canonical_path(path: &str) -> bool {
+    if !input_path(path) {
+        return false;
+    }
+    let drive = is_windows_drive(path);
+    let suffix = if drive { &path[3..] } else { &path[1..] };
+    !suffix.is_empty()
+        && suffix
+            .split(|c| c == '/' || (drive && c == '\\'))
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+fn database_key(path: &str) -> String {
+    if is_windows_drive(path) {
+        path.replace('\\', "/").to_lowercase()
+    } else {
+        path.to_string()
+    }
+}
+
+fn database_inside(project: &str, database: &str) -> bool {
+    database_key(database)
+        .strip_prefix(&database_key(project))
+        .is_some_and(|suffix| suffix.starts_with('/') && suffix.len() > 1)
+}
+
+#[derive(Clone, Debug)]
+struct Ledger {
+    path: String,
+    unix_identity: Option<(u64, u64)>,
+}
+
+#[derive(Clone, Debug)]
+struct Preflight {
+    status: &'static str,
+    project: Option<Project>,
+    ledger: Option<Ledger>,
+    args: Vec<String>,
+}
+
+impl Preflight {
+    fn unavailable(status: &'static str, project: Option<Project>) -> Self {
+        Self {
+            status,
+            project,
+            ledger: None,
+            args: Vec::new(),
+        }
+    }
+
+    fn value(&self, requested: &str) -> Value {
+        json!({
+            "schema": WORKER_SCHEMA, "requestedPath": requested, "status": self.status,
+            "project": self.project.as_ref().map(Project::value),
+            "ledger": self.ledger.as_ref().map(|ledger| json!({
+                "path": ledger.path,
+                "unixIdentity": ledger.unix_identity.map(|(device, inode)| json!({
+                    "device": device.to_string(), "inode": inode.to_string()
+                }))
+            })),
+            "queryArgs": if self.status == "ready" { json!(self.args) } else { Value::Null },
+        })
+    }
+}
+
+fn report_args(range: &Range, database: &str) -> Vec<String> {
+    vec![
+        "tokens".into(),
+        "report".into(),
+        "--json".into(),
+        "--tz-offset-seconds".into(),
+        range.offset.to_string(),
+        "--from".into(),
+        range.from.to_string(),
+        "--to".into(),
+        range.to.to_string(),
+        "--db".into(),
+        database.to_string(),
+    ]
+}
+
+fn unix_identity(value: &Value) -> Option<Option<(u64, u64)>> {
+    if value.is_null() {
+        return Some(None);
+    }
+    if !only_keys(value, &["device", "inode"]) || !cfg!(unix) {
+        return None;
+    }
+    let number = |key: &str| {
+        let text = value[key].as_str()?;
+        if text.is_empty() || text.len() > 20 || !text.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        text.parse::<u64>().ok()
+    };
+    let identity = (number("device")?, number("inode")?);
+    (identity.1 != 0).then_some(Some(identity))
+}
+
+fn validate_preflight(
+    value: Value,
+    requested: &str,
+    range: &Range,
+) -> Result<Preflight, ReadFailure> {
+    let invalid = ReadFailure::invalid;
+    if !only_keys(
+        &value,
+        &[
+            "schema",
+            "requestedPath",
+            "status",
+            "project",
+            "ledger",
+            "queryArgs",
+        ],
+    ) || value["schema"] != WORKER_SCHEMA
+        || value["requestedPath"] != requested
+    {
+        return Err(invalid());
+    }
+    let project = if value["project"].is_null() {
+        None
+    } else {
+        Some(Project::parse(&value["project"]).ok_or_else(invalid)?)
+    };
+    let status = match value["status"].as_str() {
+        Some("ready") => "ready",
+        Some("missing") => "missing",
+        Some("invalid") => "invalid",
+        _ => return Err(invalid()),
+    };
+    if status != "ready" {
+        if !value["ledger"].is_null() || !value["queryArgs"].is_null() {
+            return Err(invalid());
+        }
+        return Ok(Preflight::unavailable(status, project));
+    }
+    let project = project.ok_or_else(invalid)?;
+    if !only_keys(&value["ledger"], &["path", "unixIdentity"]) {
+        return Err(invalid());
+    }
+    let path = value["ledger"]["path"]
+        .as_str()
+        .filter(|path| canonical_path(path))
+        .ok_or_else(invalid)?;
+    if !database_inside(&project.path, path) {
+        return Err(invalid());
+    }
+    let identity = unix_identity(&value["ledger"]["unixIdentity"]).ok_or_else(invalid)?;
+    let args = value["queryArgs"]
+        .as_array()
+        .filter(|args| args.len() == 11)
+        .ok_or_else(invalid)?;
+    let args = args
+        .iter()
+        .map(|arg| arg.as_str().map(String::from).ok_or_else(invalid))
+        .collect::<Result<Vec<_>, _>>()?;
+    // Only a native canonical drive prefix is allowed in the DB argv. All
+    // other arguments must exactly equal our fixed query, including its range.
+    let database = args.last().ok_or_else(invalid)?;
+    if canonical_local_text(database).ok() != Some(path) || args != report_args(range, database) {
+        return Err(invalid());
+    }
+    Ok(Preflight {
+        status,
+        project: Some(project),
+        ledger: Some(Ledger {
+            path: path.to_string(),
+            unix_identity: identity,
+        }),
+        args,
+    })
+}
+
+fn missing_or_invalid(path: &Path) -> &'static str {
+    match std::fs::metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => "missing",
+        _ => "invalid",
+    }
+}
+
+/// Filesystem access is confined to this worker branch. It never invokes a
+/// Runtime, shell, login, Tauri, or installer and never creates a ledger.
+fn filesystem_preflight(requested: &str, range: &Range) -> Preflight {
+    let project = match crate::local_projects::validate_project(requested)
+        .ok()
+        .and_then(|value| Project::parse(&value))
+    {
+        Some(project) => project,
+        None => return Preflight::unavailable(missing_or_invalid(Path::new(requested)), None),
+    };
+    let request = json!({ "repoPath": project.path, "fromEpoch": range.from,
+        "toEpoch": range.to, "timezoneOffsetSeconds": range.offset });
+    let args = match desktop_queries::token_query_args(&request, Path::new(&project.path)) {
+        Ok(args) => args,
+        Err(_) => {
+            let status = missing_or_invalid(
+                &Path::new(&project.path).join(".simplicio/token-usage.sqlite3"),
+            );
+            return Preflight::unavailable(status, Some(project));
+        }
+    };
+    let database = Path::new(args.last().expect("fixed token query has a database"));
+    let metadata = match database.metadata() {
+        Ok(metadata) if metadata.is_file() => metadata,
+        _ => return Preflight::unavailable(missing_or_invalid(database), Some(project)),
+    };
+    let Some(path) = database
+        .to_str()
+        .and_then(|path| canonical_local_text(path).ok())
+    else {
+        return Preflight::unavailable("invalid", Some(project));
+    };
+    #[cfg(unix)]
+    let identity = {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.ino() != 0).then_some((metadata.dev(), metadata.ino()))
+    };
+    #[cfg(not(unix))]
+    let identity = {
+        let _ = metadata;
+        None
+    };
+    Preflight {
+        status: "ready",
+        project: Some(project),
+        ledger: Some(Ledger {
+            path: path.into(),
+            unix_identity: identity,
+        }),
+        args,
+    }
+}
+
+fn worker_args(requested: &str, range: &Range) -> Vec<OsString> {
+    vec![
+        WORKER_FLAG.into(),
+        requested.into(),
+        range.from.to_string().into(),
+        range.to.to_string().into(),
+        range.offset.to_string().into(),
+    ]
+}
+
+/// Called before Tauri starts. A malformed recognized flag must not fall
+/// through to GUI startup. It performs one bounded-input filesystem preflight.
+pub fn try_preflight_worker() -> Option<Result<Value, String>> {
+    dispatch_worker(std::env::args_os().skip(1))
+}
+
+fn dispatch_worker(mut args: impl Iterator<Item = OsString>) -> Option<Result<Value, String>> {
+    if args.next()? != WORKER_FLAG {
+        return None;
+    }
+    Some((|| {
+        let invalid = || "consolidated_preflight_request_invalid".to_string();
+        let args = args.take(5).collect::<Vec<_>>();
+        if args.len() != 4 {
+            return Err(invalid());
+        }
+        let path = args[0]
+            .to_str()
+            .filter(|path| input_path(path))
+            .ok_or_else(invalid)?;
+        let number = |index: usize| -> Option<&str> {
+            let text = args[index].to_str()?;
+            (!text.is_empty() && text.len() <= 17).then_some(text)
+        };
+        let from = number(1)
+            .and_then(|s| s.parse::<u64>().ok())
+            .ok_or_else(invalid)?;
+        let to = number(2)
+            .and_then(|s| s.parse::<u64>().ok())
+            .ok_or_else(invalid)?;
+        let offset = number(3)
+            .and_then(|s| s.parse::<i64>().ok())
+            .ok_or_else(invalid)?;
+        let request = Request::parse(&json!({ "repoPaths": [path], "fromEpoch": from,
+            "toEpoch": to, "timezoneOffsetSeconds": offset }))
+        .map_err(|_| invalid())?;
+        if args
+            != worker_args(path, &request.range)
+                .into_iter()
+                .skip(1)
+                .collect::<Vec<_>>()
+        {
+            return Err(invalid());
+        }
+        let report = filesystem_preflight(path, &request.range).value(path);
+        validate_preflight(report.clone(), path, &request.range).map_err(|_| invalid())?;
+        if serde_json::to_vec(&report).map_err(|_| invalid())?.len() > PREFLIGHT_BYTES {
+            return Err(invalid());
+        }
+        Ok(report)
+    })())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ReadFailure {
+    status: &'static str,
+    stop: bool,
+}
+
+impl ReadFailure {
+    fn invalid() -> Self {
+        Self {
+            status: "invalid",
+            stop: false,
+        }
+    }
+
+    fn process(failure: ProcessFailure) -> Self {
+        Self {
+            status: if failure.kind == FailureKind::Deadline {
+                "timeout"
+            } else {
+                "invalid"
+            },
+            stop: failure.child_state == ChildState::Retained
+                || matches!(
+                    failure.kind,
+                    FailureKind::CleanupPending | FailureKind::Spawn
+                ),
+        }
+    }
+}
+
+fn decode_json(success: bool, stdout: &[u8], max_bytes: usize) -> Result<Value, ReadFailure> {
+    if !success || stdout.len() > max_bytes {
+        return Err(ReadFailure::invalid());
+    }
+    serde_json::from_slice(stdout).map_err(|_| ReadFailure::invalid())
+}
+
+fn captured_json(
+    result: Result<Output, ProcessFailure>,
+    max_bytes: usize,
+) -> Result<Value, ReadFailure> {
+    let output = result.map_err(ReadFailure::process)?;
+    decode_json(output.status.success(), &output.stdout, max_bytes)
+}
+
+fn capture_limits(deadline: Duration, stdout_bytes: usize) -> CaptureLimits {
+    CaptureLimits {
+        deadline,
+        stdout_bytes,
+        stderr_bytes: STDERR_BYTES,
+    }
+}
+
+fn deadline(remaining: Duration, maximum: Duration) -> Option<Duration> {
+    remaining
+        .checked_sub(CLEANUP_RESERVE)
+        .filter(|time| !time.is_zero())
+        .map(|time| time.min(maximum))
+}
+
+#[derive(Debug)]
+struct Sample {
+    totals: [u64; 9],
+    hash: String,
+}
+
+fn valid_hash(hash: &str) -> bool {
+    hash.len() == 71
+        && hash.starts_with("sha256:")
+        && hash[7..]
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn custom_sample(value: Value, range: &Range) -> Result<Sample, ReadFailure> {
+    // Missing session metadata is not proof this is an all-session report.
+    if value.get("session_id") != Some(&Value::Null) {
+        return Err(ReadFailure::invalid());
+    }
+    let value = desktop_queries::project_token_report(value).map_err(|_| ReadFailure::invalid())?;
+    if value["timezone_offset_seconds"].as_i64() != Some(range.offset) {
+        return Err(ReadFailure::invalid());
+    }
+    let hash = value["report_hash"]
+        .as_str()
+        .filter(|hash| valid_hash(hash))
+        .ok_or_else(ReadFailure::invalid)?
+        .to_string();
+    let custom = value["periods"]
+        .as_array()
+        .and_then(|periods| periods.iter().find(|period| period["window"] == "custom"))
+        .ok_or_else(ReadFailure::invalid)?;
+    if custom["from_epoch"].as_u64() != Some(range.from)
+        || custom["to_epoch"].as_u64() != Some(range.to)
+    {
+        return Err(ReadFailure::invalid());
+    }
+    let mut totals = [0; 9];
+    for (index, key) in TOTAL_KEYS.iter().enumerate() {
+        totals[index] = custom["totals"][*key]
+            .as_u64()
+            .ok_or_else(ReadFailure::invalid)?;
+    }
+    Ok(Sample { totals, hash })
+}
+
+fn totals_value(totals: &[u64; 9]) -> Value {
+    Value::Object(
+        TOTAL_KEYS
+            .iter()
+            .zip(totals.iter())
+            .map(|(key, value)| ((*key).into(), json!(value)))
+            .collect::<Map<_, _>>(),
+    )
+}
+
+fn row(requested: &str, project: &Project, status: &str, sample: Option<&Sample>) -> Value {
+    // Echo the original request so aliases retain their own UI row. Canonical
+    // metadata and DB identities are used internally, never to collapse rows.
+    json!({ "id": project.id, "name": project.name, "path": requested, "status": status,
+        "totals": sample.map(|sample| totals_value(&sample.totals)),
+        "reportHash": sample.map(|sample| sample.hash.clone()) })
+}
+
+fn collect(
+    request: &Request,
+    generated_epoch: u64,
+    mut remaining: impl FnMut() -> Duration,
+    mut preflight: impl FnMut(&str, &Range, Duration) -> Result<Preflight, ReadFailure>,
+    mut runtime: impl FnMut(&[String], Duration) -> Result<Value, ReadFailure>,
+) -> Result<Value, String> {
+    let mut projects = Vec::with_capacity(request.paths.len());
+    let mut database_paths = BTreeSet::new();
+    let mut unix_ids = BTreeSet::new();
+    let mut sum = [0_u64; 9];
+    let mut ready = 0;
+    let mut stopped = false;
+    for path in &request.paths {
+        let fallback = Project::for_path(path);
+        let limit = deadline(remaining(), PREFLIGHT_DEADLINE);
+        if stopped || limit.is_none() {
+            stopped = true;
+            projects.push(row(path, &fallback, "skipped", None));
+            continue;
+        }
+        let checked = match preflight(path, &request.range, limit.unwrap()) {
+            Ok(checked) => checked,
+            Err(failure) => {
+                stopped = failure.stop;
+                projects.push(row(path, &fallback, failure.status, None));
+                continue;
+            }
+        };
+        let project = checked.project.as_ref().unwrap_or(&fallback);
+        if checked.status != "ready" {
+            projects.push(row(path, project, checked.status, None));
+            continue;
+        }
+        let Some(ledger) = checked.ledger else {
+            projects.push(row(path, project, "invalid", None));
+            continue;
+        };
+        let key = database_key(&ledger.path);
+        if database_paths.contains(&key)
+            || ledger
+                .unix_identity
+                .is_some_and(|id| unix_ids.contains(&id))
+        {
+            projects.push(row(path, project, "duplicate", None));
+            continue;
+        }
+        let Some(limit) = deadline(remaining(), REPORT_DEADLINE) else {
+            stopped = true;
+            projects.push(row(path, project, "skipped", None));
+            continue;
+        };
+        let sample = match runtime(&checked.args, limit)
+            .and_then(|value| custom_sample(value, &request.range))
+        {
+            Ok(sample) => sample,
+            Err(failure) => {
+                stopped = failure.stop;
+                projects.push(row(path, project, failure.status, None));
+                continue;
+            }
+        };
+        for (total, value) in sum.iter_mut().zip(sample.totals.iter()) {
+            *total = total
+                .checked_add(*value)
+                .filter(|n| *n <= MAX_SAFE)
+                .ok_or("consolidated_totals_overflow")?;
+        }
+        // Only an actually counted ledger can exclude a later requested
+        // alias. A failed read must not be labelled "already accounted for".
+        database_paths.insert(key);
+        if let Some(id) = ledger.unix_identity {
+            unix_ids.insert(id);
+        }
+        ready += 1;
+        projects.push(row(path, project, "ready", Some(&sample)));
+    }
+    let mut report = json!({ "schema": SCHEMA, "source": "runtime",
+        "fromEpoch": request.range.from, "toEpoch": request.range.to,
+        "timezoneOffsetSeconds": request.range.offset, "generatedAtEpoch": generated_epoch,
+        "projects": projects, "totals": (ready > 0).then(|| totals_value(&sum)),
+    });
+    let bytes = serde_json::to_vec(&report).map_err(|_| "consolidated_report_unavailable")?;
+    report["reportHash"] = json!(format!("sha256:{:x}", Sha256::digest(bytes)));
+    Ok(report)
+}
+
+/// One process-local batch, one fresh authorization, no fallback after a child
+/// starts. The total budget includes authorization; no project FS calls here.
+pub fn report(
+    value: &Value,
+    exe: &Path,
+    runtime_binaries: Vec<OsString>,
+    authorize: impl FnOnce() -> Result<(), String>,
+) -> Result<Value, String> {
+    let request = Request::parse(value)?;
+    if !exe.is_absolute() || runtime_binaries.is_empty() || runtime_binaries.len() > 3 {
+        return Err("consolidated_report_unavailable".into());
+    }
+    let _batch = BATCH_LOCK.try_lock().map_err(|error| match error {
+        std::sync::TryLockError::WouldBlock => "consolidated_report_busy",
+        std::sync::TryLockError::Poisoned(_) => "consolidated_report_unavailable",
+    })?;
+    let started = Instant::now();
+    authorize()?;
+    let generated_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| "consolidated_report_unavailable")?
+        .as_secs();
+    if generated_epoch > MAX_SAFE {
+        return Err("consolidated_report_unavailable".into());
+    }
+    collect(
+        &request,
+        generated_epoch,
+        || BATCH_DEADLINE.saturating_sub(started.elapsed()),
+        |path, range, limit| {
+            let mut command = Command::new(exe);
+            command.args(worker_args(path, range));
+            // stdin is null in capture. No cwd/HOME override, shell, or Runtime
+            // is launched by this worker, even when its filesystem call hangs.
+            let value = captured_json(
+                runtime_process::capture(&mut command, capture_limits(limit, PREFLIGHT_BYTES)),
+                PREFLIGHT_BYTES,
+            )?;
+            validate_preflight(value, path, range)
+        },
+        |args, limit| {
+            let commands = runtime_binaries.iter().map(|binary| {
+                let mut command = Command::new(binary);
+                command.args(args).env("SIMPLICIO_DESKTOP_BRIDGE", "1");
+                command
+            });
+            captured_json(
+                runtime_process::capture_candidates(commands, capture_limits(limit, REPORT_BYTES)),
+                REPORT_BYTES,
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::path::PathBuf;
+
+    fn range() -> Range {
+        Range {
+            from: 100,
+            to: 200,
+            offset: -10800,
+        }
+    }
+
+    fn query(paths: &[&str]) -> Value {
+        json!({"repoPaths": paths, "fromEpoch": 100, "toEpoch": 200,
+            "timezoneOffsetSeconds": -10800})
+    }
+
+    fn totals() -> [u64; 9] {
+        [2, 100, 25, 30, 7, 112, 137, 1, 1]
+    }
+
+    fn runtime_report(totals: [u64; 9]) -> Value {
+        json!({"schema": "workspace.token-analytics-report/v1", "now_epoch": 250,
+            "session_id": null, "timezone_offset_seconds": -10800,
+            "generated_by": "sqlite_ledger", "report_hash": format!("sha256:{}", "a".repeat(64)),
+            "periods": [
+                {"window": "today", "from_epoch": 1, "to_epoch": 250,
+                    "totals": totals_value(&[9, 900, 200, 300, 70, 999, 1270, 0, 9])},
+                {"window": "custom", "from_epoch": 100, "to_epoch": 200,
+                    "totals": totals_value(&totals)}],
+            "raw_prompt": "DO_NOT_LEAK_CONSOLIDATED_PROMPT"})
+    }
+
+    fn ready(project: &str, database: &str) -> Preflight {
+        Preflight {
+            status: "ready",
+            project: Some(Project::for_path(project)),
+            ledger: Some(Ledger {
+                path: database.into(),
+                unix_identity: None,
+            }),
+            args: report_args(&range(), database),
+        }
+    }
+
+    fn unlimited() -> Duration {
+        BATCH_DEADLINE
+    }
+
+    #[test]
+    fn request_is_bounded_unique_and_requires_an_explicit_common_range() {
+        assert!(Request::parse(&query(&["/project"])).is_ok());
+        assert!(Request::parse(&query(&[r"C:\Projects\Simplicio"])).is_ok());
+        assert!(Request::parse(&query(&[])).is_ok());
+        for paths in [
+            vec!["relative"],
+            vec!["--help"],
+            vec!["/project\n"],
+            vec!["//server/share"],
+            vec![r"\\?\C:\project"],
+            vec!["/project", "/project"],
+        ] {
+            assert_eq!(
+                Request::parse(&query(&paths)).unwrap_err(),
+                "consolidated_query_invalid"
+            );
+        }
+        for (field, value) in [
+            ("fromEpoch", json!(200)),
+            ("toEpoch", json!(-1)),
+            ("toEpoch", json!(MAX_SAFE + 1)),
+            ("timezoneOffsetSeconds", json!(86401)),
+            ("sessionId", json!("must-not-filter")),
+            ("fromEpoch", json!(1.5)),
+        ] {
+            let mut request = query(&["/project"]);
+            request[field] = value;
+            assert!(Request::parse(&request).is_err(), "{field}");
+        }
+        let paths = (0..97).map(|n| format!("/project-{n}")).collect::<Vec<_>>();
+        let mut request = query(&[]);
+        request["repoPaths"] = json!(paths);
+        assert!(Request::parse(&request).is_err());
+        assert!(Request::parse(&query(&[&format!("/{}", "x".repeat(4096))])).is_err());
+    }
+
+    #[test]
+    fn custom_window_is_selected_once_and_must_echo_range_offset_and_null_session() {
+        let sample = custom_sample(runtime_report(totals()), &range()).unwrap();
+        assert_eq!(sample.totals, totals());
+        for pointer in [
+            "/periods/1/from_epoch",
+            "/periods/1/to_epoch",
+            "/timezone_offset_seconds",
+            "/session_id",
+            "/periods/1/window",
+            "/report_hash",
+        ] {
+            let mut value = runtime_report(totals());
+            *value.pointer_mut(pointer).unwrap() = match pointer {
+                "/session_id" => json!("session-other"),
+                "/periods/1/window" => json!("7d"),
+                "/report_hash" => json!(format!("sha256:{}", "A".repeat(64))),
+                _ => json!(999),
+            };
+            assert_eq!(
+                custom_sample(value, &range()).unwrap_err(),
+                ReadFailure::invalid()
+            );
+        }
+        let mut missing = runtime_report(totals());
+        missing.as_object_mut().unwrap().remove("session_id");
+        assert!(custom_sample(missing, &range()).is_err());
+        let mut duplicate = runtime_report(totals());
+        duplicate["periods"].as_array_mut().unwrap().push(json!({
+            "window": "custom", "from_epoch": 100, "to_epoch": 200, "totals": totals_value(&totals())}));
+        assert!(custom_sample(duplicate, &range()).is_err());
+        let mut invalid_totals = totals();
+        invalid_totals[6] += 1;
+        assert!(custom_sample(runtime_report(invalid_totals), &range()).is_err());
+    }
+
+    #[test]
+    fn preflight_protocol_accepts_only_fixed_args_and_contained_canonical_paths() {
+        let checked = ready("/project", "/project/.simplicio/token-usage.sqlite3");
+        let value = checked.value("/alias");
+        let parsed = validate_preflight(value.clone(), "/alias", &range()).unwrap();
+        assert_eq!(parsed.args, checked.args);
+        for (pointer, replacement) in [
+            ("/queryArgs/0", json!("install")),
+            ("/queryArgs/6", json!("101")),
+            ("/queryArgs/10", json!("/outside/ledger")),
+            ("/requestedPath", json!("/other")),
+            ("/project/id", json!("not-the-path-hash")),
+            ("/ledger/path", json!("/project2/db")),
+            ("/project/path", json!("/project/../other")),
+        ] {
+            let mut malformed = value.clone();
+            *malformed.pointer_mut(pointer).unwrap() = replacement;
+            assert!(
+                validate_preflight(malformed, "/alias", &range()).is_err(),
+                "{pointer}"
+            );
+        }
+        let mut extra = value;
+        extra["rawStderr"] = json!("DO_NOT_LEAK_CONSOLIDATED_STDERR");
+        assert!(validate_preflight(extra, "/alias", &range()).is_err());
+        let mut missing = Preflight::unavailable("missing", None).value("/alias");
+        missing["queryArgs"] = json!(["install"]);
+        assert!(validate_preflight(missing, "/alias", &range()).is_err());
+    }
+
+    #[test]
+    fn windows_database_identity_is_case_and_separator_insensitive_without_fs_calls() {
+        assert_eq!(
+            database_key(r"C:\Projects\App\.simplicio\token-usage.sqlite3"),
+            database_key("c:/projects/app/.simplicio/TOKEN-USAGE.SQLITE3")
+        );
+        let mut checked = ready(
+            r"C:\Projects\App",
+            r"C:\Projects\App\.simplicio\token-usage.sqlite3",
+        );
+        checked.args[10] = r"\\?\C:\Projects\App\.simplicio\token-usage.sqlite3".into();
+        assert!(validate_preflight(checked.value(r"C:\alias"), r"C:\alias", &range()).is_ok());
+        assert!(!database_inside("/project", "/project-other/db"));
+        assert!(!canonical_path(r"C:\Projects\..\escape"));
+    }
+
+    #[test]
+    fn colon_in_a_posix_name_does_not_become_a_windows_drive_or_split_utf8() {
+        assert!(canonical_path("/:é/projeto"));
+        assert!(!is_windows_drive("/:é/projeto"));
+        assert_eq!(path_name("/:é/projeto"), "projeto");
+        assert_eq!(database_key("/:A/db"), "/:A/db");
+        assert_ne!(database_key("/:A/db"), database_key("/:a/db"));
+        assert!(!database_inside("/:A", "/:a/db"));
+        assert!(is_windows_drive(r"C:\Projects"));
+        assert!(is_windows_drive("c:/Projects"));
+    }
+
+    struct Fixture(PathBuf);
+
+    impl Fixture {
+        fn new() -> Self {
+            static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let sequence = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "simplicio-consolidated-{}-{stamp}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn project(&self, name: &str, ledger: bool) -> String {
+            let path = self.0.join(name);
+            std::fs::create_dir(&path).unwrap();
+            if ledger {
+                std::fs::create_dir(path.join(".simplicio")).unwrap();
+                // Preflight checks metadata only; it must never run SQLite or
+                // turn a fixture into a Runtime analytics mutation.
+                std::fs::write(path.join(".simplicio/token-usage.sqlite3"), b"fixture").unwrap();
+            }
+            path.to_str().unwrap().into()
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn worker_preflight_uses_existing_root_ledger_and_never_creates_a_missing_one() {
+        let fixture = Fixture::new();
+        let without = fixture.project("without", false);
+        let missing = filesystem_preflight(&without, &range());
+        assert_eq!(missing.status, "missing");
+        assert!(!Path::new(&without).join(".simplicio").exists());
+        let project = fixture.project("with", true);
+        let checked = filesystem_preflight(&project, &range());
+        assert_eq!(checked.status, "ready");
+        let parsed = validate_preflight(checked.value(&project), &project, &range()).unwrap();
+        assert_eq!(parsed.args[0..3], ["tokens", "report", "--json"]);
+        assert!(parsed.args[10].ends_with("token-usage.sqlite3"));
+        assert!(!Path::new(&project).join(".simplicio/ledger").exists());
+        assert_eq!(
+            parsed.project.unwrap().id,
+            crate::local_projects::validate_project(&project).unwrap()["id"]
+        );
+        assert_eq!(
+            filesystem_preflight(fixture.0.join("absent").to_str().unwrap(), &range()).status,
+            "missing"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_project_alias_and_hardlink_database_have_real_matching_identities() {
+        let fixture = Fixture::new();
+        let first = fixture.project("first", true);
+        let alias = fixture.0.join("alias");
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+        let second = fixture.project("second", false);
+        std::fs::create_dir(Path::new(&second).join(".simplicio")).unwrap();
+        std::fs::hard_link(
+            Path::new(&first).join(".simplicio/token-usage.sqlite3"),
+            Path::new(&second).join(".simplicio/token-usage.sqlite3"),
+        )
+        .unwrap();
+        let one = filesystem_preflight(&first, &range());
+        let two = filesystem_preflight(&second, &range());
+        let aliased = filesystem_preflight(alias.to_str().unwrap(), &range());
+        assert_eq!(
+            one.project.as_ref().unwrap().id,
+            aliased.project.unwrap().id
+        );
+        assert_eq!(
+            one.ledger.as_ref().unwrap().path,
+            aliased.ledger.unwrap().path
+        );
+        assert!(one.ledger.as_ref().unwrap().unix_identity.is_some());
+        assert_eq!(
+            one.ledger.as_ref().unwrap().unix_identity,
+            two.ledger.as_ref().unwrap().unix_identity
+        );
+        let calls = Cell::new(0);
+        let request = Request::parse(&query(&[&first, &second])).unwrap();
+        let result = collect(
+            &request,
+            250,
+            unlimited,
+            |path, _, _| {
+                Ok(if path == first {
+                    one.clone()
+                } else {
+                    two.clone()
+                })
+            },
+            |_, _| {
+                calls.set(calls.get() + 1);
+                Ok(runtime_report(totals()))
+            },
+        )
+        .unwrap();
+        assert_eq!(calls.get(), 1);
+        assert_eq!(result["projects"][1]["status"], "duplicate");
+    }
+
+    #[test]
+    fn aggregation_keeps_one_row_per_alias_and_sums_all_nine_fields_only_once_per_db() {
+        let request = Request::parse(&query(&["/one", "/alias", "/two"])).unwrap();
+        let calls = Cell::new(0);
+        let result = collect(
+            &request,
+            250,
+            unlimited,
+            |path, _, _| {
+                Ok(if path == "/two" {
+                    ready("/two", "/two/db")
+                } else {
+                    ready("/one", "/one/db")
+                })
+            },
+            |_, _| {
+                calls.set(calls.get() + 1);
+                Ok(runtime_report(totals()))
+            },
+        )
+        .unwrap();
+        assert_eq!(calls.get(), 2);
+        assert_eq!(result["projects"].as_array().unwrap().len(), 3);
+        assert_eq!(result["projects"][1]["path"], "/alias");
+        assert_eq!(result["projects"][1]["status"], "duplicate");
+        assert_eq!(result["projects"][0]["id"], result["projects"][1]["id"]);
+        assert!(result["projects"][1]["totals"].is_null());
+        assert!(result["projects"][1]["reportHash"].is_null());
+        for (index, key) in TOTAL_KEYS.iter().enumerate() {
+            assert_eq!(result["totals"][*key], totals()[index] * 2);
+        }
+        // Equal Runtime hashes in distinct DBs are not evidence that events
+        // are duplicates. We deliberately do not promise copied-event dedup.
+        assert_eq!(
+            result["projects"][0]["reportHash"],
+            result["projects"][2]["reportHash"]
+        );
+        let text = result.to_string();
+        assert!(!text.contains("DO_NOT_LEAK"));
+        assert!(!text.contains("unixIdentity"));
+        assert!(!text.contains("queryArgs"));
+        let mut unhashed = result.clone();
+        unhashed.as_object_mut().unwrap().remove("reportHash");
+        assert_eq!(
+            result["reportHash"],
+            format!(
+                "sha256:{:x}",
+                Sha256::digest(serde_json::to_vec(&unhashed).unwrap())
+            )
+        );
+    }
+
+    #[test]
+    fn completed_rows_survive_missing_invalid_timeout_and_batch_deadline() {
+        let paths = ["/ready", "/missing", "/invalid", "/timeout", "/after"];
+        let request = Request::parse(&query(&paths)).unwrap();
+        let expired = Cell::new(false);
+        let calls = Cell::new(0);
+        let result = collect(
+            &request,
+            250,
+            || {
+                if expired.get() {
+                    Duration::ZERO
+                } else {
+                    BATCH_DEADLINE
+                }
+            },
+            |path, _, limit| {
+                assert!(limit <= PREFLIGHT_DEADLINE);
+                calls.set(calls.get() + 1);
+                match path {
+                    "/missing" => Ok(Preflight::unavailable("missing", None)),
+                    "/invalid" => Err(ReadFailure::invalid()),
+                    "/timeout" => {
+                        expired.set(true);
+                        Err(ReadFailure {
+                            status: "timeout",
+                            stop: false,
+                        })
+                    }
+                    _ => Ok(ready(path, &format!("{path}/db"))),
+                }
+            },
+            |_, limit| {
+                assert!(limit <= REPORT_DEADLINE);
+                Ok(runtime_report(totals()))
+            },
+        )
+        .unwrap();
+        let statuses = result["projects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["status"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            statuses,
+            ["ready", "missing", "invalid", "timeout", "skipped"]
+        );
+        assert_eq!(calls.get(), 4);
+        assert_eq!(result["totals"], totals_value(&totals()));
+        for row in result["projects"].as_array().unwrap().iter().skip(1) {
+            assert!(row["totals"].is_null() && row["reportHash"].is_null());
+        }
+    }
+
+    #[test]
+    fn failed_first_read_does_not_falsely_count_or_exclude_a_requested_alias() {
+        let request = Request::parse(&query(&["/one", "/alias", "/third-alias"])).unwrap();
+        let calls = Cell::new(0);
+        let result = collect(
+            &request,
+            250,
+            unlimited,
+            |_, _, _| Ok(ready("/one", "/one/db")),
+            |_, _| {
+                calls.set(calls.get() + 1);
+                if calls.get() == 1 {
+                    Err(ReadFailure::invalid())
+                } else {
+                    Ok(runtime_report(totals()))
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(calls.get(), 2);
+        assert_eq!(result["projects"][0]["status"], "invalid");
+        assert_eq!(result["projects"][1]["status"], "ready");
+        assert_eq!(result["projects"][2]["status"], "duplicate");
+        assert_eq!(result["totals"], totals_value(&totals()));
+    }
+
+    #[test]
+    fn expired_budget_after_preflight_never_starts_runtime_and_cleanup_blocks_later_work() {
+        let request = Request::parse(&query(&["/one", "/two"])).unwrap();
+        let expired = Cell::new(false);
+        let result = collect(
+            &request,
+            250,
+            || {
+                if expired.get() {
+                    Duration::ZERO
+                } else {
+                    BATCH_DEADLINE
+                }
+            },
+            |path, _, _| {
+                expired.set(true);
+                Ok(ready(path, &format!("{path}/db")))
+            },
+            |_, _| panic!("Runtime started beyond the batch deadline"),
+        )
+        .unwrap();
+        assert!(result["projects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|row| row["status"] == "skipped"));
+        let calls = Cell::new(0);
+        let result = collect(
+            &request,
+            250,
+            unlimited,
+            |_, _, _| {
+                calls.set(calls.get() + 1);
+                Err(ReadFailure::process(ProcessFailure {
+                    kind: FailureKind::Deadline,
+                    child_state: ChildState::Retained,
+                }))
+            },
+            |_, _| panic!("Runtime started with unresolved worker ownership"),
+        )
+        .unwrap();
+        assert_eq!(calls.get(), 1);
+        assert_eq!(result["projects"][0]["status"], "timeout");
+        assert_eq!(result["projects"][1]["status"], "skipped");
+        assert!(result["totals"].is_null());
+        assert_eq!(
+            deadline(Duration::from_millis(700), REPORT_DEADLINE),
+            Some(Duration::from_millis(200))
+        );
+        assert!(deadline(CLEANUP_RESERVE, REPORT_DEADLINE).is_none());
+    }
+
+    #[test]
+    fn no_ready_is_null_but_a_valid_zero_sample_report_preserves_its_totals() {
+        let request = Request::parse(&query(&["/one"])).unwrap();
+        let missing = collect(
+            &request,
+            250,
+            unlimited,
+            |_, _, _| Ok(Preflight::unavailable("missing", None)),
+            |_, _| unreachable!(),
+        )
+        .unwrap();
+        assert!(missing["totals"].is_null());
+        let empty = collect(
+            &request,
+            250,
+            unlimited,
+            |_, _, _| Ok(ready("/one", "/one/db")),
+            |_, _| Ok(runtime_report([0; 9])),
+        )
+        .unwrap();
+        assert_eq!(empty["totals"], totals_value(&[0; 9]));
+        assert_eq!(empty["projects"][0]["status"], "ready");
+    }
+
+    #[test]
+    fn unsafe_aggregate_is_rejected_instead_of_saturating_or_returning_null() {
+        let request = Request::parse(&query(&["/one", "/two"])).unwrap();
+        let high = [1, MAX_SAFE, 0, 0, 0, MAX_SAFE, MAX_SAFE, 0, 1];
+        let error = collect(
+            &request,
+            250,
+            unlimited,
+            |path, _, _| Ok(ready(path, &format!("{path}/db"))),
+            |_, _| Ok(runtime_report(high)),
+        )
+        .unwrap_err();
+        assert_eq!(error, "consolidated_totals_overflow");
+    }
+
+    #[test]
+    fn nonzero_malformed_and_oversized_output_never_become_success_or_leak_output() {
+        let success_looking = serde_json::to_vec(&runtime_report(totals())).unwrap();
+        assert_eq!(
+            decode_json(false, &success_looking, REPORT_BYTES),
+            Err(ReadFailure::invalid())
+        );
+        assert_eq!(
+            decode_json(true, b"DO_NOT_LEAK_CONSOLIDATED_STDERR", REPORT_BYTES),
+            Err(ReadFailure::invalid())
+        );
+        assert_eq!(
+            decode_json(true, &success_looking, 16),
+            Err(ReadFailure::invalid())
+        );
+        let failure = ReadFailure::process(ProcessFailure {
+            kind: FailureKind::StdoutLimit,
+            child_state: ChildState::Reaped,
+        });
+        assert_eq!(failure, ReadFailure::invalid());
+        assert!(
+            ReadFailure::process(ProcessFailure {
+                kind: FailureKind::Spawn,
+                child_state: ChildState::NotStarted
+            })
+            .stop
+        );
+    }
+
+    #[test]
+    fn worker_dispatch_rejects_options_and_trailing_arguments_without_starting_gui() {
+        assert!(dispatch_worker(Vec::<OsString>::new().into_iter()).is_none());
+        assert!(dispatch_worker(vec![OsString::from("--unrelated")].into_iter()).is_none());
+        for args in [
+            vec![WORKER_FLAG],
+            vec![WORKER_FLAG, "relative", "100", "200", "0"],
+            vec![WORKER_FLAG, "/one", "100", "200", "0", "--anything"],
+            vec![WORKER_FLAG, "/one", "+100", "200", "0"],
+        ] {
+            assert!(dispatch_worker(args.into_iter().map(OsString::from))
+                .unwrap()
+                .is_err());
+        }
+        let fixture = Fixture::new();
+        let project = fixture.project("worker-only", true);
+        let output = dispatch_worker(worker_args(&project, &range()).into_iter())
+            .unwrap()
+            .unwrap();
+        assert_eq!(output["status"], "ready");
+        assert!(validate_preflight(output, &project, &range()).is_ok());
+    }
+
+    #[test]
+    fn process_local_batch_lock_prevents_duplicate_authorization_and_empty_batch_is_bounded() {
+        let exe = std::env::current_exe().unwrap();
+        let calls = Cell::new(0);
+        let held = BATCH_LOCK.lock().unwrap();
+        let blocked = report(&query(&[]), &exe, vec!["unused".into()], || {
+            calls.set(calls.get() + 1);
+            Ok(())
+        });
+        assert_eq!(blocked.unwrap_err(), "consolidated_report_busy");
+        assert_eq!(calls.get(), 0);
+        drop(held);
+        let result = report(&query(&[]), &exe, vec!["unused".into()], || {
+            calls.set(calls.get() + 1);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(calls.get(), 1);
+        assert_eq!(result["projects"], json!([]));
+        assert!(result["totals"].is_null());
+    }
+
+    #[test]
+    fn preflight_child_fixture() {
+        if std::env::var_os("SIMPLICIO_CONSOLIDATED_PREFLIGHT_FIXTURE").is_none() {
+            return;
+        }
+        eprintln!("DO_NOT_LEAK_CONSOLIDATED_STDERR");
+        // This owned fixture has no descendants and performs no filesystem IO.
+        std::thread::sleep(Duration::from_secs(3));
+        std::process::exit(0);
+    }
+
+    #[test]
+    #[ignore = "requires explicit verified Runtime and freshly built Desktop executable paths"]
+    fn native_runtime_and_desktop_worker_smoke() {
+        let binary =
+            std::env::var_os("SIMPLICIO_TEST_RUNTIME_BIN").expect("explicit Runtime required");
+        let desktop =
+            std::env::var_os("SIMPLICIO_TEST_DESKTOP_BIN").expect("explicit Desktop required");
+        assert!(Path::new(&binary).is_absolute() && Path::new(&desktop).is_absolute());
+        let fixture = Fixture::new();
+        let first = fixture.project("first-real-ledger", false);
+        let second = fixture.project("second-real-ledger", false);
+        let missing = fixture.project("no-ledger", false);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        for (id, project, input_tokens, occurred) in [
+            ("first", &first, 100, now - 10),
+            ("second", &second, 900, now - 10),
+            ("outside-window", &first, 50, now - 3600),
+        ] {
+            let input = fixture.0.join(format!("{id}.json"));
+            let sample = json!({"schema":"workspace.token-analytics/v1", "sample_id":id,
+                "receipt_ref":id, "session_id":"consolidated-synthetic-smoke", "occurred_at_epoch":occurred,
+                "input_tokens":input_tokens, "cached_input_tokens":20, "output_tokens":30,
+                "reasoning_tokens":7, "paid_remote_tokens":input_tokens+37, "provenance":"measured"});
+            std::fs::write(&input, serde_json::to_vec(&sample).unwrap()).unwrap();
+            let mut record = Command::new(&binary);
+            record
+                .args(["tokens", "record", "--input"])
+                .arg(&input)
+                .arg("--db")
+                .arg(Path::new(project).join(".simplicio/token-usage.sqlite3"))
+                .current_dir(project)
+                .env("SIMPLICIO_DESKTOP_BRIDGE", "1");
+            let output = runtime_process::capture(&mut record, CaptureLimits::QUERY).unwrap();
+            assert!(output.status.success(), "synthetic Runtime record failed");
+        }
+        let alias = format!("{first}/.");
+        let request = json!({"repoPaths":[first, alias, second, missing],
+            "fromEpoch":now-60, "toEpoch":now+1, "timezoneOffsetSeconds":-10800});
+        // Authorization is separately covered by the batch admission test and
+        // native GUI smoke. This fixture reads only its own synthetic ledgers.
+        let result = report(&request, Path::new(&desktop), vec![binary], || Ok(())).unwrap();
+        let states = result["projects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["status"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(states, ["ready", "duplicate", "ready", "missing"]);
+        assert_eq!(result["totals"]["sample_count"], 2);
+        assert_eq!(result["totals"]["total_tokens"], 1074);
+        assert_eq!(result["totals"]["cached_input_tokens"], 40);
+        assert_eq!(result["totals"]["receipt_count"], 2);
+        assert!(!Path::new(request["repoPaths"][3].as_str().unwrap())
+            .join(".simplicio")
+            .exists());
+    }
+
+    #[test]
+    fn hanging_preflight_is_killed_and_reaped_within_its_capture_budget() {
+        let mut child = Command::new(std::env::current_exe().unwrap());
+        child
+            .args([
+                "--exact",
+                "consolidated_tokens::tests::preflight_child_fixture",
+                "--nocapture",
+            ])
+            .env("SIMPLICIO_CONSOLIDATED_PREFLIGHT_FIXTURE", "1");
+        let started = Instant::now();
+        let failure = runtime_process::capture(
+            &mut child,
+            capture_limits(Duration::from_millis(80), PREFLIGHT_BYTES),
+        )
+        .unwrap_err();
+        assert_eq!(failure.kind, FailureKind::Deadline);
+        assert_eq!(failure.child_state, ChildState::Reaped);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert_eq!(
+            ReadFailure::process(failure),
+            ReadFailure {
+                status: "timeout",
+                stop: false
+            }
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Output};
 use tauri::Manager;
 
 mod auth_access;
+mod consolidated_tokens;
 mod context_report;
 mod desktop_queries;
 mod install_result;
@@ -285,6 +286,21 @@ async fn desktop_token_report(
 }
 
 #[tauri::command]
+async fn desktop_consolidated_token_report(request: Value) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let executable = std::env::current_exe().map_err(|_| "consolidated_report_unavailable")?;
+        consolidated_tokens::report(
+            &request,
+            &executable,
+            runtime_candidates(),
+            require_read_access,
+        )
+    })
+    .await
+    .map_err(|_| "consolidated_report_unavailable".to_string())?
+}
+
+#[tauri::command]
 async fn desktop_export_token_report(
     app: tauri::AppHandle,
     reports: tauri::State<'_, token_exports::TokenReports>,
@@ -557,6 +573,7 @@ pub fn run() {
             desktop_usage_projects,
             desktop_context_report,
             desktop_token_report,
+            desktop_consolidated_token_report,
             desktop_export_token_report,
             desktop_open_subscription,
             desktop_update_target,
@@ -572,6 +589,11 @@ pub fn run() {
 /// Desktop IPC still requires fresh Runtime access before launching a worker.
 pub fn try_project_discovery_worker() -> Option<Result<Value, String>> {
     project_discovery_process::try_discovery_worker()
+}
+
+/// Internal metadata-only token preflight; dispatch before Tauri initialization.
+pub fn try_consolidated_token_preflight_worker() -> Option<Result<Value, String>> {
+    consolidated_tokens::try_preflight_worker()
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    if let Some(result) = simplicio_desktop_lib::try_project_discovery_worker() {
+    if let Some(result) = simplicio_desktop_lib::try_project_discovery_worker()
+        .or_else(simplicio_desktop_lib::try_consolidated_token_preflight_worker)
+    {
         use std::io::Write;
         let code = match result {
             Ok(report) => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,7 +20,8 @@ import { ProjectDialog } from "./components/ProjectDialog";
 import { DesktopUpdates } from "./components/DesktopUpdates";
 import { installFailureMessage, installFailureRecovery, type InstallFailureRecovery } from "./install_failures";
 import { runtimeFailureMessage } from "./runtime_failures";
-import { isView, loadWorkbench, MAX_PROJECTS, moveHistory, navigate, WORKBENCH_KEY, type LocalProject, type NavigationState, type WorkbenchState } from "./workbench";
+import { isView, loadWorkbench, MAX_PROJECTS, moveHistory, navigate, WORKBENCH_KEY, type LocalProject, type NavigationEntry, type NavigationState, type WorkbenchState } from "./workbench";
+import { viewNavigationEntry } from "./settings_navigation";
 import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
@@ -59,8 +60,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   const tokenRepo = route.tokenRepo;
   const actionLock = useRef(false);
 
-  function setView(next: View) {
-    setHistory((current) => navigate(current, { view: next, projectId: current.entries[current.index].projectId, tokenRepo: "" }));
+  function setView(next: View, restoreRoute?: NavigationEntry) {
+    setHistory((current) => navigate(current, viewNavigationEntry(current.entries[current.index], next, restoreRoute)));
   }
 
   function moveNavigation(direction: -1 | 1) {
@@ -260,7 +261,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     onFinish={() => setView("home")} onDiagnostics={() => { setView("diagnostics"); void refresh(); }} />;
 
   return (
-    <Shell snapshot={snapshot} view={view} onViewChange={setView} workbench={{ ...workbench, selectedProjectId: selectedProject?.id ?? null }}
+    <Shell snapshot={snapshot} view={view} route={route} onViewChange={setView} workbench={{ ...workbench, selectedProjectId: selectedProject?.id ?? null }}
       onAddProject={() => setShowProjectDialog(true)} onProject={openProject}
       onBack={() => moveNavigation(-1)} onForward={() => moveNavigation(1)}
       canBack={history.index > 0} canForward={history.index < history.entries.length - 1}
@@ -292,7 +293,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         />
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
-      {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} />}
+      {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} projectPaths={workbench.projects.map(project => project.path)} />}
       {(view === "settings" || view === "diagnostics") && (
         <SettingsScreen section={view === "diagnostics" ? "diagnostics" : "account"} snapshot={snapshot} busy={action !== null} onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"} />
       )}

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -11,11 +11,18 @@ import { parseLocalProject, type LocalProject } from "./workbench";
 import { createReadonlyRequest } from "./readonly_request";
 import { createContextReader } from "./context_report";
 import { parseUsageProjects } from "./project_usage";
+import { createConsolidatedReader, type ConsolidatedQuery, type ConsolidatedReport } from "./consolidated_tokens";
 
 const readSnapshot = createReadonlyRequest<DesktopSnapshot>(30_000, "desktop_snapshot_timeout");
 const readContext = createContextReader((repoPath) => invoke<unknown>("desktop_context_report", { repoPath: repoPath || null }));
 // Fresh authorization (20s) plus at most four isolated root scans (3s + cleanup each).
 const readUsageProjects = createReadonlyRequest<unknown>(45_000, "project_discovery_timeout");
+const readConsolidated = createConsolidatedReader(request => invoke<unknown>("desktop_consolidated_token_report", { request }));
+
+export function loadDesktopConsolidatedTokens(request: ConsolidatedQuery): Promise<ConsolidatedReport> {
+  if (!isTauri()) return Promise.reject(new Error("preview_no_runtime"));
+  return readConsolidated(request);
+}
 
 export async function loadDesktopUsageProjects() {
   if (!isTauri()) throw new Error("preview_no_runtime");

--- a/apps/desktop/src/components/ConsolidatedTokens.tsx
+++ b/apps/desktop/src/components/ConsolidatedTokens.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+import { loadDesktopConsolidatedTokens } from "../bridge";
+import { collectReportPaths, consolidatedError, consolidatedRange, CONSOLIDATED_PERIODS, PROJECT_STATUS, type ConsolidatedPeriod, type ConsolidatedReport } from "../consolidated_tokens";
+import "../consolidated_tokens.css";
+
+const number = (n: number) => n.toLocaleString("pt-BR");
+const date = (n: number) => new Date(n * 1000).toLocaleString("pt-BR");
+
+export function ConsolidatedTokens({ paths, discoveryReady, discoveryPartial }: { paths: string[]; discoveryReady: boolean; discoveryPartial: boolean }) {
+  const candidates = collectReportPaths(paths);
+  const key = JSON.stringify(candidates.paths);
+  const [period, setPeriod] = useState<ConsolidatedPeriod>("30d");
+  const [loadedReport, setReport] = useState<ConsolidatedReport | null>(null);
+  const [reportScope, setReportScope] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [revision, setRevision] = useState(0);
+  const generation = useRef(0);
+  const scope = JSON.stringify([key, discoveryReady, period, revision]);
+  const report = reportScope === scope ? loadedReport : null;
+
+  useEffect(() => {
+    const current = ++generation.current;
+    setReport(null); setError(null);
+    if (!discoveryReady || !JSON.parse(key).length) { setBusy(false); return; }
+    setBusy(true);
+    const query = { ...consolidatedRange(period), repoPaths: JSON.parse(key) as string[] };
+    void loadDesktopConsolidatedTokens(query).then(next => {
+      if (current === generation.current) { setReportScope(scope); setReport(next); }
+    }).catch(cause => { if (current === generation.current) setError(consolidatedError(cause)); })
+      .finally(() => { if (current === generation.current) setBusy(false); });
+    return () => { generation.current += 1; };
+  }, [key, discoveryReady, period, revision]);
+
+  const ready = report?.projects.filter(p => p.status === "ready") ?? [];
+  const measured = ready.filter(p => p.totals!.sample_count > p.totals!.missing_usage_events);
+  const incomplete = discoveryPartial || candidates.omitted > 0 || Boolean(report?.projects.some(p => p.status !== "ready" && p.status !== "duplicate")) || Boolean(report?.totals?.missing_usage_events);
+  const totals = report?.totals;
+  const hasUsage = Boolean(totals && totals.sample_count > totals.missing_usage_events);
+  const ranked = [...measured].sort((a, b) => b.totals!.total_tokens - a.totals!.total_tokens);
+  const bars = ranked.slice(0, 8).map(p => ({ label: p.name, path: p.path, total: p.totals!.total_tokens }));
+  if (ranked.length > 8) bars.push({ label: `Outros ${ranked.length - 8} projetos`, path: "Demais projetos consultados", total: ranked.slice(8).reduce((n, p) => n + p.totals!.total_tokens, 0) });
+  const maximum = Math.max(1, ...bars.map(p => p.total));
+  const composition = totals ? [["Entrada", totals.input_tokens, "input"], ["Saída", totals.output_tokens, "output"], ["Raciocínio", totals.reasoning_tokens, "reasoning"]] as const : [];
+
+  return <section className="consolidated-report" aria-label="Relatório consolidado">
+    <div className="consolidated-heading"><div><span className="eyebrow">Visão geral</span><h2>Todos os projetos</h2><p>Uso registrado nos projetos encontrados e adicionados, no mesmo intervalo.</p></div>
+      <button type="button" className="button button-secondary" disabled={busy || !discoveryReady || !candidates.paths.length} onClick={() => setRevision(n => n + 1)}>Atualizar consolidado</button></div>
+    <div className="consolidated-periods" role="group" aria-label="Período do consolidado">{CONSOLIDATED_PERIODS.map(([id, label]) => <button type="button" key={id} aria-pressed={period === id} disabled={busy} onClick={() => setPeriod(id)}>{label}</button>)}</div>
+    {!discoveryReady && <p role="status">Aguardando a descoberta de projetos…</p>}
+    {discoveryReady && !candidates.paths.length && <p role="status">Nenhum projeto disponível para consolidar. Adicione uma pasta ou atualize a descoberta abaixo.</p>}
+    {busy && <p role="status">Consolidando {candidates.paths.length} projetos pelo Runtime… A consulta tem prazo limitado e preserva resultados parciais.</p>}
+    {error && <p className="token-notice" role="alert">{error}</p>}
+    {report && <>
+      <div className="consolidated-coverage"><span className={incomplete ? "coverage-partial" : "coverage-ready"}>{incomplete ? "Cobertura parcial" : "Consulta concluída"}</span><span>{ready.length} de {report.projects.length} pastas consultadas · {measured.length} com uso informado</span></div>
+      <p className="consolidated-dates">{date(report.fromEpoch)} → {date(report.toEpoch)} · fim exclusivo</p>
+      <div className="token-metrics consolidated-metrics" aria-label="Totais consolidados">{[["Tokens registrados", totals?.total_tokens, hasUsage], ["Entrada em cache", totals?.cached_input_tokens, hasUsage], ["Eventos registrados", totals?.sample_count, totals !== null], ["Recibos", totals?.receipt_count, totals !== null]].map(([label, value, known]) => <article className="panel token-metric" key={String(label)}><span>{label}</span><strong>{known && typeof value === "number" ? number(value) : "—"}</strong></article>)}</div>
+      {!hasUsage && <p role="status">Nenhum uso informado neste período. Ausência de telemetria não significa consumo zero.</p>}
+      {hasUsage && <div className="consolidated-charts">
+        <article className="panel"><h3>Uso por projeto</h3><p>Total registrado · todos os projetos com uso</p><div className="project-bars" role="img" aria-label="Gráfico de barras do total de tokens por projeto; valores detalhados na tabela abaixo">{bars.map(bar => <div className="project-bar" key={bar.path}><div><span title={bar.path}>{bar.label}</span><strong>{number(bar.total)}</strong></div><div className="bar-track"><span style={{ width: `${bar.total / maximum * 100}%` }} /></div></div>)}</div></article>
+        <article className="panel"><h3>Composição dos tokens</h3><p>Entrada, saída e raciocínio</p><svg className="composition-chart" viewBox="0 0 200 200" role="img" aria-labelledby="composition-title composition-description"><title id="composition-title">Composição dos tokens registrados</title><desc id="composition-description">{composition.map(([label, value]) => `${label}: ${number(value)}`).join("; ")}. Cache é parte da entrada.</desc><circle cx="100" cy="100" r="72" fill="none" stroke="var(--border, #e5e7eb)" strokeWidth="24" />{composition.map(([label, value, color], index) => {
+          const fraction = totals!.total_tokens ? value / totals!.total_tokens : 0;
+          const previous = composition.slice(0, index).reduce((n, entry) => n + entry[1], 0);
+          return <circle key={label} className={`composition-${color}`} cx="100" cy="100" r="72" pathLength="100" fill="none" strokeWidth="24" strokeDasharray={`${fraction * 100} ${100 - fraction * 100}`} strokeDashoffset={totals!.total_tokens ? -previous / totals!.total_tokens * 100 : 0} transform="rotate(-90 100 100)" />;
+        })}<text x="100" y="98" textAnchor="middle">{totals!.total_tokens.toLocaleString("pt-BR", { notation: "compact", maximumFractionDigits: 1 })}</text><text className="composition-caption" x="100" y="119" textAnchor="middle">tokens</text></svg><ul className="composition-legend">{composition.map(([label, value, color]) => <li key={label}><span><i className={`composition-${color}`} />{label}</span><strong>{number(value)}</strong></li>)}</ul><p>Tokens em cache já fazem parte da entrada; não são somados novamente.</p></article>
+      </div>}
+      <section className="panel consolidated-details"><h3>Cobertura por projeto</h3><div className="consolidated-table-scroll" role="region" aria-label="Tabela de projetos" tabIndex={0}><table><thead><tr><th scope="col">Projeto</th><th scope="col">Estado</th><th scope="col">Tokens</th><th scope="col">Eventos sem uso</th></tr></thead><tbody>{report.projects.map(p => <tr key={p.path}><th scope="row">{p.name}<small>{p.path}</small></th><td>{PROJECT_STATUS[p.status]}</td><td>{p.totals && p.totals.sample_count > p.totals.missing_usage_events ? number(p.totals.total_tokens) : "—"}</td><td>{p.totals ? number(p.totals.missing_usage_events) : "—"}</td></tr>)}</tbody></table></div></section>
+      <details className="consolidated-method"><summary>Escopo e critérios do relatório</summary><p>7 e 30 dias são intervalos corridos de 24 horas; 3, 6 e 12 meses seguem o calendário local, ajustando o último dia do mês. Todas as sessões são incluídas. O horário final é fixado antes da consulta dos projetos.</p><p>Apenas relatórios válidos entram nos totais. Aliases do mesmo ledger são excluídos; eventos copiados para bancos independentes não podem ser deduplicados pelo contrato atual. Não há séries diárias, custo ou cobrança neste contrato.</p><p>A descoberta é limitada aos locais informados abaixo e aos projetos adicionados, até 96 caminhos. Não representa uma varredura completa do computador. {discoveryPartial && "A descoberta não concluiu todos os locais."} {candidates.omitted > 0 && `${candidates.omitted} caminhos ficaram fora do limite.`}</p><p>A economia de contexto apresentada abaixo usa o histórico do projeto selecionado e não faz parte deste consolidado por período.</p><code>{report.reportHash}</code></details>
+    </>}
+  </section>;
+}

--- a/apps/desktop/src/components/IntegrationSetup.tsx
+++ b/apps/desktop/src/components/IntegrationSetup.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { planDesktopIntegrations } from "../bridge";
-import type { IntegrationPlan } from "../integration_setup";
+import { integrationChangeLabel, type IntegrationPlan } from "../integration_setup";
 import type { InstallFailureRecovery } from "../install_failures";
 
 export function IntegrationSetup({ busy, onApply, recovery, onDiagnostics }: {
@@ -40,7 +40,7 @@ export function IntegrationSetup({ busy, onApply, recovery, onDiagnostics }: {
     {blocked && <div className="integration-recovery"><p>{recovery === "refresh" ? "A aplicação foi confirmada; falta verificar o estado final. Consulte o diagnóstico, sem reinstalar." : recovery === "wait" ? "Já há uma instalação em andamento. Aguarde sua conclusão antes de outra aplicação." : "Há uma instalação com resultado incerto. Novas aplicações estão bloqueadas nesta sessão; atualizar ou reiniciar o app não comprova a conclusão."}</p>{onDiagnostics && <button type="button" className="button button-secondary" disabled={busy} onClick={onDiagnostics}>Atualizar diagnóstico</button>}</div>}
     {plan && !blocked && <div className="integration-plan">
       <p>{plan.source === "preview" ? "Demonstração: nenhuma alteração real." : "Plano do Runtime, ainda não executado."} {plan.changes.filter((row) => row.changed).length} alterações propostas.</p>
-      <ul>{plan.changes.map((row) => <li key={row.label}><span>{row.label}</span><strong>{row.changed ? row.exists ? "Atualizar" : "Criar" : "Já configurado"}</strong></li>)}</ul>
+      <ul>{plan.changes.map((row) => <li key={row.label}><span>{row.label}</span><strong>{integrationChangeLabel(row)}</strong></li>)}</ul>
       <label className="setup-consent"><input type="checkbox" checked={confirmed} disabled={busy} onChange={(event) => setConfirmed(event.target.checked)} />Autorizo o Runtime a aplicar este plano de instalação e registro.</label>
       <div className="settings-actions"><button type="button" className="button button-primary" disabled={!confirmed || busy} onClick={() => void apply()}>{busy ? "Configurando…" : "Aplicar configuração MCP"}</button><button type="button" className="button button-secondary" disabled={busy} onClick={() => { setPlan(null); setConfirmed(false); }}>Cancelar</button></div>
     </div>}

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import type { DesktopSnapshot } from "../contracts";
 import { Brand, Glyph, type GlyphName } from "./Brand";
 import { REFERENCE_SCREENS, type ReferenceSettingsView } from "../reference_screens";
-import { isNavigationVisible, isSettingsView, runtimeSummary, searchMatches, VIEW_LABELS, type LocalProject, type View, type WorkbenchState } from "../workbench";
+import { isNavigationVisible, isSettingsView, runtimeSummary, searchMatches, VIEW_LABELS, type LocalProject, type NavigationEntry, type View, type WorkbenchState } from "../workbench";
+import { rememberWorkspaceRoute } from "../settings_navigation";
 
 export type { View } from "../workbench";
 
@@ -43,7 +44,8 @@ interface ShellProps {
   children: ReactNode;
   snapshot: DesktopSnapshot;
   view: View;
-  onViewChange: (view: View) => void;
+  route: NavigationEntry;
+  onViewChange: (view: View, restoreRoute?: NavigationEntry) => void;
   workbench: WorkbenchState;
   onAddProject: () => void;
   onProject: (project: LocalProject) => void;
@@ -55,7 +57,7 @@ interface ShellProps {
   busy: boolean;
 }
 
-export function Shell({ children, snapshot, view, onViewChange, workbench, onAddProject, onProject,
+export function Shell({ children, snapshot, view, route, onViewChange, workbench, onAddProject, onProject,
   onBack, onForward, canBack, canForward, onRefresh, busy }: ShellProps) {
   const [narrow, setNarrow] = useState(() => typeof window !== "undefined" && window.innerWidth < 760);
   const [collapsed, setCollapsed] = useState(() => typeof window !== "undefined" && window.innerWidth < 760);
@@ -65,7 +67,7 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
   const sidebarScroll = useRef<HTMLDivElement>(null);
   const sidebarToggle = useRef<HTMLButtonElement>(null);
   const mainContent = useRef<HTMLElement>(null);
-  const lastWorkspace = useRef<View>("home");
+  const lastWorkspace = useRef<NavigationEntry>({ view: "home", projectId: route.projectId, tokenRepo: "" });
   const drawerOpen = narrow && !collapsed;
   const inSettings = isSettingsView(view);
   const status = runtimeSummary(snapshot);
@@ -88,9 +90,9 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
     else closeSidebar(drawerOpen ? "toggle" : null);
   }, [collapsed, drawerOpen, closeSidebar]);
 
-  const selectView = useCallback((next: View) => {
+  const selectView = useCallback((next: View, restoreRoute?: NavigationEntry) => {
     if (drawerOpen) closeSidebar("content");
-    onViewChange(next);
+    onViewChange(next, restoreRoute);
   }, [drawerOpen, closeSidebar, onViewChange]);
 
   function addProject() {
@@ -139,8 +141,8 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
 
   useEffect(() => {
     setQuery("");
-    if (!isSettingsView(view)) lastWorkspace.current = view;
-  }, [view]);
+    lastWorkspace.current = rememberWorkspaceRoute(lastWorkspace.current, { ...route, view });
+  }, [route, view]);
 
   useEffect(() => { sidebarScroll.current?.scrollTo({ top: 0 }); }, [query]);
 
@@ -196,7 +198,7 @@ export function Shell({ children, snapshot, view, onViewChange, workbench, onAdd
       {drawerOpen && <button className="sidebar-scrim" type="button" aria-label="Fechar navegação" tabIndex={-1} onClick={() => closeSidebar()} />}
       <aside ref={sidebar} id="workbench-sidebar" className="sidebar" role={drawerOpen ? "dialog" : undefined} aria-modal={drawerOpen ? true : undefined} aria-label={inSettings ? "Configurações" : "Espaço de trabalho"}>
         <div className="sidebar-heading">
-          {inSettings ? <button className="back-to-app" type="button" onClick={() => selectView(lastWorkspace.current)} aria-label="Voltar ao app"><Glyph name="back" size={18} />{!collapsed && <span>Voltar ao app</span>}</button>
+          {inSettings ? <button className="back-to-app" type="button" onClick={() => selectView(lastWorkspace.current.view, lastWorkspace.current)} aria-label="Voltar ao app"><Glyph name="back" size={18} />{!collapsed && <span>Voltar ao app</span>}</button>
             : <button className="brand-home" type="button" onClick={() => selectView("home")} aria-label="Início do Simplicio"><Brand compact={collapsed} /></button>}
           {drawerOpen && <button className="icon-button sidebar-close" type="button" aria-label="Recolher barra lateral" onClick={() => closeSidebar()}><Glyph name="close" size={18} /></button>}
         </div>

--- a/apps/desktop/src/components/TokenProjects.tsx
+++ b/apps/desktop/src/components/TokenProjects.tsx
@@ -3,8 +3,9 @@ import { chooseDesktopProject, loadDesktopUsageProjects } from "../bridge";
 import { projectDiscoveryError, type UsageProjects } from "../project_usage";
 import "../project_usage.css";
 
-export function TokenProjects({ repoPath, allowAutoSelect, onSelect }: {
+export function TokenProjects({ repoPath, allowAutoSelect, onSelect, onDiscovery }: {
   repoPath: string; allowAutoSelect: boolean; onSelect: (path: string) => void;
+  onDiscovery?: (result: UsageProjects | null) => void;
 }) {
   const [discovery, setDiscovery] = useState<UsageProjects | null>(null);
   const [busy, setBusy] = useState(false);
@@ -14,8 +15,8 @@ export function TokenProjects({ repoPath, allowAutoSelect, onSelect }: {
   const readLock = useRef(false);
   const pickerLock = useRef(false);
   const mounted = useRef(false);
-  const latest = useRef({ repoPath, allowAutoSelect, onSelect });
-  latest.current = { repoPath, allowAutoSelect, onSelect };
+  const latest = useRef({ repoPath, allowAutoSelect, onSelect, onDiscovery });
+  latest.current = { repoPath, allowAutoSelect, onSelect, onDiscovery };
 
   async function discover() {
     if (readLock.current) return;
@@ -26,11 +27,12 @@ export function TokenProjects({ repoPath, allowAutoSelect, onSelect }: {
       const result = await loadDesktopUsageProjects();
       if (generation !== request.current) return;
       setDiscovery(result);
+      latest.current.onDiscovery?.(result);
       if (latest.current.allowAutoSelect && !latest.current.repoPath.trim() && result.projects.length) {
         latest.current.onSelect(result.projects[0].path);
       }
     } catch (cause) {
-      if (generation === request.current) setError(projectDiscoveryError(cause));
+      if (generation === request.current) { setError(projectDiscoveryError(cause)); latest.current.onDiscovery?.(null); }
     } finally {
       readLock.current = false;
       if (generation === request.current) setBusy(false);

--- a/apps/desktop/src/consolidated_tokens.css
+++ b/apps/desktop/src/consolidated_tokens.css
@@ -1,0 +1,41 @@
+.consolidated-report { display: grid; gap: 18px; min-width: 0; margin-bottom: 32px; }
+.individual-token-report { display: grid; gap: 20px; min-width: 0; }
+.consolidated-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.consolidated-heading h2 { margin: 6px 0; font-size: 26px; letter-spacing: -.7px; }
+.consolidated-heading p, .consolidated-charts p, .consolidated-dates, .consolidated-method { color: var(--muted, #66716e); font-size: 13px; line-height: 1.6; }
+.consolidated-periods { display: flex; flex-wrap: wrap; gap: 6px; }
+.consolidated-periods button { border: 1px solid var(--border, #e0e6e3); border-radius: 9px; padding: 9px 16px; background: white; color: #46534e; font: inherit; cursor: pointer; }
+.consolidated-periods button[aria-pressed="true"] { background: #173f35; border-color: #173f35; color: white; }
+.consolidated-periods button:disabled { cursor: wait; opacity: .65; }
+.consolidated-periods button:focus-visible { outline: 2px solid #25856a; outline-offset: 3px; }
+.consolidated-coverage { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; font-size: 13px; }
+.coverage-partial, .coverage-ready { padding: 5px 9px; border-radius: 20px; background: #e7f1eb; color: #22513e; }
+.coverage-partial { background: #fff1d6; color: #795310; }
+.consolidated-dates { margin: 0; }
+.token-metrics.consolidated-metrics { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.consolidated-metrics strong { overflow-wrap: anywhere; }
+.consolidated-charts { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr); gap: 18px; }
+.consolidated-charts .panel, .consolidated-details { min-width: 0; padding: 24px; }
+.consolidated-charts h3, .consolidated-details h3 { margin: 0; font-size: 16px; }
+.project-bars { display: grid; gap: 18px; margin-top: 26px; }
+.project-bar > div:first-child { display: flex; justify-content: space-between; gap: 14px; margin-bottom: 7px; font-size: 13px; }
+.project-bar span { min-width: 0; overflow-wrap: anywhere; }
+.project-bar strong { font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.bar-track { height: 10px; background: #eef3f0; border-radius: 3px; overflow: hidden; }
+.bar-track span { display: block; height: 100%; background: #36866a; border-radius: 3px; }
+.composition-chart { display: block; width: min(100%, 240px); margin: 12px auto; }
+.composition-chart text { font-size: 19px; fill: #173f35; font-weight: 650; }
+.composition-chart .composition-caption { font-size: 12px; fill: #66716e; font-weight: 400; }
+.composition-input { stroke: #36866a; background: #36866a; }
+.composition-output { stroke: #7c9ca8; background: #7c9ca8; }
+.composition-reasoning { stroke: #c5985b; background: #c5985b; }
+.composition-legend { display: grid; gap: 10px; padding: 0; list-style: none; font-size: 13px; }
+.composition-legend li { display: flex; justify-content: space-between; gap: 12px; }
+.composition-legend i { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 8px; }
+.consolidated-table-scroll { overflow-x: auto; margin-top: 18px; }
+.consolidated-details table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.consolidated-details th, .consolidated-details td { text-align: left; padding: 12px 10px; border-bottom: 1px solid var(--border, #e0e6e3); vertical-align: top; }
+.consolidated-details th:first-child { width: 45%; }
+.consolidated-details small { display: block; font-weight: 400; color: #66716e; overflow-wrap: anywhere; margin-top: 5px; }
+.consolidated-method code { overflow-wrap: anywhere; }
+@media (max-width: 900px) { .token-metrics.consolidated-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } .consolidated-charts { grid-template-columns: minmax(0, 1fr); } .consolidated-heading { align-items: flex-start; flex-direction: column; } }

--- a/apps/desktop/src/consolidated_tokens.test.ts
+++ b/apps/desktop/src/consolidated_tokens.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectReportPaths, consolidatedRange, createConsolidatedReader, parseConsolidatedReport, type ConsolidatedQuery } from "./consolidated_tokens";
+
+afterEach(() => vi.useRealTimers());
+
+const hash = `sha256:${"a".repeat(64)}`;
+const query: ConsolidatedQuery = { repoPaths: ["/projects/a", "/projects/b"], fromEpoch: 10, toEpoch: 20, timezoneOffsetSeconds: 0 };
+function fixture() {
+  const totals = { sample_count: 2, input_tokens: 10, cached_input_tokens: 3, output_tokens: 4, reasoning_tokens: 1, paid_remote_tokens: 15, total_tokens: 15, missing_usage_events: 1, receipt_count: 2 };
+  return { schema: "simplicio.desktop-consolidated-tokens/v1", source: "runtime", ...query, generatedAtEpoch: 21,
+    projects: query.repoPaths.map((path, i) => ({ id: `project-${i}`, path, name: path, status: "ready", totals: { ...totals }, reportHash: hash })),
+    totals: Object.fromEntries(Object.entries(totals).map(([key, value]) => [key, value * 2])), reportHash: hash };
+}
+
+describe("consolidated report", () => {
+  it("does not duplicate a pending native batch after a timeout", async () => {
+    vi.useFakeTimers();
+    let complete!: (value: unknown) => void;
+    const invoke = vi.fn(() => new Promise(resolve => { complete = resolve; }));
+    const read = createConsolidatedReader(invoke, 20);
+    const first = read(query);
+    const failure = expect(first).rejects.toThrow("consolidated_report_timeout");
+    await vi.advanceTimersByTimeAsync(21); await failure;
+    expect(read(query)).toBe(first);
+    await expect(read({ ...query, toEpoch: 30 })).rejects.toThrow("consolidated_report_busy");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    complete(fixture()); await vi.advanceTimersByTimeAsync(0);
+    const next = read(query); await vi.advanceTimersByTimeAsync(0);
+    complete(fixture()); await expect(next).resolves.toMatchObject({ totals: { total_tokens: 30 } });
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+  it("uses exact rolling days, not calendar month for 30 days", () => {
+    const now = new Date(2026, 7, 31, 12);
+    expect(consolidatedRange("7d", now).toEpoch - consolidatedRange("7d", now).fromEpoch).toBe(7 * 86400);
+    expect(consolidatedRange("30d", now).toEpoch - consolidatedRange("30d", now).fromEpoch).toBe(30 * 86400);
+  });
+  it("clamps calendar months and handles leap years", () => {
+    expect(new Date(consolidatedRange("6m", new Date(2026, 7, 31, 12)).fromEpoch * 1000).getDate()).toBe(28);
+    expect(new Date(consolidatedRange("6m", new Date(2024, 7, 31, 12)).fromEpoch * 1000).getDate()).toBe(29);
+    expect(new Date(consolidatedRange("12m", new Date(2024, 1, 29, 12)).fromEpoch * 1000).getDate()).toBe(28);
+    expect(new Date(consolidatedRange("3m", new Date(2026, 0, 31, 12)).fromEpoch * 1000).getMonth()).toBe(9);
+    expect(() => consolidatedRange("7d", new Date(NaN))).toThrow();
+  });
+  it("merges discovered/bookmarked paths and bounds the batch", () => {
+    const result = collectReportPaths(["/a", "/a", "relative", "//network/share", "/a\0", "C:\\projects\\a"]);
+    expect(result.paths).toEqual(["/a", "C:\\projects\\a"]);
+    expect(collectReportPaths(Array.from({ length: 100 }, (_, i) => `/p/${i}`)).omitted).toBe(4);
+  });
+  it("validates the exact interval and checked native sum, strips unknown fields", () => {
+    const parsed = parseConsolidatedReport({ ...fixture(), prompts: "private" }, query);
+    expect(parsed.totals?.total_tokens).toBe(30);
+    expect(parsed).not.toHaveProperty("prompts");
+    for (const field of ["fromEpoch", "toEpoch", "timezoneOffsetSeconds"]) expect(() => parseConsolidatedReport({ ...fixture(), [field]: 999 }, query)).toThrow();
+    const bad = fixture(); bad.totals.input_tokens++;
+    expect(() => parseConsolidatedReport(bad, query)).toThrow();
+  });
+  it("rejects missing, duplicated or unrequested project responses", () => {
+    const short = fixture(); short.projects.pop();
+    expect(() => parseConsolidatedReport(short, query)).toThrow();
+    const duplicate = fixture(); duplicate.projects[1] = duplicate.projects[0];
+    expect(() => parseConsolidatedReport(duplicate, query)).toThrow();
+    const wrong = fixture(); wrong.projects[0].path = "/elsewhere";
+    expect(() => parseConsolidatedReport(wrong, query)).toThrow();
+  });
+  it("accepts unknown coverage without interpreting it as zero", () => {
+    const base = fixture();
+    const projects = base.projects.map(p => ({ ...p, status: "missing", totals: null, reportHash: null }));
+    expect(parseConsolidatedReport({ ...base, projects, totals: null }, query).totals).toBeNull();
+    expect(() => parseConsolidatedReport({ ...base, projects }, query)).toThrow();
+  });
+  it("excludes duplicate ledgers from totals and rejects unsafe numbers", () => {
+    const base = fixture();
+    const projects = [base.projects[0], { ...base.projects[1], status: "duplicate", totals: null, reportHash: null }];
+    expect(parseConsolidatedReport({ ...base, projects, totals: base.projects[0].totals }, query).totals?.total_tokens).toBe(15);
+    const bad = fixture(); bad.projects[0].totals.input_tokens = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => parseConsolidatedReport(bad, query)).toThrow();
+    expect(() => parseConsolidatedReport({ ...base, reportHash: "fake" }, query)).toThrow();
+  });
+});

--- a/apps/desktop/src/consolidated_tokens.ts
+++ b/apps/desktop/src/consolidated_tokens.ts
@@ -1,0 +1,102 @@
+import { parseTokenUsageReport, type TokenTotals } from "./token_usage";
+
+export const CONSOLIDATED_PERIODS = [["7d", "7 dias"], ["30d", "30 dias"], ["3m", "3 meses"], ["6m", "6 meses"], ["12m", "12 meses"]] as const;
+export type ConsolidatedPeriod = typeof CONSOLIDATED_PERIODS[number][0];
+export interface ConsolidatedQuery { repoPaths: string[]; fromEpoch: number; toEpoch: number; timezoneOffsetSeconds: number }
+export type ProjectReportStatus = "ready" | "missing" | "invalid" | "timeout" | "skipped" | "duplicate";
+export interface ConsolidatedProject { id: string; path: string; name: string; status: ProjectReportStatus; totals: TokenTotals | null; reportHash: string | null }
+export interface ConsolidatedReport extends Omit<ConsolidatedQuery, "repoPaths"> {
+  schema: "simplicio.desktop-consolidated-tokens/v1"; source: "runtime"; generatedAtEpoch: number;
+  projects: ConsolidatedProject[]; totals: TokenTotals | null; reportHash: string;
+}
+export const PROJECT_STATUS: Record<ProjectReportStatus, string> = { ready: "Consultado", missing: "Sem ledger de uso", invalid: "Não validado", timeout: "Sem resposta", skipped: "Não consultado (limite)", duplicate: "Ledger já contabilizado" };
+const hashPattern = /^sha256:[a-f0-9]{64}$/;
+const absolutePath = /^(?:\/(?!\/)|[a-zA-Z]:[\\/])/;
+const validPath = (value: unknown): value is string => typeof value === "string" && value.length <= 4096 && absolutePath.test(value) && !/[\u0000-\u001f\u007f]/.test(value);
+function invalid(): never { throw new Error("consolidated_report_invalid"); }
+function object(value: unknown): Record<string, unknown> { return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : invalid(); }
+function epoch(value: unknown): number { return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= 8_640_000_000_000 ? value : invalid(); }
+
+/** Rolling days; calendar months clamp the day at month-end, in local time. */
+export function consolidatedRange(period: ConsolidatedPeriod, now = new Date()): Omit<ConsolidatedQuery, "repoPaths"> {
+  const end = new Date(now);
+  const start = new Date(now);
+  if (period === "7d" || period === "30d") start.setTime(end.getTime() - (period === "7d" ? 7 : 30) * 86_400_000);
+  else {
+    const day = start.getDate();
+    start.setDate(1);
+    start.setMonth(start.getMonth() - Number.parseInt(period, 10));
+    const lastDay = new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
+    start.setDate(Math.min(day, lastDay));
+  }
+  const fromEpoch = Math.floor(start.getTime() / 1000), toEpoch = Math.floor(end.getTime() / 1000);
+  if (!Number.isSafeInteger(fromEpoch) || fromEpoch < 0 || fromEpoch >= toEpoch) throw new Error("token_query_invalid");
+  return { fromEpoch, toEpoch, timezoneOffsetSeconds: -end.getTimezoneOffset() * 60 };
+}
+
+export function collectReportPaths(paths: string[]): { paths: string[]; omitted: number } {
+  const unique = [...new Set(paths.filter(validPath))].sort();
+  return { paths: unique.slice(0, 96), omitted: unique.length - Math.min(unique.length, 96) };
+}
+
+/** Validate provenance, exact requested scope and the native checked sum. */
+export function parseConsolidatedReport(value: unknown, query: ConsolidatedQuery): ConsolidatedReport {
+  const raw = object(value);
+  if (raw.schema !== "simplicio.desktop-consolidated-tokens/v1" || raw.source !== "runtime"
+    || raw.fromEpoch !== query.fromEpoch || raw.toEpoch !== query.toEpoch || raw.timezoneOffsetSeconds !== query.timezoneOffsetSeconds
+    || !hashPattern.test(String(raw.reportHash)) || !Array.isArray(raw.projects) || raw.projects.length !== query.repoPaths.length || raw.projects.length > 96) invalid();
+  const fromEpoch = epoch(raw.fromEpoch), toEpoch = epoch(raw.toEpoch);
+  if (fromEpoch >= toEpoch) invalid();
+  const totals = (input: unknown): TokenTotals => {
+    try { return parseTokenUsageReport({ schema: "workspace.token-analytics-report/v1", generated_by: "sqlite_ledger", report_hash: raw.reportHash,
+      now_epoch: epoch(raw.generatedAtEpoch), session_id: null, timezone_offset_seconds: query.timezoneOffsetSeconds,
+      periods: [{ window: "custom", from_epoch: fromEpoch, to_epoch: toEpoch, totals: input }] }).periods[0].totals; } catch { return invalid(); }
+  };
+  const seen = new Set<string>();
+  const projects = raw.projects.map((item): ConsolidatedProject => {
+    const p = object(item);
+    if (typeof p.id !== "string" || p.id.length < 1 || p.id.length > 256 || !validPath(p.path)
+      || !query.repoPaths.includes(p.path) || seen.has(p.path) || typeof p.name !== "string" || !p.name || p.name.length > 4096
+      || !Object.hasOwn(PROJECT_STATUS, String(p.status))) invalid();
+    seen.add(p.path);
+    const ready = p.status === "ready";
+    if (ready ? !hashPattern.test(String(p.reportHash)) : p.totals !== null || p.reportHash !== null) invalid();
+    return { id: p.id, path: p.path, name: p.name, status: p.status as ProjectReportStatus, totals: ready ? totals(p.totals) : null, reportHash: ready ? String(p.reportHash) : null };
+  });
+  const ready = projects.filter(p => p.totals !== null);
+  const sum = raw.totals === null ? null : totals(raw.totals);
+  if (Boolean(ready.length) !== Boolean(sum)) invalid();
+  if (sum) for (const key of Object.keys(sum) as Array<keyof TokenTotals>) {
+    const expected = ready.reduce((n, p) => n + p.totals![key], 0);
+    if (!Number.isSafeInteger(expected) || sum[key] !== expected) invalid();
+  }
+  return { schema: "simplicio.desktop-consolidated-tokens/v1", source: "runtime", fromEpoch, toEpoch,
+    timezoneOffsetSeconds: query.timezoneOffsetSeconds, generatedAtEpoch: epoch(raw.generatedAtEpoch), projects, totals: sum, reportHash: String(raw.reportHash) };
+}
+
+export function consolidatedError(cause: unknown): string {
+  const code = cause instanceof Error ? cause.message : String(cause);
+  if (code.includes("preview_no_runtime")) return "Abra o app desktop para consolidar os ledgers locais. A demonstração não inventa dados de uso.";
+  if (code.includes("busy") || code.includes("timeout")) return "A consulta ainda não foi concluída. Aguarde antes de atualizar; nenhum total foi presumido.";
+  if (code.includes("access")) return "O acesso da conta não foi confirmado para esta consulta. Verifique a conta e tente novamente.";
+  return "Não foi possível validar o consolidado. Atualize para consultar novamente; nenhum consumo foi presumido.";
+}
+
+/** One batch at a time. Retain its slot after observer timeout until native completion. */
+export function createConsolidatedReader(invoke: (request: ConsolidatedQuery) => Promise<unknown>, timeoutMs = 130_000) {
+  let pending: { key: string; promise: Promise<ConsolidatedReport> } | undefined;
+  return (request: ConsolidatedQuery): Promise<ConsolidatedReport> => {
+    const key = JSON.stringify(request);
+    if (pending) return pending.key === key ? pending.promise : Promise.reject(new Error("consolidated_report_busy"));
+    const native = Promise.resolve().then(() => invoke(request));
+    const promise = new Promise<ConsolidatedReport>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("consolidated_report_timeout")), timeoutMs);
+      native.then(value => {
+        clearTimeout(timer); pending = undefined;
+        try { resolve(parseConsolidatedReport(value, request)); } catch (cause) { reject(cause); }
+      }, cause => { clearTimeout(timer); pending = undefined; reject(cause); });
+    });
+    pending = { key, promise };
+    return promise;
+  };
+}

--- a/apps/desktop/src/integration_setup.test.ts
+++ b/apps/desktop/src/integration_setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { integrationTargetsVerified, parseIntegrationPlan, type IntegrationPlan } from "./integration_setup";
+import { integrationChangeLabel, integrationTargetsVerified, parseIntegrationPlan, type IntegrationPlan } from "./integration_setup";
 
 describe("Desktop installation review", () => {
   const plan = { schema: "simplicio.desktop-integration-plan/v1", source: "runtime", planDigest: `sha256:${"a".repeat(64)}`, changes: [{ label: "codex", changed: true, exists: true, path: "/private", diff: "secret" }] };
@@ -11,6 +11,19 @@ describe("Desktop installation review", () => {
   it("rejects an absent digest and arbitrary config labels", () => {
     expect(() => parseIntegrationPlan({ ...plan, planDigest: "" })).toThrow();
     expect(() => parseIntegrationPlan({ ...plan, changes: [{ label: "/private", changed: true, exists: true }] })).toThrow();
+  });
+  it("rejects duplicate target labels before a plan can be reviewed or applied", () => {
+    for (const duplicate of [plan.changes[0], { label: "codex", changed: false, exists: false }]) {
+      expect(() => parseIntegrationPlan({ ...plan, changes: [...plan.changes, duplicate] })).toThrow("integration_plan_ambiguous_targets");
+    }
+  });
+  it.each([
+    { exists: true, changed: true, expected: "Atualizar" },
+    { exists: false, changed: true, expected: "Criar" },
+    { exists: true, changed: false, expected: "Já configurado" },
+    { exists: false, changed: false, expected: "Configuração ausente" },
+  ])("labels exists=$exists changed=$changed without assuming configuration", ({ exists, changed, expected }) => {
+    expect(integrationChangeLabel({ label: "codex", exists, changed })).toBe(expected);
   });
 });
 

--- a/apps/desktop/src/integration_setup.ts
+++ b/apps/desktop/src/integration_setup.ts
@@ -5,6 +5,11 @@ export interface IntegrationPlan {
   changes: Array<{ label: string; changed: boolean; exists: boolean }>;
 }
 
+export function integrationChangeLabel(change: IntegrationPlan["changes"][number]): string {
+  if (change.changed) return change.exists ? "Atualizar" : "Criar";
+  return change.exists ? "Já configurado" : "Configuração ausente";
+}
+
 export function parseIntegrationPlan(value: unknown): IntegrationPlan {
   if (!value || typeof value !== "object") throw new Error("integration_plan_invalid");
   const plan = value as Record<string, unknown>;
@@ -18,6 +23,9 @@ export function parseIntegrationPlan(value: unknown): IntegrationPlan {
       || typeof row.changed !== "boolean" || typeof row.exists !== "boolean") throw new Error("integration_plan_invalid");
     return { label: row.label, changed: row.changed, exists: row.exists };
   });
+  if (new Set(changes.map((row) => row.label)).size !== changes.length) {
+    throw new Error("integration_plan_ambiguous_targets");
+  }
   return { schema: "simplicio.desktop-integration-plan/v1", source: plan.source as IntegrationPlan["source"], planDigest: plan.planDigest, changes };
 }
 

--- a/apps/desktop/src/runtime_timestamp.test.ts
+++ b/apps/desktop/src/runtime_timestamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatRuntimeTimestamp } from "./runtime_timestamp";
+
+describe("Runtime timestamp display", () => {
+  it("formats Unix seconds and ISO instants with the same known UTC date", () => {
+    expect(formatRuntimeTimestamp("unix:0", { timeZone: "UTC" })).toBe("01/01/1970, 00:00:00");
+    for (const timestamp of ["unix:1704067200", "2024-01-01T00:00:00Z", "2024-01-01T03:00:00+03:00", "2024-01-01T00:00:00.000000Z"]) {
+      expect(formatRuntimeTimestamp(timestamp, { timeZone: "UTC" })).toBe("01/01/2024, 00:00:00");
+    }
+  });
+
+  it("preserves date-only calendar dates without inventing or shifting their time", () => {
+    expect(formatRuntimeTimestamp("2024-02-29", { timeZone: "America/Sao_Paulo" })).toBe("29/02/2024");
+    expect(formatRuntimeTimestamp("2026-09-01", { timeZone: "Pacific/Honolulu" })).toBe("01/09/2026");
+  });
+
+  it.each([
+    undefined, null, true, 1704067200, {}, [], "", "0", "1704067200", "2024", "01/02/2024",
+    "unix:", "unix:-1", "unix:1.5", "unix:01", "unix:9007199254740991", "unix:8640000000001",
+    "unix:1704067200 ", "unix:1\n", "2024-01-01T00:00:00", "2024-02-30T00:00:00Z",
+    "2023-02-29", "1900-02-29", "2024-00-01", "2024-13-01", "2024-01-00",
+    "2024-01-01T24:00:00Z", "2024-01-01T00:60:00Z", "2024-01-01T00:00:60Z",
+    "2024-01-01T00:00:00+24:00", "2024-01-01T00:00:00+03:60", "2024-01-01T00:00:00Z\n",
+    "private-timestamp@example.test", "x".repeat(1000),
+  ])("keeps malformed or unsupported metadata unavailable (%j)", (value) => {
+    expect(formatRuntimeTimestamp(value, { timeZone: "UTC" })).toBe("Data não informada.");
+  });
+
+  it("uses a caller-owned fallback for absent expiry or unavailable date formatting", () => {
+    expect(formatRuntimeTimestamp(null, { fallback: "Validade não informada." })).toBe("Validade não informada.");
+    expect(formatRuntimeTimestamp("unix:0", { timeZone: "invalid-time-zone" })).toBe("Data não informada.");
+  });
+});

--- a/apps/desktop/src/runtime_timestamp.ts
+++ b/apps/desktop/src/runtime_timestamp.ts
@@ -1,0 +1,32 @@
+const UNAVAILABLE = "Data não informada.";
+const UNIX = /^unix:(0|[1-9]\d{0,12})$/;
+const ISO = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2})))?$/;
+
+/** Display supported Runtime timestamps only; malformed metadata is never echoed. */
+export function formatRuntimeTimestamp(value: unknown, options: { fallback?: string; timeZone?: string } = {}): string {
+  const unavailable = options.fallback ?? UNAVAILABLE;
+  if (typeof value !== "string" || value.length > 64) return unavailable;
+  const unix = UNIX.exec(value);
+  const iso = unix ? null : ISO.exec(value);
+  if (!unix && !iso) return unavailable;
+  if (iso) {
+    const year = Number(iso[1]);
+    const month = Number(iso[2]);
+    const day = Number(iso[3]);
+    const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+    const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    if (month < 1 || month > 12 || day < 1 || day > days[month - 1]
+      || Number(iso[4] ?? 0) > 23 || Number(iso[5] ?? 0) > 59 || Number(iso[6] ?? 0) > 59
+      || Number(iso[8] ?? 0) > 23 || Number(iso[9] ?? 0) > 59) return unavailable;
+  }
+  const milliseconds = unix ? Number(unix[1]) * 1000 : Date.parse(value);
+  if (!Number.isSafeInteger(milliseconds) || Math.abs(milliseconds) > 8_640_000_000_000_000) return unavailable;
+  const dateOnly = iso !== null && iso[4] === undefined;
+  try {
+    // A date-only expiry is a calendar date, not midnight in the user's timezone.
+    return new Intl.DateTimeFormat("pt-BR", dateOnly
+      ? { year: "numeric", month: "2-digit", day: "2-digit", timeZone: "UTC" }
+      : { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit", hourCycle: "h23", timeZone: options.timeZone }
+    ).format(new Date(milliseconds));
+  } catch { return unavailable; }
+}

--- a/apps/desktop/src/screens/BotCenterScreen.test.tsx
+++ b/apps/desktop/src/screens/BotCenterScreen.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createDemoBotCenter, type BotActionRequest } from "../bot_center";
+import { BotCenterScreen, dispatchAvailableBotAction } from "./BotCenterScreen";
+
+const request: BotActionRequest = { kind: "approve", botId: "test-bot", sessionId: "test-session", approvalId: "test-approval" };
+
+describe("Bot Center action availability", () => {
+  it("keeps readonly approval history visible while disabling both decisions", () => {
+    const snapshot = createDemoBotCenter();
+    snapshot.actionAuthority = "unavailable";
+    const onAction = vi.fn().mockResolvedValue(undefined);
+    const html = renderToStaticMarkup(<BotCenterScreen snapshot={snapshot} onAction={onAction} />);
+    expect(html).toContain("Contrato indisponível");
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Aprovar<\/button>/);
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Negar<\/button>/);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("never calls the action or changes busy state without action authority", async () => {
+    const onAction = vi.fn().mockResolvedValue(undefined);
+    const onBusy = vi.fn();
+    const pending = { current: false };
+    await dispatchAvailableBotAction({ request, authority: "unavailable", pending, onAction, onBusy });
+    expect(onAction).not.toHaveBeenCalled();
+    expect(onBusy).not.toHaveBeenCalled();
+    expect(pending.current).toBe(false);
+  });
+
+  it.each(["runtime", "preview"] as const)("dispatches once while a %s action is pending", async (authority) => {
+    let finish!: () => void;
+    const onAction = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const onBusy = vi.fn();
+    const pending = { current: false };
+    const first = dispatchAvailableBotAction({ request, authority, pending, onAction, onBusy });
+    expect(pending.current).toBe(true);
+    await dispatchAvailableBotAction({ request: { ...request, kind: "deny" }, authority, pending, onAction, onBusy });
+    expect(onAction).toHaveBeenCalledExactlyOnceWith(request);
+    expect(onBusy).toHaveBeenCalledExactlyOnceWith("approve");
+    finish();
+    await first;
+    expect(pending.current).toBe(false);
+    expect(onBusy.mock.calls).toEqual([["approve"], [null]]);
+  });
+
+  it("releases local busy state after rejection without hiding the failure or retrying", async () => {
+    const failure = new Error("test-only action failure");
+    const onAction = vi.fn().mockRejectedValue(failure);
+    const onBusy = vi.fn();
+    const pending = { current: false };
+    await expect(dispatchAvailableBotAction({ request, authority: "runtime", pending, onAction, onBusy })).rejects.toBe(failure);
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(pending.current).toBe(false);
+    expect(onBusy.mock.calls).toEqual([["approve"], [null]]);
+  });
+});

--- a/apps/desktop/src/screens/BotCenterScreen.tsx
+++ b/apps/desktop/src/screens/BotCenterScreen.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useMemo, useRef, useState } from "react";
 import type {
   BotActionKind,
   BotCenterSnapshot,
@@ -44,7 +44,26 @@ function statusClass(lifecycle: BotLifecycle): string {
   return lifecycle === "active" || lifecycle === "busy" ? "bot-status-live" : lifecycle === "blocked" ? "bot-status-blocked" : "bot-status-muted";
 }
 
-function TimelineEvent({ item, onAction }: { item: BotTimelineEvent; onAction: (request: BotActionRequest) => Promise<void> }) {
+/** Synchronous admission also covers repeated clicks before React renders busy state. */
+export async function dispatchAvailableBotAction({ request, authority, pending, onAction, onBusy }: {
+  request: BotActionRequest;
+  authority: BotCenterSnapshot["actionAuthority"];
+  pending: { current: boolean };
+  onAction: (request: BotActionRequest) => Promise<void>;
+  onBusy: (action: BotActionKind | null) => void;
+}): Promise<void> {
+  if ((authority !== "runtime" && authority !== "preview") || pending.current) return;
+  pending.current = true;
+  try {
+    onBusy(request.kind);
+    await onAction(request);
+  } finally {
+    pending.current = false;
+    onBusy(null);
+  }
+}
+
+function TimelineEvent({ item, onAction, disabled }: { item: BotTimelineEvent; onAction: (request: BotActionRequest) => Promise<void>; disabled: boolean }) {
   const approvalAction: BotActionKind | null = item.kind === "approval_request" && item.approvalId ? "approve" : null;
   return (
     <article className={`bot-event bot-event-${item.kind} ${item.state === "blocked" ? "is-blocked" : ""}`}>
@@ -62,8 +81,8 @@ function TimelineEvent({ item, onAction }: { item: BotTimelineEvent; onAction: (
         {item.reasonCode && <span className="bot-reason">reason: {item.reasonCode}</span>}
         {approvalAction && (
           <div className="bot-approval-actions">
-            <button className="button button-primary" type="button" onClick={() => onAction({ kind: "approve", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Aprovar</button>
-            <button className="button button-secondary" type="button" onClick={() => onAction({ kind: "deny", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Negar</button>
+            <button className="button button-primary" type="button" disabled={disabled} onClick={() => onAction({ kind: "approve", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Aprovar</button>
+            <button className="button button-secondary" type="button" disabled={disabled} onClick={() => onAction({ kind: "deny", botId: item.botId, sessionId: item.sessionId, approvalId: item.approvalId })}>Negar</button>
           </div>
         )}
       </div>
@@ -76,19 +95,15 @@ export function BotCenterScreen({ snapshot, onAction }: { snapshot: BotCenterSna
   const [message, setMessage] = useState("");
   const [steer, setSteer] = useState("");
   const [busyAction, setBusyAction] = useState<BotActionKind | null>(null);
+  const actionLock = useRef(false);
   const selectedBot = snapshot.bots.find((bot) => bot.botId === selectedBotId) ?? null;
   const session = selectedBotId ? sessionFor(snapshot, selectedBotId) : undefined;
   const room = snapshot.rooms.find((item) => item.sessionId === session?.sessionId) ?? snapshot.rooms[0];
   const recentEvents = useMemo(() => session?.events.slice(-30) ?? [], [session]);
-  const isUnavailable = snapshot.actionAuthority === "unavailable";
+  const isUnavailable = snapshot.actionAuthority !== "runtime" && snapshot.actionAuthority !== "preview";
 
   async function dispatch(request: BotActionRequest) {
-    setBusyAction(request.kind);
-    try {
-      await onAction(request);
-    } finally {
-      setBusyAction(null);
-    }
+    await dispatchAvailableBotAction({ request, authority: snapshot.actionAuthority, pending: actionLock, onAction, onBusy: setBusyAction });
   }
 
   async function submitTurn(event: FormEvent) {
@@ -170,7 +185,7 @@ export function BotCenterScreen({ snapshot, onAction }: { snapshot: BotCenterSna
               <div className="bot-chip-row"><span>toolset: {selectedBot.toolset.join(" · ") || "—"}</span><span>skills: {selectedBot.skills.join(" · ") || "—"}</span></div>
 
               <div className="bot-timeline" aria-live="polite">
-                {recentEvents.length === 0 ? <p className="empty-state">Sem transcript disponível para este Bot.</p> : recentEvents.map((item) => <TimelineEvent key={item.eventId} item={item} onAction={dispatch} />)}
+                {recentEvents.length === 0 ? <p className="empty-state">Sem transcript disponível para este Bot.</p> : recentEvents.map((item) => <TimelineEvent key={item.eventId} item={item} onAction={dispatch} disabled={actionDisabled} />)}
               </div>
 
               <div className="bot-composer-wrap">

--- a/apps/desktop/src/screens/SettingsScreen.timestamp.test.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.timestamp.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createDemoSnapshot } from "../demo";
+import { SettingsScreen } from "./SettingsScreen";
+
+describe("diagnostic snapshot timestamp", () => {
+  it("renders the legacy Runtime unix timestamp instead of Invalid Date", () => {
+    const snapshot = createDemoSnapshot("active");
+    snapshot.generatedAt = "unix:1704110400";
+    const html = renderToStaticMarkup(<SettingsScreen snapshot={snapshot} section="diagnostics"
+      busy={false} logoutBusy={false} onRefresh={() => {}} onSubscribe={() => {}} onLogout={() => {}} />);
+    expect(html).toContain("Leitura do snapshot");
+    expect(html).toContain("2024");
+    expect(html).not.toContain("Invalid Date");
+    expect(html).not.toContain("unix:1704110400");
+  });
+});

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -3,6 +3,7 @@ import type { DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { exportDesktopSnapshot } from "../bridge";
 import { runtimeSummary } from "../workbench";
+import { formatRuntimeTimestamp } from "../runtime_timestamp";
 
 export function redactedDiagnostic(snapshot: DesktopSnapshot) {
   return {
@@ -46,14 +47,14 @@ export function SettingsScreen({ snapshot, busy, onRefresh, onSubscribe, onLogou
     {section !== "diagnostics" && <section className="settings-section"><h2>Minha conta</h2><div className="settings-slab">
       <div className="account-summary"><span className="account-avatar">{snapshot.access.displayName?.slice(0, 1).toUpperCase() ?? "S"}</span><div><h3>{snapshot.access.displayName ?? "Conta conectada"}</h3><p>{snapshot.access.email ?? "Identidade protegida pelo Runtime"}</p></div><span className="neutral-badge">{snapshot.access.plan ?? "Plano não informado"}</span></div>
       <div className="preference-row"><div><strong>Acesso ao produto</strong><p>Identidade e assinatura são verificações independentes.</p></div><span className={snapshot.access.state === "active" ? "access-confirmed" : "neutral-badge"}><Glyph name="shield" size={15} />{snapshot.access.state === "active" ? "Assinatura ativa" : "Acesso não confirmado"}</span></div>
-      <div className="preference-row"><div><strong>Validade informada</strong><p>{snapshot.access.expiresAt ? new Date(snapshot.access.expiresAt).toLocaleString("pt-BR") : "O Runtime não informou uma data de expiração."}</p></div><button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}>{busy ? "Atualizando…" : "Atualizar estado"}</button></div>
+      <div className="preference-row"><div><strong>Validade informada</strong><p>{formatRuntimeTimestamp(snapshot.access.expiresAt, { fallback: "O Runtime não informou uma data de expiração válida." })}</p></div><button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}>{busy ? "Atualizando…" : "Atualizar estado"}</button></div>
       <div className="preference-row"><div><strong>Gerenciar assinatura</strong><p>Abre sua conta no site do Simplicio.</p></div><button className="button button-secondary" type="button" onClick={onSubscribe} disabled={busy}>Gerenciar plano<Glyph name="external" size={15} /></button></div>
       <div className="preference-row"><div><strong>Sair deste computador</strong><p>O Runtime revoga a sessão e remove as credenciais locais.</p></div><button className="button button-secondary" type="button" onClick={onLogout} disabled={busy || logoutBusy}>{logoutBusy ? "Saindo…" : "Sair da conta"}</button></div>
     </div></section>}
     {section !== "account" && <>
       <section className="settings-section"><h2>Runtime local</h2><div className="settings-slab">
         <div className="preference-row"><div><strong>{runtime.label}</strong><p>Versão {snapshot.runtime.version || "não informada"} · transporte {snapshot.runtime.transport}</p></div><button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Atualizar estado"}</button></div>
-        <div className="preference-row"><div><strong>Leitura do snapshot</strong><p>{new Date(snapshot.generatedAt).toLocaleString("pt-BR")}</p></div><span className="neutral-badge">{snapshot.source === "runtime" ? "Runtime" : "Demonstração"}</span></div>
+        <div className="preference-row"><div><strong>Leitura do snapshot</strong><p>{formatRuntimeTimestamp(snapshot.generatedAt)}</p></div><span className="neutral-badge">{snapshot.source === "runtime" ? "Runtime" : "Demonstração"}</span></div>
         <div className="preference-row"><div><strong>Conexões MCP</strong><p>Um registro não comprova uma sessão ativa.</p></div><span>{runtime.connected} confirmadas</span></div>
       </div></section>
       <section className="settings-section"><h2>Exportar diagnóstico</h2><div className="settings-slab"><div className="preference-row"><div><strong>Relatório sem dados sensíveis</strong><p>Omite email, caminhos pessoais, prompts, configurações, credenciais, skills e ledger bruto. Salvo em Downloads sem substituir arquivos.</p></div><button className="button button-secondary" type="button" onClick={() => void download()} disabled={exporting}>{exporting ? "Exportando…" : "Exportar diagnóstico"}</button></div></div>

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -2,10 +2,15 @@ import { useEffect, useRef, useState } from "react";
 import { Glyph } from "../components/Brand";
 import { ContextSavings } from "../components/ContextSavings";
 import { TokenProjects } from "../components/TokenProjects";
+import { ConsolidatedTokens } from "../components/ConsolidatedTokens";
+import type { UsageProjects } from "../project_usage";
 import { exportDesktopTokenReport, loadDesktopTokenReport } from "../bridge";
 import { TOKEN_PERIODS, tokenErrorMessage, tokenExportErrorMessage, type TokenPeriod, type TokenQuery, type TokenUsageReport } from "../token_usage";
 
-export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: string }) {
+export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { initialRepoPath?: string; projectPaths?: string[] }) {
+  const [discovery, setDiscovery] = useState<UsageProjects | null>(null);
+  const [discoveryReady, setDiscoveryReady] = useState(false);
+  const [extraPaths, setExtraPaths] = useState<string[]>(initialRepoPath ? [initialRepoPath] : []);
   const [period, setPeriod] = useState<TokenPeriod>("1m");
   const [repoPath, setRepoPath] = useState(initialRepoPath);
   const [allowAutoSelect, setAllowAutoSelect] = useState(!initialRepoPath);
@@ -55,6 +60,7 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
 
   function submit(path = repoPath) {
     if (exportLock.current) return;
+    if (path.trim()) setExtraPaths(paths => paths.includes(path.trim()) ? paths : [...paths.slice(-95), path.trim()]);
     const query: TokenQuery = { timezoneOffsetSeconds: -new Date().getTimezoneOffset() * 60 };
     if (path.trim()) query.repoPath = path.trim();
     if (sessionId.trim()) query.sessionId = sessionId.trim();
@@ -98,7 +104,10 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
       <section className="page-heading">
         <div><span className="eyebrow">Recibos do Runtime</span><h1>Relatório de tokens</h1><p>Uso registrado por período e sessão. Economia de contexto não é consumo faturado.</p></div>
       </section>
-      <TokenProjects repoPath={repoPath} allowAutoSelect={allowAutoSelect} onSelect={(path) => {
+      <ConsolidatedTokens paths={[...projectPaths, ...extraPaths, ...(discovery?.projects.map(project => project.path) ?? [])]} discoveryReady={discoveryReady} discoveryPartial={!discovery || discovery.partial} />
+      <section className="individual-token-report" aria-label="Relatório individual">
+      <h2>Detalhes por projeto</h2>
+      <TokenProjects repoPath={repoPath} allowAutoSelect={allowAutoSelect} onDiscovery={result => { setDiscovery(result); setDiscoveryReady(true); }} onSelect={(path) => {
         if (exportLock.current) return;
         setAllowAutoSelect(false); setAutoContext(true); invalidate(); setRepoPath(path); submit(path);
       }} />
@@ -131,6 +140,7 @@ export function TokensScreen({ initialRepoPath = "" }: { initialRepoPath?: strin
         </section>
       </>}
       <ContextSavings repoPath={repoPath} autoLoad={autoContext} />
+      </section>
     </div>
   );
 }

--- a/apps/desktop/src/settings_navigation.test.ts
+++ b/apps/desktop/src/settings_navigation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { rememberWorkspaceRoute, viewNavigationEntry } from "./settings_navigation";
+import { moveHistory, navigate, type NavigationEntry, type NavigationState } from "./workbench";
+
+const home: NavigationEntry = { view: "home", projectId: null, tokenRepo: "" };
+const projectReport: NavigationEntry = { view: "tokens", projectId: "project-a", tokenRepo: "/Projects/Project A" };
+
+describe("settings workspace return", () => {
+  it("restores the report view, project and repository after multiple settings pages", () => {
+    let history: NavigationState = { entries: [projectReport], index: 0 };
+    let workspace = rememberWorkspaceRoute(home, projectReport);
+    for (const next of ["settings", "general", "diagnostics", "permissions"] as const) {
+      history = navigate(history, viewNavigationEntry(history.entries[history.index], next));
+      workspace = rememberWorkspaceRoute(workspace, history.entries[history.index]);
+      expect(history.entries[history.index].tokenRepo).toBe("/Projects/Project A");
+    }
+    history = navigate(history, viewNavigationEntry(history.entries[history.index], workspace.view, workspace));
+    expect(history.entries[history.index]).toEqual({ view: "tokens", projectId: "project-a", tokenRepo: "/Projects/Project A" });
+    expect(history.entries[moveHistory(history, -1).index].view).toBe("permissions");
+    expect(history.entries[moveHistory(moveHistory(history, -1), 1).index]).toEqual(projectReport);
+  });
+
+  it("updates the return scope when the repository changes without changing view", () => {
+    const first = rememberWorkspaceRoute(home, projectReport);
+    const second = rememberWorkspaceRoute(first, { view: "tokens", projectId: "project-b", tokenRepo: "/Projects/Project B" });
+    const settings = viewNavigationEntry(second, "settings");
+    const workspace = rememberWorkspaceRoute(second, settings);
+    expect(viewNavigationEntry(settings, workspace.view, workspace)).toEqual({ view: "tokens", projectId: "project-b", tokenRepo: "/Projects/Project B" });
+    expect(first).toEqual(projectReport);
+  });
+
+  it("keeps an explicit global report click distinct from returning to the project report", () => {
+    const settings = viewNavigationEntry(projectReport, "settings");
+    expect(viewNavigationEntry(settings, "tokens")).toEqual({ view: "tokens", projectId: "project-a", tokenRepo: "" });
+    expect(viewNavigationEntry(settings, "tokens", projectReport)).toEqual(projectReport);
+    expect(viewNavigationEntry(settings, "home")).toEqual({ view: "home", projectId: "project-a", tokenRepo: "" });
+  });
+
+  it("returns to a project workspace and preserves an explicitly unselected global route", () => {
+    const project: NavigationEntry = { view: "project", projectId: "project-a", tokenRepo: "" };
+    expect(viewNavigationEntry(viewNavigationEntry(project, "settings"), "project", project)).toEqual(project);
+    expect(viewNavigationEntry(viewNavigationEntry(project, "settings"), "home", home)).toEqual(home);
+  });
+
+  it("captures route values without mutating or retaining the caller's mutable route", () => {
+    const current = { ...projectReport };
+    const workspace = rememberWorkspaceRoute(home, current);
+    current.tokenRepo = "/Projects/other";
+    expect(workspace.tokenRepo).toBe("/Projects/Project A");
+    const restored = viewNavigationEntry(viewNavigationEntry(current, "settings"), "tokens", workspace);
+    restored.tokenRepo = "";
+    expect(workspace.tokenRepo).toBe("/Projects/Project A");
+  });
+
+  it("keeps the return target even when settings visits exhaust bounded history", () => {
+    let history: NavigationState = { entries: [projectReport], index: 0 };
+    let workspace = rememberWorkspaceRoute(home, projectReport);
+    for (let index = 0; index < 60; index += 1) {
+      history = navigate(history, viewNavigationEntry(history.entries[history.index], index % 2 ? "diagnostics" : "settings"));
+      workspace = rememberWorkspaceRoute(workspace, history.entries[history.index]);
+    }
+    expect(history.entries).toHaveLength(50);
+    expect(viewNavigationEntry(history.entries[history.index], workspace.view, workspace)).toEqual(projectReport);
+  });
+});

--- a/apps/desktop/src/settings_navigation.ts
+++ b/apps/desktop/src/settings_navigation.ts
@@ -1,0 +1,16 @@
+import { isSettingsView, type NavigationEntry, type View } from "./workbench";
+
+/** Keep the full workspace route while visiting any number of settings pages. */
+export function rememberWorkspaceRoute(previous: NavigationEntry, current: NavigationEntry): NavigationEntry {
+  return isSettingsView(current.view) ? previous : { ...current };
+}
+
+/** Explicit workspace return restores scope; ordinary report navigation remains global. */
+export function viewNavigationEntry(current: NavigationEntry, next: View, restore?: NavigationEntry): NavigationEntry {
+  if (restore && restore.view === next && !isSettingsView(next)) return { ...restore };
+  return {
+    view: next,
+    projectId: current.projectId,
+    tokenRepo: isSettingsView(next) ? current.tokenRepo : "",
+  };
+}

--- a/docs/desktop/TOKEN-REPORTS.md
+++ b/docs/desktop/TOKEN-REPORTS.md
@@ -40,3 +40,46 @@ The separate `insights.tokens/v1` summary preserves savings/cache evidence
 labels. Only `measured` savings with a valid ledger reference may populate its
 saved-token counter; `mixed`, `estimated`, `replayed` and missing receipts do
 not become measured usage. Neither surface calculates provider cache hits.
+
+## All-project consolidated report
+
+The top section consolidates discovered projects, saved project shortcuts and
+manually selected projects (up to 96 distinct absolute paths). It reuses the
+project discovery already performed for the individual report. Discovery is
+bounded, not a claim to have searched every folder on the computer; partial
+discovery and excluded paths remain explicit.
+
+The five filters are **7 days, 30 days, 3 months, 6 months and 12 months**.
+Days are rolling 24-hour intervals. Months use the local calendar and clamp
+month-end dates, including leap years. Start and exclusive end are fixed once
+before the batch, with one timezone offset and no session filter. In particular,
+30 days is not the Runtime's calendar `1m` window. Every Runtime query uses the
+same explicit custom interval and its echoed bounds are checked.
+
+`desktop_consolidated_token_report` returns
+`simplicio.desktop-consolidated-tokens/v1`. Each requested path has a status:
+`ready`, `missing`, `invalid`, `timeout`, `skipped` or `duplicate`. Native code
+adds only validated `ready` aggregates using checked JavaScript-safe integers;
+the WebView independently validates that sum and the exact requested scope.
+Unknown usage stays unknown, not zero. Canonical ledger paths (and device/inode
+identity on Unix) exclude aliases of the same database. Copies in independent
+databases cannot be event-deduplicated by this aggregate-only contract.
+
+The report has accessible project bars, an input/output/reasoning composition
+chart and a table containing every project/status. Bars show the eight largest
+projects plus a sum of the remainder; totals always include all valid reports.
+Cached input is a subset of input and is not added twice. No daily time series,
+model split, financial cost or measured savings is fabricated. Individual JSON
+and CSV exports below still refer only to the selected project's report, not
+the consolidated view.
+
+Filesystem preflight runs in a bounded pre-Tauri worker, without starting a
+Runtime grandchild. The parent starts fixed Runtime argv directly. A single
+native batch has a 90-second budget, each filesystem preflight at most 2 seconds,
+and each Runtime query at most 5 seconds, plus bounded process cleanup. Fresh
+read authorization is performed once. Completed project results survive the
+deadline, while remaining projects are explicitly skipped. The frontend's
+observer timeout does not release the native read slot or trigger a retry.
+
+The separate context-savings panel is the selected project's **all-history**
+report. Its values are not mixed into this time-filtered usage consolidation.


### PR DESCRIPTION
## Entrega

- Relatório consolidado dos projetos descobertos, adicionados e selecionados: 7 dias, 30 dias, 3, 6 e 12 meses.
- Gráficos acessíveis de uso por projeto e composição; tabela completa de cobertura. Cache não é contado duas vezes; falta de telemetria não vira zero.
- IPC nativo somente leitura, intervalo comum validado, deduplicação por identidade de ledger, soma segura e prazos de processo/lote. Worker de filesystem antes do Tauri, sem Runtime neto.
- Corrige retorno das configurações preservando o projeto, datas Unix/ISO, decisões indisponíveis/concorrentes no Bot Center e planos de integração ambíguos.
- Preserva os 22 destinos ocultados anteriormente e o visual branco.

## Verificação manual (sem GitHub Actions)

- 347 testes unitários TypeScript; build TypeScript/Vite.
- 100 testes Playwright, incluindo telas existentes, filtros, cobertura parcial, erros, ausência de uso e gráficos responsivos.
- 119 testes Rust; mais 2 smokes explicitamente executados com Runtime verificado e Desktop recém-compilado.
- Smoke real: dois ledgers, alias deduplicado, evento fora do intervalo excluído; total esperado 1.074 confirmado.
- App macOS local compilado offline/locked, cópia isolada assinada ad hoc e verificada. Hash do Runtime embarcado preservado.
- Janela nativa abriu com a sessão existente, descobriu projetos e mostrou gráficos corretos de um ledger sintético isolado (137 tokens).

## Limites explícitos

Descoberta limitada, não varredura completa da máquina. Ledgers ausentes/inválidos/sem resposta ficam identificados. Eventos copiados entre bancos independentes não são deduplicados. Preflight não é um lease atômico do arquivo. Economia de contexto histórica não é misturada ao uso por período; nenhum custo ou série diária é inventado.

Esta entrega altera código e app de validação local: não publica release, instaladores Windows/Linux ou PyPI, nem substitui a instalação principal. Novos logins OAuth e handshakes de todos os clientes externos não foram exercitados. O Runtime privado e a frente de autenticação de outra tarefa não foram alterados.
