### PR TITLE
fix(desktop): hide requested home and settings navigation [skip ci]

### DIFF
--- a/apps/desktop/e2e/hidden-settings.spec.ts
+++ b/apps/desktop/e2e/hidden-settings.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 const hidden = [
+  "Agentes e IDEs", "Modelos e skills", "Artefatos", "Automações",
   "Orquestração", "Uso do computador", "Voz", "Integrações de serviços", "Simplicio Mobile",
   "Memória", "Compartilhar skills", "Git e código-fonte", "Fontes de tarefas", "Terminal", "Navegador",
   "Emulador mobile", "Janela flutuante", "Atalhos", "Entrada e edição", "Notificações",
@@ -13,7 +14,7 @@ test("requested settings are absent from categories and both search surfaces", a
   const categories = sidebar.getByRole("navigation");
   for (const label of hidden) await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
   for (const group of ["HOSTS REMOTOS", "EXPERIMENTAL"]) await expect(categories.getByText(group, { exact: true })).toHaveCount(0);
-  for (const label of ["Contas de IA", "Geral", "Artefatos", "Comandos rápidos", "Aparência", "Permissões do sistema", "Runtime e diagnóstico", "Integrações MCP", "Relatório de tokens"])
+  for (const label of ["Contas de IA", "Geral", "Comandos rápidos", "Aparência", "Permissões do sistema", "Runtime e diagnóstico", "Integrações MCP", "Relatório de tokens"])
     await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(1);
   await expect(sidebar.getByRole("button", { name: "Ver atalhos", exact: true })).toHaveCount(0);
   await page.screenshot({ path: testInfo.outputPath("visible-settings.png") });
@@ -22,6 +23,12 @@ test("requested settings are absent from categories and both search surfaces", a
     await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
   }
   await page.goto("/");
+  for (const label of ["Agentes e IDEs", "Automações"]) {
+    await expect(sidebar.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+    await expect(page.getByRole("main").getByRole("button", { name: new RegExp(label) })).toHaveCount(0);
+  }
+  await expect(page.getByRole("main").getByRole("button", { name: /Tokens e economia/ })).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("visible-home.png") });
   await expect(page.getByRole("button", { name: "Todos os atalhos", exact: true })).toHaveCount(0);
   for (const label of hidden) {
     await sidebar.getByRole("searchbox").fill(label);
@@ -30,7 +37,7 @@ test("requested settings are absent from categories and both search surfaces", a
 });
 
 test("visible reference pages do not expose links back to hidden destinations", async ({ page }) => {
-  for (const view of ["provider-accounts", "general-settings", "artifacts", "quick-commands", "permissions"]) {
+  for (const view of ["provider-accounts", "general-settings", "quick-commands", "permissions"]) {
     await page.goto("/?view=" + view);
     await expect(page.locator(".reference-settings-page")).toBeVisible();
     await expect(page.getByRole("main").getByRole("button", { name: /Ver atalhos|Abrir atalhos|Abrir navegador|Abrir terminal|Configurar voz/ })).toHaveCount(0);

--- a/apps/desktop/e2e/reference-navigation.spec.ts
+++ b/apps/desktop/e2e/reference-navigation.spec.ts
@@ -5,6 +5,7 @@ import { isNavigationVisible } from "../src/workbench";
 const visibleScreens = REFERENCE_SCREENS.filter((screen) => isNavigationVisible(screen.id));
 
 test("every supplied-reference settings destination is searchable and reachable without losing navigation", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
   await page.goto("/?view=settings");
   const sidebar = page.getByRole("complementary", { name: "Configurações", exact: true });
   const categories = sidebar.getByRole("navigation", { name: "Categorias de configurações", exact: true });
@@ -51,8 +52,9 @@ test("reference navigation is discoverable by description and usable in a narrow
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
 });
 
-test("the main sidebar exposes the existing automation surface", async ({ page }) => {
+test("the main sidebar hides automations while retaining its direct preview", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("navigation", { name: "Navegação principal", exact: true }).getByRole("button", { name: "Automações", exact: true }).click();
+  await expect(page.getByRole("navigation", { name: "Navegação principal", exact: true }).getByRole("button", { name: "Automações", exact: true })).toHaveCount(0);
+  await page.goto("/?view=automations");
   await expect(page.getByRole("heading", { name: "Automações", exact: true, level: 1 })).toBeVisible();
 });

--- a/apps/desktop/e2e/runtime-integration.spec.ts
+++ b/apps/desktop/e2e/runtime-integration.spec.ts
@@ -139,7 +139,12 @@ test("active login opens guided setup and duplicate account effects stay seriali
   await expect(page.getByRole("heading", { name: "Simplicio", exact: true })).toBeVisible();
   expect(await calls(page, "desktop_login")).toHaveLength(1);
   await page.getByRole("button", { name: "Configurações", exact: true }).click();
-  await page.getByRole("button", { name: "Modelos e skills", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Modelos e skills", exact: true })).toHaveCount(0);
+});
+
+test("hidden model inventory remains available as a direct preview (mocked IPC)", async ({ page }) => {
+  await mockNativeBridge(page);
+  await page.goto("/?view=models");
   await expect(page.getByText(/Nenhum modelo foi informado/)).toBeVisible();
 });
 

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -47,7 +47,7 @@ describe("Simplicio Desktop product states", () => {
       <DesktopApp snapshot={createDemoSnapshot("active")} />,
     );
     expect(html).toContain("Runtime online");
-    expect(html).toContain("Agentes e IDEs");
+    expect(html).toContain("Integrações MCP");
     expect(html).toContain("Demonstração");
   });
 
@@ -57,7 +57,8 @@ describe("Simplicio Desktop product states", () => {
     );
     expect(html).toContain("Início");
     expect(html).toContain("Adicionar projeto");
-    expect(html).toContain("Agentes e IDEs");
+    expect(html).not.toContain("Agentes e IDEs");
+    expect(html).not.toContain("Automações");
     expect(html).toContain("Atividade");
     expect(html).toContain("Configurações");
     expect(html).toContain("v3.8.39");

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -8,11 +8,11 @@ import { rememberWorkspaceRoute } from "../settings_navigation";
 export type { View } from "../workbench";
 
 interface Destination { id: View; icon: GlyphName; group?: string; description?: string }
-const navigation: Destination[] = [
+const navigation: Destination[] = ([
   { id: "home", icon: "home" }, { id: "activity", icon: "activity" },
   { id: "automations", icon: "automation" },
   { id: "agents", icon: "teams" }, { id: "providers", icon: "providers" }, { id: "tokens", icon: "spark" },
-];
+] satisfies Destination[]).filter((item) => isNavigationVisible(item.id));
 const referenceIcons: Record<ReferenceSettingsView, GlyphName> = {
   "provider-accounts": "providers", orchestration: "teams", "computer-use": "monitor", voice: "live",
   integrations: "providers", mobile: "monitor", "general-settings": "settings", artifacts: "folder",

--- a/apps/desktop/src/navigation_visibility.test.ts
+++ b/apps/desktop/src/navigation_visibility.test.ts
@@ -4,6 +4,7 @@ import { isNavigationVisible, isView, VIEW_LABELS, type View } from "./workbench
 describe("requested navigation visibility", () => {
   it("hides exactly the requested destinations without deleting routes", () => {
     const hidden: View[] = [
+      "agents", "models", "artifacts", "automations",
       "orchestration", "computer-use", "voice", "integrations", "mobile", "memory",
       "share-skills", "git", "task-sources", "terminal", "browser", "emulator", "floating",
       "shortcuts", "input", "notifications", "hosts", "servers", "privacy", "advanced", "experimental", "plugins",

--- a/apps/desktop/src/screens/WorkbenchHome.tsx
+++ b/apps/desktop/src/screens/WorkbenchHome.tsx
@@ -41,7 +41,7 @@ export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, o
       <div className="welcome-shortcuts"><span><kbd>⌘ / Ctrl K</kbd> Buscar</span>{isNavigationVisible("shortcuts") && <button type="button" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={14} />Todos os atalhos</button>}</div>
     </div>
     <section className="welcome-resources" aria-label="Acesso rápido">
-      <button type="button" onClick={() => onViewChange("agents")}><Glyph name="teams" size={20} /><span><strong>Agentes e IDEs</strong><small>{status.installed} detectados · {status.connected} MCP confirmados</small></span><Glyph name="arrow" size={16} /></button>
+      {isNavigationVisible("agents") && <button type="button" onClick={() => onViewChange("agents")}><Glyph name="teams" size={20} /><span><strong>Agentes e IDEs</strong><small>{status.installed} detectados · {status.connected} MCP confirmados</small></span><Glyph name="arrow" size={16} /></button>}
       <button type="button" onClick={() => onTokens()}><Glyph name="activity" size={20} /><span><strong>Tokens e economia</strong><small>Consulte uso, períodos e recibos</small></span><Glyph name="arrow" size={16} /></button>
       <button type="button" onClick={() => onViewChange("diagnostics")}><Glyph name="shield" size={20} /><span><strong>Runtime e diagnóstico</strong><small>{status.label} · v{snapshot.runtime.version || "—"}</small></span><Glyph name="arrow" size={16} /></button>
     </section>

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -7,6 +7,7 @@ export type View = ReferenceSettingsView | "home" | "project" | "agents" | "mode
 
 /** Presentation policy only: retain implementations and direct preview routes. */
 const HIDDEN_NAVIGATION_VIEWS: ReadonlySet<View> = new Set<View>([
+  "agents", "models", "artifacts", "automations",
   "orchestration", "computer-use", "voice", "integrations", "mobile",
   "memory", "share-skills", "git", "task-sources", "terminal", "browser", "emulator", "floating",
   "shortcuts", "input", "notifications", "hosts", "servers", "privacy", "advanced", "experimental", "plugins",


### PR DESCRIPTION
## Summary

- Hide Agentes e IDEs and Modelos e skills in settings capabilities; hide Artefatos in flows.
- Hide Automações and Agentes e IDEs in the main navigation, home quick access, and search results.
- Reuse the central presentation policy; retain underlying implementations and direct preview routes. MCP integrations, token reports, and diagnostics remain visible.

## Local validation

- 347 Vitest tests passed.
- 101 Playwright tests passed, including visibility/search, remaining navigation, and direct previews.
- TypeScript/Vite production build and git diff --check passed.
- Inspected home/settings screenshots with preview data.
- No GitHub Actions, release publication, installer regeneration, or installed application replacement.
