### PR TITLE
fix(desktop): finish guarded login and installation recovery [skip ci]

### DIFF
--- a/apps/desktop/e2e/access-update-recovery.spec.ts
+++ b/apps/desktop/e2e/access-update-recovery.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+import { DESKTOP_RELEASES_API, DESKTOP_RELEASES_URL, DESKTOP_UPDATE_EVENT } from "../src/desktop_updates";
+
+type AccessUpdateWindow = Window & {
+  __accessUpdateCalls: string[];
+  __accessUpdateMenu: () => void;
+  __accessUpdateListeners: () => number;
+};
+
+async function mockAccessUpdates(page: Page, state: "signed_out" | "unknown" | "active", authOnlyUnsupported = false) {
+  const snapshots = {
+    signed_out: createDemoSnapshot("signed_out"),
+    unknown: createDemoSnapshot("unknown"),
+    active: createDemoSnapshot("active"),
+  };
+  for (const snapshot of Object.values(snapshots)) snapshot.source = "runtime";
+  await page.addInitScript(({ snapshots, state, eventName, authOnlyUnsupported }) => {
+    let sequence = 0;
+    const callbacks = new Map<number, (event: unknown) => void>();
+    const listeners = new Map<number, { event: string; handler: number }>();
+    const calls: string[] = [];
+    Object.assign(window, {
+      isTauri: true,
+      __accessUpdateCalls: calls,
+      __accessUpdateListeners: () => [...listeners.values()].filter((entry) => entry.event === eventName).length,
+      __accessUpdateMenu: () => {
+        for (const [id, entry] of listeners) {
+          if (entry.event === eventName) callbacks.get(entry.handler)?.({ event: eventName, id, payload: null });
+        }
+      },
+      __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: (_event: string, id: number) => listeners.delete(id) },
+      __TAURI_INTERNALS__: {
+        transformCallback: (callback: (event: unknown) => void) => { const id = ++sequence; callbacks.set(id, callback); return id; },
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          calls.push(command);
+          if (command === "plugin:event|listen") {
+            const id = ++sequence;
+            listeners.set(id, { event: String(args.event), handler: Number(args.handler) });
+            return id;
+          }
+          if (command === "plugin:event|unlisten") return;
+          if (command === "desktop_snapshot") return snapshots[state];
+          if (command === "refresh_desktop_snapshot") return authOnlyUnsupported ? snapshots.unknown : snapshots[state];
+          if (command === "desktop_login" && authOnlyUnsupported) throw "runtime_auth_only_unsupported";
+          if (command === "desktop_logout" && authOnlyUnsupported) return snapshots.signed_out;
+          if (command === "plugin:app|version") return "3.8.39";
+          if (command === "desktop_update_target") return { platform: "macos", arch: "arm64" };
+          throw new Error(`Unexpected access update recovery IPC: ${command}`);
+        },
+      },
+    });
+  }, { snapshots, state, eventName: DESKTOP_UPDATE_EVENT, authOnlyUnsupported });
+  const name = "Simplicio-3.8.40-arm64.dmg";
+  await page.route((url) => url.href === DESKTOP_RELEASES_API, (route) => route.fulfill({
+    status: 200,
+    headers: { "content-type": "application/json", "access-control-allow-origin": "*" },
+    body: JSON.stringify([{
+      tag_name: "v3.8.40", draft: false, prerelease: false,
+      html_url: `${DESKTOP_RELEASES_URL}/tag/v3.8.40`,
+      assets: [{ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` }],
+    }]),
+  }));
+}
+
+async function showAndCloseUpdates(page: Page) {
+  await expect.poll(() => page.evaluate(() => (window as AccessUpdateWindow).__accessUpdateListeners())).toBe(1);
+  await page.evaluate(() => (window as AccessUpdateWindow).__accessUpdateMenu());
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toHaveAttribute("data-update-state", "available");
+  await expect(dialog).toContainText("Versão deste aplicativo: 3.8.39");
+  await expect(dialog).toContainText("Download e instalação manuais");
+  await expect(page.getByRole("button", { name: "Ver releases oficiais", exact: true })).toBeEnabled();
+  await page.getByRole("button", { name: "Fechar atualizações", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function accountAndInstallCalls(page: Page) {
+  const calls = await page.evaluate(() => (window as AccessUpdateWindow).__accessUpdateCalls);
+  return calls.filter((command) => [
+    "desktop_login", "desktop_logout", "desktop_open_subscription",
+    "desktop_plan_integrations", "desktop_repair_providers", "desktop_open_releases",
+  ].includes(command));
+}
+
+test("signed-out welcome and Google entry retain manual updates without account or installation effects (mocked IPC/metadata)", async ({ page }) => {
+  await mockAccessUpdates(page, "signed_out");
+  await page.goto("/");
+  const start = page.getByRole("button", { name: "Começar", exact: true });
+  await expect(start).toBeVisible();
+  await showAndCloseUpdates(page);
+  await expect(start).toBeFocused();
+  await start.click();
+  const google = page.getByRole("button", { name: "Continuar com Google", exact: true });
+  await expect(google).toBeFocused();
+  await showAndCloseUpdates(page);
+  await expect(google).toBeFocused();
+  expect(await accountAndInstallCalls(page)).toEqual([]);
+});
+
+test("unknown access retains manual updates and explicit account recovery (mocked IPC/metadata)", async ({ page }) => {
+  await mockAccessUpdates(page, "unknown");
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+  await showAndCloseUpdates(page);
+  for (const name of ["Tentar novamente", "Entrar ou reconectar", "Abrir diagnóstico", "Sair da conta"]) {
+    await expect(page.getByRole("button", { name, exact: true })).toBeEnabled();
+  }
+  expect(await accountAndInstallCalls(page)).toEqual([]);
+});
+
+test("guided setup retains manual updates and an exit without applying a plan (mocked IPC/metadata)", async ({ page }) => {
+  await mockAccessUpdates(page, "active");
+  await page.goto("/?view=setup");
+  await expect(page.getByRole("heading", { name: "Um bom começo.", exact: true })).toBeVisible();
+  await showAndCloseUpdates(page);
+  await expect(page.getByRole("button", { name: "Configurar Simplicio", exact: true })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Agora não", exact: true })).toBeEnabled();
+  expect(await accountAndInstallCalls(page)).toEqual([]);
+});
+
+test("unsupported authentication-only Runtime explains the update path and permits verification and sign-out without retrying OAuth (mocked IPC/metadata)", async ({ page }) => {
+  await mockAccessUpdates(page, "signed_out", true);
+  await page.goto("/");
+  await page.getByRole("button", { name: "Começar", exact: true }).click();
+  await page.getByRole("button", { name: "Continuar com Google", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("O Runtime não oferece login separado da instalação.");
+  await expect(page.getByRole("alert")).toContainText("Atualize o Simplicio Desktop para entrar com Google com segurança.");
+  await expect(page.getByRole("alert")).not.toContainText("runtime_auth_only_unsupported");
+  await expect(page.getByRole("navigation", { name: "Navegação principal" })).toHaveCount(0);
+  await showAndCloseUpdates(page);
+  expect(await accountAndInstallCalls(page)).toEqual(["desktop_login"]);
+  await page.getByRole("button", { name: "Abrir diagnóstico", exact: true }).click();
+  await expect(page.getByText("Estado de acesso desconhecido", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Tentar novamente", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Tente novamente", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Entrar ou reconectar", exact: true })).toBeEnabled();
+  expect(await accountAndInstallCalls(page)).toEqual(["desktop_login"]);
+  const calls = await page.evaluate(() => (window as AccessUpdateWindow).__accessUpdateCalls);
+  expect(calls.filter((command) => command === "refresh_desktop_snapshot")).toHaveLength(1);
+  await page.getByRole("button", { name: "Sair da conta", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Começar", exact: true })).toBeVisible();
+  expect(await accountAndInstallCalls(page)).toEqual(["desktop_login", "desktop_logout"]);
+});

--- a/apps/desktop/e2e/hidden-settings.spec.ts
+++ b/apps/desktop/e2e/hidden-settings.spec.ts
@@ -40,6 +40,38 @@ test("visible reference pages do not expose links back to hidden destinations", 
   for (const view of ["provider-accounts", "general-settings", "quick-commands", "permissions"]) {
     await page.goto("/?view=" + view);
     await expect(page.locator(".reference-settings-page")).toBeVisible();
-    await expect(page.getByRole("main").getByRole("button", { name: /Ver atalhos|Abrir atalhos|Abrir navegador|Abrir terminal|Configurar voz/ })).toHaveCount(0);
+    await expect(page.getByRole("main").getByRole("button", { name: /Ver atalhos|Abrir atalhos|Abrir navegador|Abrir terminal|Configurar voz|Ver agente e IDE/ })).toHaveCount(0);
   }
+});
+
+test("narrow navigation and account pages keep requested destinations hidden", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 740 });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Expandir barra lateral", exact: true }).click();
+  const workspaceMenu = page.getByRole("dialog", { name: "Espaço de trabalho", exact: true });
+  await expect(workspaceMenu).toBeVisible();
+  for (const label of hidden) {
+    await workspaceMenu.getByRole("searchbox").fill(label);
+    await expect(workspaceMenu.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
+  await workspaceMenu.getByRole("searchbox").fill("");
+  await workspaceMenu.getByRole("button", { name: "Configurações", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Conta Simplicio", exact: true })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Expandir barra lateral", exact: true }).click();
+  const settingsMenu = page.getByRole("dialog", { name: "Configurações", exact: true });
+  const categories = settingsMenu.getByRole("navigation", { name: "Categorias de configurações", exact: true });
+  for (const label of hidden) await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  for (const group of ["HOSTS REMOTOS", "EXPERIMENTAL"]) await expect(categories.getByText(group, { exact: true })).toHaveCount(0);
+  for (const label of hidden) {
+    await settingsMenu.getByRole("searchbox").fill(label);
+    await expect(categories.getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
+  await settingsMenu.getByRole("searchbox").fill("");
+  await categories.getByRole("button", { name: "Contas de IA", exact: true }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Contas de IA", exact: true, level: 1 })).toBeVisible();
+  await expect(page.getByRole("main").getByRole("button", { name: "Ver agente e IDE", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Abrir conta Simplicio", exact: true })).toBeVisible();
 });

--- a/apps/desktop/e2e/install-partial-diagnostic.spec.ts
+++ b/apps/desktop/e2e/install-partial-diagnostic.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+test("a typed partial receipt shows sanitized steps without enabling another install (mocked IPC)", async ({ page }) => {
+  const snapshot = createDemoSnapshot("active");
+  snapshot.source = "runtime";
+  await page.addInitScript(({ snapshot }) => {
+    let applications = 0;
+    Object.assign(window, { __installDiagnosticApplications: () => applications, __TAURI_INTERNALS__: {
+      invoke: async (command: string) => {
+        if (command === "desktop_snapshot" || command === "refresh_desktop_snapshot") return snapshot;
+        if (command === "desktop_plan_integrations") return {
+          schema: "simplicio.desktop-integration-plan/v1", source: "runtime",
+          planDigest: "sha256:" + "a".repeat(64),
+          changes: [{ label: "hermes", exists: true, changed: true }],
+        };
+        if (command === "desktop_repair_providers") {
+          applications += 1;
+          throw {
+            schema: "simplicio.desktop-install-error/v1", code: "integration_install_exit_code:1",
+            diagnostic: { schema: "simplicio.desktop-install-diagnostic/v1", status: "partial", failedSteps: ["hermes"], unknownFailedSteps: 0 },
+            detail: "DO_NOT_LEAK /private/test-user",
+          };
+        }
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:event|unlisten") return;
+        throw "unexpected_install_diagnostic_command";
+      },
+    } });
+  }, { snapshot });
+  await page.goto("/?view=setup");
+  await page.getByRole("button", { name: "Configurar Simplicio", exact: true }).click();
+  await page.getByRole("checkbox", { name: /Autorizo o Runtime/ }).check();
+  await page.getByRole("button", { name: "Instalar e conectar", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Não foi possível concluir.", exact: true })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("Etapas com falha: Hermes.");
+  await expect(page.getByRole("alert")).toContainText("código 1.");
+  await expect(page.locator("body")).not.toContainText("DO_NOT_LEAK");
+  await expect(page.locator("body")).not.toContainText("/private/test-user");
+  await expect(page.getByRole("button", { name: "Revisar novamente", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Instalar e conectar", exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+  await page.getByRole("button", { name: "Integrações MCP", exact: true }).click();
+  const integration = page.getByRole("region", { name: "Configuração do MCP", exact: true });
+  await expect(integration.getByRole("button", { name: "Revisar configuração MCP", exact: true })).toBeDisabled();
+  await integration.getByRole("button", { name: "Atualizar diagnóstico", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Runtime e diagnóstico", exact: true })).toBeVisible();
+  expect(await page.evaluate(() => (window as Window & { __installDiagnosticApplications: () => number }).__installDiagnosticApplications())).toBe(1);
+});

--- a/apps/desktop/e2e/integration-preflight-recovery.spec.ts
+++ b/apps/desktop/e2e/integration-preflight-recovery.spec.ts
@@ -1,6 +1,17 @@
 import { expect, test, type Page } from "@playwright/test";
 import { createDemoSnapshot } from "../src/demo";
 
+// Surface browser exceptions as failures, including asynchronous Tauri event cleanup.
+const browserErrors = new WeakMap<Page, string[]>();
+test.beforeEach(({ page }) => {
+  const errors: string[] = [];
+  browserErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(error.message));
+});
+test.afterEach(({ page }) => {
+  expect(browserErrors.get(page)).toEqual([]);
+});
+
 type PreflightWindow = Window & {
   __preflightCalls: string[];
   __preflightDigests: unknown[];
@@ -14,12 +25,15 @@ async function preparePreflightFailure(page: Page) {
     const digests: unknown[] = [];
     let reviews = 0;
     let applied = false;
+    const eventListeners = new Set<number>();
+    let callbackId = 0;
     Object.assign(window, {
       isTauri: true,
       __preflightCalls: calls,
       __preflightDigests: digests,
+      __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: (_event: string, id: number) => eventListeners.delete(id) },
       __TAURI_INTERNALS__: {
-        transformCallback: () => 1,
+        transformCallback: () => ++callbackId,
         unregisterCallback: () => undefined,
         metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
         invoke: async (command: string, args: Record<string, unknown> = {}) => {
@@ -41,7 +55,7 @@ async function preparePreflightFailure(page: Page) {
             applied = true;
             return snapshot;
           }
-          if (command === "plugin:event|listen") return 1;
+          if (command === "plugin:event|listen") { const id = ++callbackId; eventListeners.add(id); return id; }
           if (command === "plugin:event|unlisten") return;
           throw "unexpected_preflight_recovery_command";
         },

--- a/apps/desktop/e2e/settings-return.spec.ts
+++ b/apps/desktop/e2e/settings-return.spec.ts
@@ -2,6 +2,17 @@ import { expect, test, type Page } from "@playwright/test";
 import { createDemoSnapshot } from "../src/demo";
 import { emptyWorkbench, WORKBENCH_KEY } from "../src/workbench";
 
+// Surface browser exceptions as failures, including asynchronous Tauri event cleanup.
+const browserErrors = new WeakMap<Page, string[]>();
+test.beforeEach(({ page }) => {
+  const errors: string[] = [];
+  browserErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(error.message));
+});
+test.afterEach(({ page }) => {
+  expect(browserErrors.get(page)).toEqual([]);
+});
+
 type SettingsTestWindow = Window & {
   __settingsCalls: Array<{ command: string; args: Record<string, unknown> }>;
 };
@@ -17,11 +28,14 @@ async function nativeSettings(page: Page) {
   await page.addInitScript(({ snapshot, workbench, storageKey }) => {
     window.localStorage.setItem(storageKey, JSON.stringify(workbench));
     const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
+    const eventListeners = new Set<number>();
+    let callbackId = 0;
     Object.assign(window, {
       isTauri: true,
       __settingsCalls: calls,
+      __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: (_event: string, id: number) => eventListeners.delete(id) },
       __TAURI_INTERNALS__: {
-        transformCallback: () => 1,
+        transformCallback: () => ++callbackId,
         unregisterCallback: () => undefined,
         metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
         invoke: async (command: string, args: Record<string, unknown> = {}) => {
@@ -36,7 +50,7 @@ async function nativeSettings(page: Page) {
           if (command === "desktop_token_report") throw "token_ledger_unavailable";
           if (command === "desktop_context_report") throw "context_ledger_unavailable";
           if (command === "desktop_consolidated_token_report") throw "consolidated_report_unavailable";
-          if (command === "plugin:event|listen") return 1;
+          if (command === "plugin:event|listen") { const id = ++callbackId; eventListeners.add(id); return id; }
           if (command === "plugin:event|unlisten") return;
           throw "unexpected_settings_test_command";
         },

--- a/apps/desktop/src-tauri/src/auth_login.rs
+++ b/apps/desktop/src-tauri/src/auth_login.rs
@@ -1,0 +1,297 @@
+//! Google authentication is negotiated before any account effect.
+//! The capability probe and login use one selected Runtime candidate.
+use crate::runtime_process::ProcessFailure;
+use std::ffi::{OsStr, OsString};
+use std::process::Output;
+
+pub const LOGIN_ARGS: &[&str] = &["login", "google", "--authentication-only", "--json"];
+pub const STATUS_ARGS: &[&str] = &["desktop", "status", "--json"];
+const MAX_AUTH_BYTES: usize = 64 * 1024;
+
+fn supported(output: &Output) -> bool {
+    if !output.status.success() || output.stdout.len() > MAX_AUTH_BYTES {
+        return false;
+    }
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&output.stdout) else {
+        return false;
+    };
+    value["schema"] == "simplicio.desktop.app/v1"
+        && value["action"] == "status"
+        && value["authentication"]["schema"] == "simplicio.desktop-auth-capabilities/v1"
+        && value["authentication"]["authentication_only"] == true
+}
+
+fn confirmed(output: &Output) -> bool {
+    if !output.status.success() || output.stdout.len() > MAX_AUTH_BYTES {
+        return false;
+    }
+    let Ok(text) = std::str::from_utf8(&output.stdout) else {
+        return false;
+    };
+    // Pending device-authorization events may precede the terminal JSONL event.
+    let Some(last) = text.lines().rev().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(last) else {
+        return false;
+    };
+    value["schema"] == "simplicio.auth-login/v1"
+        && value["status"] == "authenticated"
+        && value["bootstrap"]["status"] == "skipped"
+        && value["bootstrap"]["reason"] == "authentication_only"
+}
+
+/// Only a failed spawn before the read-only probe may select another candidate.
+/// No process output, credential, argument, or executable path becomes an error.
+pub fn authenticate(
+    candidates: impl IntoIterator<Item = OsString>,
+    mut capture: impl FnMut(&OsStr, &'static [&'static str]) -> Result<Output, ProcessFailure>,
+) -> Result<(), String> {
+    for binary in candidates {
+        let capability = match capture(&binary, STATUS_ARGS) {
+            Err(failure) if failure.may_try_another_candidate() => continue,
+            Err(failure) => return Err(crate::runtime_failure_code(STATUS_ARGS, failure)),
+            Ok(output) => output,
+        };
+        if !supported(&capability) {
+            return Err("runtime_auth_only_unsupported".into());
+        }
+        let result = capture(&binary, LOGIN_ARGS)
+            .map_err(|failure| crate::runtime_failure_code(LOGIN_ARGS, failure))?;
+        if !confirmed(&result) {
+            return Err("runtime_auth_result_unconfirmed".into());
+        }
+        return Ok(());
+    }
+    Err("runtime_not_started".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_process::{ChildState, FailureKind};
+    use serde_json::{json, Value};
+
+    fn output(code: i32, value: Value) -> Output {
+        bytes_output(code, serde_json::to_vec(&value).unwrap())
+    }
+
+    fn bytes_output(code: i32, stdout: Vec<u8>) -> Output {
+        #[cfg(unix)]
+        use std::os::unix::process::ExitStatusExt;
+        #[cfg(windows)]
+        use std::os::windows::process::ExitStatusExt;
+        #[cfg(unix)]
+        let status = std::process::ExitStatus::from_raw(code << 8);
+        #[cfg(windows)]
+        let status = std::process::ExitStatus::from_raw(code as u32);
+        Output {
+            status,
+            stdout,
+            stderr: b"SECRET_STDERR /private/example".to_vec(),
+        }
+    }
+
+    fn capability() -> Value {
+        json!({
+            "schema": "simplicio.desktop.app/v1",
+            "action": "status",
+            "authentication": {
+                "schema": "simplicio.desktop-auth-capabilities/v1",
+                "authentication_only": true
+            }
+        })
+    }
+
+    fn receipt() -> Value {
+        json!({
+            "schema": "simplicio.auth-login/v1",
+            "status": "authenticated",
+            "bootstrap": { "status": "skipped", "reason": "authentication_only" }
+        })
+    }
+
+    fn candidates() -> Vec<OsString> {
+        vec!["bundled".into(), "managed".into()]
+    }
+
+    #[test]
+    fn rejects_legacy_missing_false_malformed_or_oversized_capability_before_login() {
+        let mut disabled = capability();
+        disabled["authentication"]["authentication_only"] = json!(false);
+        let mut untyped = capability();
+        untyped["authentication"]["authentication_only"] = json!("true");
+        let mut wrong_schema = capability();
+        wrong_schema["schema"] = json!("simplicio.desktop-app/v1");
+        let mut wrong_action = capability();
+        wrong_action["action"] = json!("login");
+        let mut wrong_auth_schema = capability();
+        wrong_auth_schema["authentication"]["schema"] = json!("unknown");
+        let bad = vec![
+            output(0, json!({"schema":"simplicio.desktop.app/v1"})),
+            output(0, Value::Null),
+            output(0, disabled),
+            output(0, untyped),
+            output(0, wrong_schema),
+            output(0, wrong_auth_schema),
+            output(0, wrong_action),
+            output(1, capability()),
+            bytes_output(0, b"SECRET_OUTPUT".to_vec()),
+            bytes_output(0, vec![b' '; MAX_AUTH_BYTES + 1]),
+        ];
+        for response in bad {
+            let mut response = Some(response);
+            let mut calls = 0;
+            let result = authenticate(candidates(), |binary, args| {
+                calls += 1;
+                assert_eq!(binary, OsStr::new("bundled"));
+                assert_eq!(args, STATUS_ARGS);
+                Ok(response.take().unwrap())
+            });
+            assert_eq!(result, Err("runtime_auth_only_unsupported".into()));
+            assert_eq!(calls, 1);
+        }
+    }
+
+    #[test]
+    fn a_verified_candidate_is_used_for_exact_authentication_only_arguments() {
+        let mut calls = vec![];
+        let result = authenticate(candidates(), |binary, args| {
+            calls.push((binary.to_os_string(), args.to_vec()));
+            if args == STATUS_ARGS {
+                Ok(output(0, capability()))
+            } else {
+                assert_eq!(args, LOGIN_ARGS);
+                Ok(output(0, receipt()))
+            }
+        });
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            calls,
+            vec![
+                (OsString::from("bundled"), STATUS_ARGS.to_vec()),
+                (OsString::from("bundled"), LOGIN_ARGS.to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn fallback_is_only_for_an_unstarted_read_only_probe() {
+        let mut calls = vec![];
+        let result = authenticate(candidates(), |binary, args| {
+            calls.push((binary.to_os_string(), args.to_vec()));
+            if binary == OsStr::new("bundled") {
+                Err(ProcessFailure {
+                    kind: FailureKind::Spawn,
+                    child_state: ChildState::NotStarted,
+                })
+            } else if args == STATUS_ARGS {
+                Ok(output(0, capability()))
+            } else {
+                Ok(output(0, receipt()))
+            }
+        });
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            calls,
+            vec![
+                (OsString::from("bundled"), STATUS_ARGS.to_vec()),
+                (OsString::from("managed"), STATUS_ARGS.to_vec()),
+                (OsString::from("managed"), LOGIN_ARGS.to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn never_falls_back_after_a_verified_candidate_even_if_login_does_not_spawn() {
+        let mut calls = 0;
+        let result = authenticate(candidates(), |binary, args| {
+            calls += 1;
+            assert_eq!(binary, OsStr::new("bundled"));
+            if args == STATUS_ARGS {
+                Ok(output(0, capability()))
+            } else {
+                Err(ProcessFailure {
+                    kind: FailureKind::Spawn,
+                    child_state: ChildState::NotStarted,
+                })
+            }
+        });
+        assert_eq!(result, Err("runtime_not_started".into()));
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn probe_timeout_or_unconfirmed_cleanup_never_launches_login() {
+        for failure in [
+            ProcessFailure {
+                kind: FailureKind::Deadline,
+                child_state: ChildState::Reaped,
+            },
+            ProcessFailure {
+                kind: FailureKind::Capture,
+                child_state: ChildState::Retained,
+            },
+        ] {
+            let mut calls = 0;
+            let result = authenticate(candidates(), |_, args| {
+                calls += 1;
+                assert_eq!(args, STATUS_ARGS);
+                Err(failure)
+            });
+            assert!(result.is_err());
+            assert_eq!(calls, 1);
+        }
+    }
+
+    #[test]
+    fn requires_successful_terminal_auth_only_receipt_and_never_reflects_output() {
+        let mut bootstrapped = receipt();
+        bootstrapped["bootstrap"]["status"] = json!("applied");
+        let mut unknown = receipt();
+        unknown["status"] = json!("unknown");
+        let mut legacy = receipt();
+        legacy.as_object_mut().unwrap().remove("schema");
+        for response in [
+            output(1, receipt()),
+            output(0, bootstrapped),
+            output(0, unknown),
+            output(0, legacy),
+            bytes_output(0, b"SECRET_OUTPUT /private/example".to_vec()),
+            bytes_output(0, vec![0xff]),
+            bytes_output(0, vec![b' '; MAX_AUTH_BYTES + 1]),
+        ] {
+            let mut response = Some(response);
+            let mut calls = 0;
+            let result = authenticate(candidates(), |_, args| {
+                calls += 1;
+                if args == STATUS_ARGS {
+                    Ok(output(0, capability()))
+                } else {
+                    Ok(response.take().unwrap())
+                }
+            });
+            assert_eq!(result, Err("runtime_auth_result_unconfirmed".into()));
+            assert_eq!(calls, 2);
+            assert!(!format!("{result:?}").contains("SECRET"));
+        }
+    }
+
+    #[test]
+    fn accepts_jsonl_pending_then_terminal_receipt_but_not_trailing_pending_or_garbage() {
+        let success = serde_json::to_string(&receipt()).unwrap();
+        let pending = r#"{"status":"pending","device_code":"SECRET"}"#;
+        assert!(confirmed(&bytes_output(
+            0,
+            format!("{pending}\n{success}\n\n").into_bytes()
+        )));
+        assert!(!confirmed(&bytes_output(
+            0,
+            format!("{success}\n{pending}").into_bytes()
+        )));
+        assert!(!confirmed(&bytes_output(
+            0,
+            format!("{success}\ngarbage").into_bytes()
+        )));
+    }
+}

--- a/apps/desktop/src-tauri/src/install_result.rs
+++ b/apps/desktop/src-tauri/src/install_result.rs
@@ -2,10 +2,101 @@ use serde_json::Value;
 
 const MAX_INSTALL_OUTPUT_BYTES: usize = 64 * 1024;
 
+const MAX_INSTALL_ACTIONS: usize = 128;
+
+/// A closed projection: no raw action name, path, detail, stdout or stderr.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstallDiagnostic {
+    schema: &'static str,
+    status: &'static str,
+    failed_steps: Vec<&'static str>,
+    unknown_failed_steps: usize,
+}
+
+pub type InstallError = Value;
+
+fn known_step(name: &str) -> Option<&'static str> {
+    match name {
+        "binary-copy" => Some("binary-copy"),
+        "path-registration" => Some("path-registration"),
+        "install-manifest" => Some("install-manifest"),
+        "assistant-config:codex" => Some("codex"),
+        "assistant-config:codex-hooks" => Some("codex-hooks"),
+        "assistant-config:mcp-route-hook" => Some("mcp-route-hook"),
+        "assistant-config:hermes" => Some("hermes"),
+        "assistant-config:claude-code" => Some("claude-code"),
+        "assistant-config:claude-code-hooks" => Some("claude-code-hooks"),
+        "assistant-config:claude-desktop" => Some("claude-desktop"),
+        "assistant-config:cursor" => Some("cursor"),
+        "assistant-config:windsurf" => Some("windsurf"),
+        "assistant-config:windsurf-next" => Some("windsurf-next"),
+        "assistant-config:kiro" => Some("kiro"),
+        "assistant-config:gemini" => Some("gemini"),
+        "assistant-config:trae" => Some("trae"),
+        "assistant-config:antigravity" => Some("antigravity"),
+        "assistant-config:jetbrains-junie" => Some("jetbrains-junie"),
+        "assistant-config:vscode-cline" => Some("vscode-cline"),
+        "assistant-config:vscode" => Some("vscode"),
+        "assistant-config:zed" => Some("zed"),
+        "assistant-config:opencode" => Some("opencode"),
+        "assistant-config:grok-mcp-route" => Some("grok-mcp-route"),
+        _ => None,
+    }
+}
+
+fn partial_diagnostic(stdout: &[u8]) -> Option<InstallDiagnostic> {
+    if stdout.len() > MAX_INSTALL_OUTPUT_BYTES {
+        return None;
+    }
+    let receipt: Value = serde_json::from_slice(stdout).ok()?;
+    if receipt.get("schema")?.as_str()? != "simplicio.install-apply/v1"
+        || receipt.get("status")?.as_str()? != "partial"
+    {
+        return None;
+    }
+    let actions = receipt.get("actions")?.as_array()?;
+    if actions.is_empty() || actions.len() > MAX_INSTALL_ACTIONS {
+        return None;
+    }
+    let mut names = std::collections::HashSet::new();
+    let mut failed_steps = Vec::new();
+    let mut unknown_failed_steps = 0;
+    for action in actions {
+        let name = action.get("name")?.as_str()?;
+        if name.is_empty() || name.len() > 128 || !names.insert(name) {
+            return None;
+        }
+        match action.get("status")?.as_str()? {
+            "done" | "skipped" => {}
+            "failed" => match known_step(name) {
+                Some(step) => failed_steps.push(step),
+                None => unknown_failed_steps += 1,
+            },
+            _ => return None,
+        }
+    }
+    if failed_steps.is_empty() && unknown_failed_steps == 0 {
+        return None;
+    }
+    Some(InstallDiagnostic {
+        schema: "simplicio.desktop-install-diagnostic/v1",
+        status: "partial",
+        failed_steps,
+        unknown_failed_steps,
+    })
+}
+
 /// Public classifications contain no process output or native error strings.
 /// None of these failures authorizes retrying an installation automatically.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstallFailure {
+    Busy,
+    PreflightUnavailable,
+    PlanChanged,
+    ExitCodeWithDiagnostic {
+        code: i32,
+        diagnostic: InstallDiagnostic,
+    },
     // Command::output may fail while capturing/waiting, not only when spawning.
     // The absence of an output result does not prove there were no effects.
     OutputUnavailable,
@@ -23,9 +114,31 @@ pub enum InstallFailure {
 }
 
 impl InstallFailure {
+    pub fn public_error(&self) -> InstallError {
+        let mut error = serde_json::json!({
+            "schema": "simplicio.desktop-install-error/v1",
+            "code": self.public_code(),
+        });
+        if let Self::ExitCodeWithDiagnostic { diagnostic, .. } = self {
+            error["diagnostic"] = serde_json::json!({
+                "schema": diagnostic.schema,
+                "status": diagnostic.status,
+                "failedSteps": diagnostic.failed_steps,
+                "unknownFailedSteps": diagnostic.unknown_failed_steps,
+            });
+        }
+        error
+    }
+
     /// Only fixed tags and an OS-provided i32 can cross the frontend boundary.
     pub fn public_code(&self) -> String {
         match self {
+            Self::Busy => "integration_install_busy".into(),
+            Self::PreflightUnavailable => "integration_preflight_unavailable".into(),
+            Self::PlanChanged => "integration_plan_changed_review_again".into(),
+            Self::ExitCodeWithDiagnostic { code, .. } => {
+                format!("integration_install_exit_code:{code}")
+            }
             Self::OutputUnavailable => "integration_install_output_unavailable".into(),
             Self::NotStarted => "integration_install_not_started".into(),
             Self::TimedOut => "integration_install_timeout".into(),
@@ -89,7 +202,12 @@ pub fn validate_install_output(
 ) -> Result<(), InstallFailure> {
     match exit_code {
         Some(0) => {}
-        Some(code) => return Err(InstallFailure::ExitCode(code)),
+        Some(code) => {
+            return Err(match partial_diagnostic(stdout) {
+                Some(diagnostic) => InstallFailure::ExitCodeWithDiagnostic { code, diagnostic },
+                None => InstallFailure::ExitCode(code),
+            })
+        }
         None => return Err(InstallFailure::NoExitCode),
     }
     if stdout.len() > MAX_INSTALL_OUTPUT_BYTES {
@@ -327,5 +445,92 @@ mod tests {
         ] {
             assert_eq!(failure.public_code(), expected);
         }
+    }
+}
+
+#[cfg(test)]
+mod diagnostic_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn partial(actions: Value) -> Vec<u8> {
+        serde_json::to_vec(&json!({
+            "schema":"simplicio.install-apply/v1", "status":"partial", "actions":actions
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn partial_exit_exposes_only_known_steps_and_does_not_release_attempt() {
+        let stdout = partial(json!([
+            {"name":"binary-copy","status":"done"},
+            {"name":"assistant-config:hermes","status":"failed","detail":"DO_NOT_LEAK /private/test-user"},
+            {"name":"unknown-private-name","status":"failed","token":"DO_NOT_LEAK"},
+            {"name":"install-manifest","status":"done"}
+        ]));
+        let failure = validate_install_output(Some(1), &stdout).unwrap_err();
+        let projection = serde_json::to_value(failure.public_error()).unwrap();
+        assert_eq!(projection["code"], "integration_install_exit_code:1");
+        assert_eq!(projection["diagnostic"]["failedSteps"], json!(["hermes"]));
+        assert_eq!(projection["diagnostic"]["unknownFailedSteps"], 1);
+        for rendered in [projection.to_string(), format!("{failure:?}")] {
+            for secret in ["DO_NOT_LEAK", "/private/test-user", "unknown-private-name"] {
+                assert!(!rendered.contains(secret));
+            }
+        }
+        let mut attempt = InstallAttempt::new();
+        attempt.begin().unwrap();
+        attempt.finish(&Err(failure));
+        assert_eq!(
+            attempt.check_ready(),
+            Err(InstallFailure::ReconciliationRequired)
+        );
+        assert_eq!(
+            validate_install_output(Some(0), &stdout),
+            Err(InstallFailure::ReceiptUnconfirmed)
+        );
+    }
+
+    #[test]
+    fn malformed_partial_diagnostics_never_override_nonzero_exit() {
+        for actions in [
+            json!([]),
+            json!([{"name":"assistant-config:hermes","status":"unknown"}]),
+            json!([{"name":"assistant-config:hermes","status":"done"}]),
+            json!([{"name":"assistant-config:hermes","status":"failed"},{"name":"assistant-config:hermes","status":"done"}]),
+            json!([{"name":"","status":"failed"}]),
+            Value::Null,
+        ] {
+            let failure = validate_install_output(Some(7), &partial(actions)).unwrap_err();
+            assert_eq!(failure, InstallFailure::ExitCode(7));
+            assert!(serde_json::to_value(failure.public_error())
+                .unwrap()
+                .get("diagnostic")
+                .is_none());
+        }
+        for stdout in [b"not JSON".to_vec(), vec![b' '; MAX_INSTALL_OUTPUT_BYTES + 1],
+            br#"{"schema":"wrong","status":"partial","actions":[{"name":"binary-copy","status":"failed"}]}"#.to_vec()] {
+            assert_eq!(validate_install_output(Some(7), &stdout), Err(InstallFailure::ExitCode(7)));
+        }
+    }
+
+    #[test]
+    fn exactly_128_unique_actions_are_bounded_and_129_are_refused() {
+        let mut actions: Vec<Value> = (0..128)
+            .map(|i| {
+                json!({
+                    "name":format!("private-{i}"),"status":"failed"
+                })
+            })
+            .collect();
+        let failure = validate_install_output(Some(1), &partial(json!(actions))).unwrap_err();
+        let projection = serde_json::to_value(failure.public_error()).unwrap();
+        assert_eq!(projection["diagnostic"]["unknownFailedSteps"], 128);
+        assert!(!projection.to_string().contains("private-"));
+        actions.push(json!({"name":"one-too-many","status":"failed"}));
+        assert_eq!(
+            validate_install_output(Some(1), &partial(json!(actions))),
+            Err(InstallFailure::ExitCode(1))
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Output};
 use tauri::Manager;
 
 mod auth_access;
+mod auth_login;
 mod consolidated_tokens;
 mod context_report;
 mod desktop_queries;
@@ -64,9 +65,9 @@ async fn desktop_export_snapshot(
 const SNAPSHOT_SCHEMA: &str = "simplicio.desktop-snapshot/v1";
 const MAX_SNAPSHOT_BYTES: usize = 65_536;
 const SNAPSHOT_ARGS: &[&str] = &["desktop", "snapshot", "--json"];
-const LOGIN_ARGS: &[&str] = &["login", "google", "--json"];
+const LOGIN_ARGS: &[&str] = auth_login::LOGIN_ARGS;
 const LOGOUT_ARGS: &[&str] = &["logout", "--json"];
-const STATUS_ARGS: &[&str] = &["desktop", "status", "--json"];
+const STATUS_ARGS: &[&str] = auth_login::STATUS_ARGS;
 const LEGACY_AUTH_ARGS: &[&str] = &["auth", "status", "--json"];
 const LEGACY_STATUS_ARGS: &[&str] = &["status", "--json"];
 const LEGACY_SAVINGS_ARGS: &[&str] = &["savings", "report", "--json"];
@@ -483,7 +484,11 @@ async fn refresh_desktop_snapshot() -> Result<Value, String> {
 #[tauri::command]
 async fn desktop_login() -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(|| {
-        run_runtime_action(LOGIN_ARGS)?;
+        auth_login::authenticate(runtime_candidates(), |binary, args| {
+            let mut command = Command::new(binary);
+            command.args(args).env("SIMPLICIO_DESKTOP_BRIDGE", "1");
+            runtime_process::capture(&mut command, runtime_capture_limits(args))
+        })?;
         snapshot_from_runtime()
     })
     .await
@@ -501,30 +506,35 @@ async fn desktop_logout() -> Result<Value, String> {
 }
 
 #[tauri::command]
-async fn desktop_repair_providers(plan_digest: String) -> Result<Value, String> {
+async fn desktop_repair_providers(
+    plan_digest: String,
+) -> Result<Value, install_result::InstallError> {
+    use install_result::InstallFailure;
     tauri::async_runtime::spawn_blocking(move || {
         let mut attempt = INSTALL_LOCK.try_lock().map_err(|error| match error {
-            std::sync::TryLockError::WouldBlock => "integration_install_busy",
-            std::sync::TryLockError::Poisoned(_) => "integration_install_reconciliation_required",
+            std::sync::TryLockError::WouldBlock => InstallFailure::Busy.public_error(),
+            std::sync::TryLockError::Poisoned(_) => {
+                InstallFailure::ReconciliationRequired.public_error()
+            }
         })?;
         attempt
             .check_ready()
-            .map_err(|failure| failure.public_code())?;
+            .map_err(|failure| failure.public_error())?;
         // Preflight is read-only: no installer has started before attempt.begin().
-        let plan =
-            integration_plan_from_runtime().map_err(|_| "integration_preflight_unavailable")?;
+        let plan = integration_plan_from_runtime()
+            .map_err(|_| InstallFailure::PreflightUnavailable.public_error())?;
         if plan["planDigest"].as_str() != Some(plan_digest.as_str()) {
-            return Err("integration_plan_changed_review_again".into());
+            return Err(InstallFailure::PlanChanged.public_error());
         }
-        attempt.begin().map_err(|failure| failure.public_code())?;
+        attempt.begin().map_err(|failure| failure.public_error())?;
         let result = repair_provider_integrations();
         attempt.finish(&result);
-        result.map_err(|failure| failure.public_code())?;
+        result.map_err(|failure| failure.public_error())?;
         snapshot_from_runtime()
-            .map_err(|_| install_result::InstallFailure::AppliedSnapshotUnavailable.public_code())
+            .map_err(|_| InstallFailure::AppliedSnapshotUnavailable.public_error())
     })
     .await
-    .map_err(|_| "Falha interna durante o reparo das integrações".to_string())?
+    .map_err(|_| InstallFailure::OutputUnavailable.public_error())?
 }
 
 #[tauri::command]
@@ -646,7 +656,10 @@ mod tests {
     #[test]
     fn bridge_exposes_only_fixed_runtime_arguments() {
         assert_eq!(SNAPSHOT_ARGS, ["desktop", "snapshot", "--json"]);
-        assert_eq!(LOGIN_ARGS, ["login", "google", "--json"]);
+        assert_eq!(
+            LOGIN_ARGS,
+            ["login", "google", "--authentication-only", "--json"]
+        );
         assert_eq!(LOGOUT_ARGS, ["logout", "--json"]);
         assert_eq!(STATUS_ARGS, ["desktop", "status", "--json"]);
         assert_eq!(LEGACY_AUTH_ARGS, ["auth", "status", "--json"]);

--- a/apps/desktop/src/install_failures.test.ts
+++ b/apps/desktop/src/install_failures.test.ts
@@ -118,3 +118,52 @@ describe("installer recovery without repeated side effects", () => {
     ]) expect(installFailureRecovery(error)).toBe("reconcile");
   });
 });
+
+describe("typed partial install diagnostics", () => {
+  const partial = (overrides: Record<string, unknown> = {}) => ({
+    schema: "simplicio.desktop-install-error/v1",
+    code: "integration_install_exit_code:1",
+    diagnostic: {
+      schema: "simplicio.desktop-install-diagnostic/v1", status: "partial",
+      failedSteps: ["hermes"], unknownFailedSteps: 0,
+    },
+    ...overrides,
+  });
+
+  it("shows only reviewed step labels without releasing retry protection", () => {
+    const message = installFailureMessage(partial());
+    expect(message).toContain("Hermes");
+    expect(message).toContain("código 1.");
+    expect(message).toContain("bloqueadas nesta sessão");
+    expect(installFailureRecovery(partial())).toBe("reconcile");
+  });
+
+  it("never reflects unknown names, details, paths, or an inconsistent no-start claim", () => {
+    const secret = "DO_NOT_LEAK /private/test-user";
+    for (const diagnostic of [
+      { schema: "simplicio.desktop-install-diagnostic/v1", status: "partial", failedSteps: [secret], unknownFailedSteps: 0 },
+      { schema: "simplicio.desktop-install-diagnostic/v1", status: "partial", failedSteps: ["hermes", "hermes"], unknownFailedSteps: 0 },
+      { schema: "simplicio.desktop-install-diagnostic/v1", status: "partial", failedSteps: ["hermes"], unknownFailedSteps: 129 },
+      { schema: "wrong", status: "partial", failedSteps: ["hermes"], unknownFailedSteps: 0 },
+    ]) {
+      const error = partial({ diagnostic });
+      expect(installFailureMessage(error)).not.toContain(secret);
+      expect(installFailureMessage(error)).not.toContain("Hermes");
+      expect(installFailureRecovery(error)).toBe("reconcile");
+    }
+    const inconsistent = partial({ code: "integration_install_not_started" });
+    expect(installFailureRecovery(inconsistent)).toBe("reconcile");
+    expect(installFailureMessage(inconsistent)).not.toContain("não foi iniciado");
+    expect(installFailureMessage(partial({ code: "integration_install_exit_code:0" }))).not.toContain("Hermes");
+  });
+
+  it("supports typed preflight errors and generic unknown failed steps", () => {
+    expect(installFailureRecovery({ schema: "simplicio.desktop-install-error/v1", code: "integration_preflight_unavailable" })).toBe("review");
+    const error = partial({ diagnostic: {
+      schema: "simplicio.desktop-install-diagnostic/v1", status: "partial",
+      failedSteps: [], unknownFailedSteps: 2,
+    } });
+    expect(installFailureMessage(error)).toContain("2 etapa(s) não identificada(s)");
+    expect(installFailureRecovery(error)).toBe("reconcile");
+  });
+});

--- a/apps/desktop/src/install_failures.ts
+++ b/apps/desktop/src/install_failures.ts
@@ -36,7 +36,7 @@ const MESSAGES: Readonly<Record<string, string>> = {
 };
 
 /** Translate only closed native codes; never reflect stdout, stderr or user paths. */
-export function installFailureMessage(error: unknown): string {
+function baseFailureMessage(error: unknown): string {
   const code = nativeCode(error);
   if (code.length <= 100 && Object.prototype.hasOwnProperty.call(MESSAGES, code)) return MESSAGES[code];
   if (code.length <= 100) {
@@ -52,6 +52,77 @@ export function installFailureMessage(error: unknown): string {
 }
 
 function nativeCode(error: unknown): string {
-  const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+  const code = typeof error === "string" ? error : error instanceof Error ? error.message : typedError(error)?.code ?? "";
   return typeof code === "string" && code.length <= 100 ? code : "";
+}
+
+const STEP_LABELS: Readonly<Record<string, string>> = {
+  "binary-copy": "Runtime",
+  "path-registration": "PATH",
+  "install-manifest": "recibo de instalação",
+  "codex": "Codex",
+  "codex-hooks": "hooks do Codex",
+  "mcp-route-hook": "hook de roteamento MCP",
+  "hermes": "Hermes",
+  "claude-code": "Claude Code",
+  "claude-code-hooks": "hooks do Claude Code",
+  "claude-desktop": "Claude Desktop",
+  "cursor": "Cursor",
+  "windsurf": "Windsurf",
+  "windsurf-next": "Windsurf Next",
+  "kiro": "Kiro",
+  "gemini": "Gemini",
+  "trae": "Trae",
+  "antigravity": "Antigravity",
+  "jetbrains-junie": "JetBrains Junie",
+  "vscode-cline": "Cline",
+  "vscode": "VS Code",
+  "zed": "Zed",
+  "opencode": "OpenCode",
+  "grok-mcp-route": "hook MCP do Grok"
+};
+
+type PartialDiagnostic = { failedSteps: string[]; unknownFailedSteps: number };
+type NativeInstallError = { code: string; diagnostic?: PartialDiagnostic };
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validExitCode(code: string): boolean {
+  const match = /^integration_install_exit_code:(-?\d{1,11})$/.exec(code);
+  if (!match) return false;
+  const value = Number(match[1]);
+  return Number.isInteger(value) && value !== 0 && value >= -2_147_483_648 && value <= 2_147_483_647;
+}
+
+function typedError(error: unknown): NativeInstallError | undefined {
+  if (!record(error) || error.schema !== "simplicio.desktop-install-error/v1") return;
+  const code = error.code;
+  if (typeof code !== "string" || code.length > 100 ||
+      !(Object.prototype.hasOwnProperty.call(MESSAGES, code) || validExitCode(code))) return;
+  if (error.diagnostic === undefined) return { code };
+  // A partial effect can never become a no-start/review/refresh authorization.
+  if (!validExitCode(code)) return;
+  const value = error.diagnostic;
+  if (!record(value) || value.schema !== "simplicio.desktop-install-diagnostic/v1" ||
+      value.status !== "partial" || !Array.isArray(value.failedSteps) ||
+      value.failedSteps.length > 128 || !Number.isInteger(value.unknownFailedSteps) ||
+      typeof value.unknownFailedSteps !== "number" || value.unknownFailedSteps < 0 ||
+      value.unknownFailedSteps > 128) return;
+  const steps = value.failedSteps.filter((step): step is string =>
+    typeof step === "string" && Object.prototype.hasOwnProperty.call(STEP_LABELS, step));
+  if (steps.length !== value.failedSteps.length || new Set(steps).size !== steps.length ||
+      steps.length + value.unknownFailedSteps < 1 || steps.length + value.unknownFailedSteps > 128) return;
+  return { code, diagnostic: { failedSteps: steps, unknownFailedSteps: value.unknownFailedSteps } };
+}
+
+/** Fixed labels only: diagnostic payload details never reach the UI. */
+export function installFailureMessage(error: unknown): string {
+  const message = baseFailureMessage(error);
+  const diagnostic = typedError(error)?.diagnostic;
+  if (!diagnostic) return message;
+  const labels = diagnostic.failedSteps.map((step) => STEP_LABELS[step]);
+  if (diagnostic.unknownFailedSteps > 0) labels.push(`${diagnostic.unknownFailedSteps} etapa(s) não identificada(s)`);
+  return `Etapas com falha: ${labels.join(", ")}. ${message}`;
 }

--- a/apps/desktop/src/runtime_failures.test.ts
+++ b/apps/desktop/src/runtime_failures.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { runtimeFailureMessage } from "./runtime_failures";
 
 describe("safe Runtime failure messages", () => {
+  it("explains auth-only compatibility without claiming account state or reflecting output", () => {
+    const unsupported = runtimeFailureMessage("runtime_auth_only_unsupported", "login");
+    expect(unsupported).toContain("Atualize o Simplicio Desktop");
+    expect(unsupported).toContain("Consulte o estado da conta");
+    expect(runtimeFailureMessage("runtime_auth_result_unconfirmed", "login")).toContain("não confirmou um login sem configuração automática");
+    expect(runtimeFailureMessage("runtime_auth_only_unsupported: SECRET", "login")).not.toContain("SECRET");
+  });
   it("distinguishes the native query deadline from the Desktop waiting deadline", () => {
     expect(runtimeFailureMessage("runtime_query_timeout")).toContain("20 segundos");
     expect(runtimeFailureMessage(new Error("desktop_snapshot_timeout"))).toContain("ainda pode estar concluindo");

--- a/apps/desktop/src/runtime_failures.ts
+++ b/apps/desktop/src/runtime_failures.ts
@@ -4,6 +4,8 @@ const REASONS: Readonly<Record<string, string>> = {
   runtime_not_started: "Não foi possível iniciar um comando do Simplicio Runtime.",
   runtime_query_timeout: "Uma etapa do Runtime ultrapassou o prazo de 20 segundos.",
   runtime_oauth_timeout: "O login ultrapassou o prazo de 3 minutos sem confirmação.",
+  runtime_auth_only_unsupported: "O Runtime não oferece login separado da instalação. Atualize o Simplicio Desktop para entrar com Google com segurança.",
+  runtime_auth_result_unconfirmed: "O Runtime não confirmou um login sem configuração automática.",
   runtime_install_timeout: "A instalação ultrapassou o prazo de 5 minutos sem confirmação. Não repita a instalação sem esclarecer o resultado.",
   runtime_stdout_limit: "A resposta do Runtime ultrapassou o limite permitido.",
   runtime_stderr_limit: "A saída de diagnóstico do Runtime ultrapassou o limite permitido.",

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.test.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.test.tsx
@@ -101,6 +101,12 @@ describe("reference settings route coverage", () => {
     expect(html).not.toMatch(/>Conta ativa<|>Autenticado<|>System default</);
   });
 
+  it.each([false, true])("does not expose hidden agent navigation from visible accounts (runtime=%s)", (runtime) => {
+    const html = markup("provider-accounts", snapshot(runtime));
+    expect(html).not.toContain("Ver agente e IDE");
+    expect(html).toContain("Abrir conta Simplicio");
+  });
+
   it("disables refresh while another root action owns its lock", () => {
     const html = renderToStaticMarkup(<ReferenceSettingsScreen view="voice" snapshot={snapshot()} onNavigate={() => {}} onRefresh={() => {}} busy />);
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*aria-label="Atualizar consulta do Runtime"/);

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
@@ -177,7 +177,7 @@ function Accounts({ evidence, onNavigate }: { evidence: Evidence; onNavigate: Na
       return <section className="ref-account-card" key={account.id}><div className="ref-account-heading"><span className={"ref-monogram ref-monogram-" + account.id}>{account.mark}</span><div><h2>{account.name}</h2><p>{account.description}</p></div></div>
         <Row title="Contas neste dispositivo" description="O inventário atual não informa contas gerenciadas deste provedor."><Unavailable label={"Adicionar conta " + account.name} reason="Gerenciamento de contas ainda indisponível." /></Row>
         <div className="ref-account-default"><div><strong>Autenticação no cliente</strong><p>Identidade e sessão não consultadas pelo Desktop.</p></div><Badge>Não verificada</Badge></div>
-        <div className="ref-account-evidence"><span>{provider ? providerStateLabels[provider.state] : "Cliente não informado nesta consulta"}</span><button type="button" className="text-button" onClick={() => onNavigate("agents")}>Ver agente e IDE</button></div>
+        <div className="ref-account-evidence"><span>{provider ? providerStateLabels[provider.state] : "Cliente não informado nesta consulta"}</span><LinkButton to="agents" onNavigate={onNavigate}>Ver agente e IDE</LinkButton></div>
       </section>;
     })}
     <Section title="Outros provedores" description="Integrações adicionais continuam pertencendo ao cliente de IA."><Row title="MiniMax e provedores personalizados" description="Cookies de sessão e chaves de API não são coletados nesta tela."><Unavailable label="Configurar provedor" reason="Falta um contrato seguro de autenticação." /></Row></Section>

--- a/docs/desktop/AUTH.md
+++ b/docs/desktop/AUTH.md
@@ -1,61 +1,63 @@
 # Desktop authentication contract
 
-The Google button invokes the native `desktop_login` IPC command, which runs
-`simplicio login google --json`. In the currently bundled Runtime this is a
-Runtime-owned device authorization flow: it opens the system browser and polls
-for the authorization result, using PKCE/state at the Runtime/service boundary.
-It is not an embedded Google login or a React deep-link callback flow.
+The Google button invokes the native `desktop_login` IPC command. Before any
+account effect, the Desktop runs `desktop status --json` on a Runtime candidate
+and requires `simplicio.desktop.app/v1`, action `status`, and
+`authentication: {schema: "simplicio.desktop-auth-capabilities/v1", authentication_only: true}`.
+Only that same candidate may then run `login google --authentication-only --json`.
 
-The Desktop never receives access or refresh tokens in a URL or React state.
-`src/auth.ts` contains a separately tested PKCE/callback utility, but it is not
-wired into the production login path and is not evidence that the Desktop itself
-performs the callback exchange.
+This is a Runtime-owned device authorization flow: it opens the system browser
+and polls for authorization, with PKCE/state at the Runtime/service boundary.
+It is not embedded Google login. Tokens never enter a URL or React state.
+`src/auth.ts` contains a separately tested callback utility, but is not wired
+into this production exchange.
+
+## Capability and effect boundary
+
+Only an unstarted read-only capability probe permits another Runtime candidate.
+A legacy/malformed response stops before login; a started probe failure, login
+failure or ambiguous result never retries another binary. Capability and final
+receipt parsing are bounded to 64 KiB and do not reflect raw output to the UI.
+The last non-empty JSONL event must be `simplicio.auth-login/v1`, status
+`authenticated`, with bootstrap `skipped` and reason `authentication_only`.
+The fresh authoritative snapshot still determines account access.
+
+Runtime 3.8.39 does not support this contract and is refused before Google login.
+A new release must bundle the verified compatible Runtime and recheck its
+identity and capability after packaging; a source merge alone is insufficient.
+In the compatible Runtime, the authentication-only flag skips bootstrap for both
+new and existing sessions. Normal CLI login retains its Full/Mapper behavior.
+No provider failure or fake inactive entitlement is used to suppress bootstrap.
 
 ## Account states and recovery
 
-1. Startup requests the Runtime's versioned Desktop snapshot. A canonical
-   `signed_out` state presents the welcome/Google entry screens.
-2. Explicit login starts one account action. The native process is bounded to
-   three minutes; React does not time it out independently or retry it.
-3. Only a fresh authoritative `active` snapshot opens guided installation.
-   If the first result is `unknown`, a later successful **Tentar novamente**
-   verification resumes that installation screen without another OAuth attempt.
-4. An error from login or logout may occur after the account action completed,
-   during its following snapshot query. The UI therefore switches to the
-   `unknown` gate rather than reusing a stale signed-out/active snapshot.
-   Refresh is read-only; it does not repeat login, logout or installation.
-5. `inactive` and `unknown` never grant access. A provider/network failure is
-   not interpreted as an inactive subscription.
+1. Startup requests the Runtime's versioned Desktop snapshot. Canonical
+   `signed_out` presents the welcome/Google screens.
+2. Explicit login starts one account action; native capture bounds it to three
+   minutes. React does not independently time out or repeat the operation.
+3. Only a fresh `active` snapshot opens guided setup. If the initial result is
+   `unknown`, successful read-only **Tentar novamente** verification resumes
+   setup without another OAuth attempt.
+4. A login/logout error can happen after its effect but during the next snapshot.
+   The UI therefore invalidates stale account state and uses the `unknown` gate.
+   Refresh does not repeat login, logout or installation.
+5. `inactive` and `unknown` never grant access; provider/network errors are not
+   interpreted as an inactive subscription.
 
-Logout is available in account settings and the access-recovery gate. It invokes
-`logout --json`, then requests a new snapshot. The Runtime removes its local
-login file and **attempts** remote revocation; its `remote_revoke` result can be
-`unverified`, so local logout must not be described as confirmed server-side
-revocation. Project files and saved project shortcuts are not deleted.
+Logout remains available in account settings and the recovery gate. It invokes
+`logout --json`, then queries a fresh snapshot. The Runtime removes local login
+and attempts remote revocation; `remote_revoke: unverified` is not confirmed
+server revocation. Project files and saved project shortcuts are preserved.
 
-## Native compatibility and consent boundary
-
-The bundled Runtime source at release commit
-`d91aa04b39ab33c252c628fab6806bf8ea2c39a8` calls
-`bootstrap_apply::after_authentication` after a successful login. That path
-defaults to the recommended CLI profile and can install the CLI and persist
-bootstrap state before the Desktop's separate integration-plan consent screen.
-It does not honor `SIMPLICIO_DESKTOP_BRIDGE` as a bootstrap opt-out.
-
-Consequently, mocked Desktop tests proving that the UI never calls
-`desktop_repair_providers` without consent do **not** prove that this Runtime
-login has no bootstrap effects. A Runtime-supported authentication-only mode
-and a verified compatible bundle are required before making that stronger
-claim. Do not fake an inactive entitlement to suppress bootstrap.
-
-`SIMPLICIO_AUTH_FILE` isolates the Runtime login file for QA, but
-`SIMPLICIO_HOME` does not isolate all bootstrap paths in this Runtime release.
-Do not conduct a supposedly isolated live login with only those settings.
+Installation remains a separate reviewed-plan and explicit-consent action.
+Authentication-only does not install a CLI, MCP registration, hook or plugin.
 
 ## Verification boundaries
 
-The account-effect Playwright tests exercise real UI transitions with mocked
-Tauri IPC, including OAuth/snapshot failure, later verification, and logout
-recovery. They are not a fresh Google grant, live remote revocation or global
-installation test. Native signed-out projection is checked independently with
-an absent isolated login file; no real user session is revoked by that check.
+Native protocol tests use injected subprocess responses, while Playwright tests
+use mocked Tauri IPC. They prove argument selection, no unsafe fallback, account
+state recovery and consent boundaries; they are not a fresh Google grant,
+remote revocation, global installation or live client handshake.
+
+`SIMPLICIO_AUTH_FILE` isolates a QA login file, not every Runtime/bootstrap path.
+Do not treat that variable or `SIMPLICIO_HOME` alone as a host-isolation sandbox.

--- a/docs/desktop/LOGIN-INSTALL-VALIDATION.md
+++ b/docs/desktop/LOGIN-INSTALL-VALIDATION.md
@@ -22,11 +22,18 @@ Regression tests were run failing before these fixes, then passing. The review p
 | Live MCP connection | Shown separately from detection and registration | Requires a current handshake from each client |
 | Models/provider subscriptions | Remain owned by the chosen host/provider | Simplicio login is not a model-provider login |
 
-The CLI install actions were inspected read-only at the published Runtime source. No real host configurations, credentials or subscriptions were changed for this audit.
+The initial source inspection was read-only. During the later native QA session,
+the local install manifest recorded an attempted global install at
+`2026-08-31T19:08:58.548Z`: Runtime binary copy and Codex/route-hook writes with
+backups were confirmed, followed by exit code 1. The UI had observed consent,
+but the exact initiating interaction was not established. The failing action was
+not persisted; Hermes is a source-supported hypothesis, not a confirmed cause.
+No automatic retry, rollback, credential removal or lock clearing was performed.
+This corrects the initial audit's overly broad no-host-effects statement.
 
 ## Remaining acceptance blockers
 
-1. **Authentication-only mode:** the exact published Runtime commit `d91aa04b39ab33c252c628fab6806bf8ea2c39a8` calls `bootstrap_apply::after_authentication` after Google. It has no supported bootstrap opt-out, including through `desktop login` or `auth login`. Isolating the login file alone does not isolate the bootstrap. See [AUTH.md](AUTH.md). A new compatible signed Runtime is required before claiming no installation effects before the Desktop consent screen.
+1. **Compatible published Runtime:** the exact previously published Runtime commit `d91aa04b39ab33c252c628fab6806bf8ea2c39a8` calls `bootstrap_apply::after_authentication` after Google. It has no supported bootstrap opt-out, including through `desktop login` or `auth login`. Isolating the login file alone does not isolate the bootstrap. See [AUTH.md](AUTH.md). A new compatible signed Runtime is required before claiming no installation effects before the Desktop consent screen.
 2. **Plugin parity:** the current native installer does not install all host marketplace plugins. `simplicio plugin install` targets the Runtime's internal registry, not Codex/Claude/Gemini/Hermes host managers. The safe next implementation is Runtime-owned per-host plan/apply/verify with immutable payload digests, detected executable/version, reviewed destinations, backups and bounded per-host receipts. The Desktop and terminal wrappers should consume that same contract.
 3. **Real platform acceptance:** new Google authorization, remote revocation, full clean installation and live handshakes were not performed. Windows/Linux/macOS Intel installed acceptance remains separate; local macOS ad-hoc signing is not notarization.
 
@@ -46,3 +53,47 @@ Prism/Loop skills guided survey, independent slots, regression/fix and review. T
 ## References consulted
 
 [Orca installation](https://www.onorca.dev/docs/install) separates first-launch detection/import and permission choices. [Buzz getting started](https://github.com/block/buzz#getting-started) distinguishes the packaged client from backend readiness. These inform the onboarding structure; neither proves Simplicio authentication or integration correctness.
+
+
+## Follow-up corrections (source, 2026-08-31)
+
+- The Desktop now negotiates authentication-only capability with one selected
+  Runtime before Google, validates the terminal receipt, and refuses legacy
+  Runtime login before account effects. See [AUTH.md](AUTH.md).
+- The companion Runtime change skips bootstrap for new and existing sessions
+  only under an explicit validated flag. The auth harness passed 74 tests,
+  including a regression shown to fail on the original source.
+- Hidden-navigation policy also covers the indirect Accounts link and the
+  390px drawer/search; 71 screen-unit and 3 hidden-navigation E2E tests passed.
+- Partial installation failures now carry a bounded closed diagnostic of failed
+  steps, excluding raw output, paths, credentials and unknown action names.
+  A nonzero exit still fails and retains the reconciliation lock.
+- The Prism/Loop decision recommended this follow-up route (`use_loop: true`,
+  report `run-1788204184-f863575d`). Execution used four available agent slots
+  in bounded waves, governed edits and separately recorded test receipts.
+  This supersedes only the prior paragraph's routing observation, not its tests.
+
+These source changes do not certify a newly published or installed package.
+Fresh Google authorization, remote revocation, clean platform installation,
+per-host package installation and live MCP handshakes remain separate acceptance
+steps. The package/plugin parity gap above remains open; no consent is implied
+by hiding navigation entries or authenticating the account.
+
+
+### Follow-up verification results
+
+- Full Vitest: 353 passed; TypeScript and Vite production build passed.
+- Native Desktop Rust: 129 passed, 2 existing ignored, release profile,
+  locked/offline with one build job.
+- Public installer contract fixtures: 23 passed; these do not install clients.
+- Companion atomic-binary helper: 10 isolated tests passed after RED/repair.
+  It retains backups, preserves open inodes, checks installed/backup SHA-256
+  before binary rollback, and rejects missing/stale manifest evidence.
+  This is not a crash-durable transaction or global concurrent-update CAS.
+- Full Playwright: 114 passed. Two legacy test fixtures lacked Tauri's event
+  unregister interface; page-error assertions reproduced four failures and
+  the fixtures were corrected without suppressing production errors.
+
+The previous source-only and native-session observations are kept above as
+history. No additional real global install, rollback, logout or Google grant was
+performed during this follow-up's source/fixture verification.

--- a/docs/desktop/RELEASE.md
+++ b/docs/desktop/RELEASE.md
@@ -54,3 +54,21 @@ the Runtime's public signature or provenance to accept a bundler-modified binary
 Any required change to the Runtime's platform signature belongs in a new signed
 Runtime release, not an invisible Desktop packaging rewrite. Ad-hoc signing is
 not Developer ID signing or Apple notarization.
+
+
+## Authentication-only release gate
+
+This Desktop source requires the authentication capability in [AUTH.md](AUTH.md).
+Before publication, run the exact final sidecar's `desktop status --json` on each
+available native executor and require root schema `simplicio.desktop.app/v1`,
+`action: status`, authentication schema `simplicio.desktop-auth-capabilities/v1`
+and boolean `authentication_only: true`. Do not initiate Google to test the probe.
+Runtime 3.8.39 is not compatible with this login path. A cross-compiled artifact
+without native execution evidence must be reported as unexecuted, not passed.
+
+After the probe and identity/signature verification, a separately authorized
+account acceptance run must confirm `login google --authentication-only --json`
+returns terminal `simplicio.auth-login/v1`, status `authenticated`, and bootstrap
+`skipped/authentication_only`, without new install/bootstrap effects. This check
+does not itself certify a fresh Google grant, remote revocation, package-manager
+plugins or every client's live MCP connection.


### PR DESCRIPTION
## Summary

- Enforce the requested hidden navigation policy on the Accounts shortcut, narrow drawer and search.
- Keep the white borderless login and accessible Google focus target; negotiate Runtime authentication-only capability before account effects.
- Use one verified Runtime candidate, require the terminal auth-only receipt, and never fall back/retry another binary after the probe.
- Surface bounded, sanitized per-step installation failures without clearing the reconciliation lock.
- Preserve logout/recovery and Check for Updates during signed-out, unknown and guided-setup states.
- Correct the native-session audit and document the compatible Runtime release gate and remaining host-plugin acceptance boundary.

## Verification

- 353 Vitest tests; TypeScript/Vite production build.
- 129 native Desktop Rust tests passed, 2 existing ignored (release profile, locked/offline, one build job).
- 23 public installer contract tests.
- 114 Playwright scenarios, including narrow navigation, login/recovery, installation diagnostics and updates. Page-error guards exposed and fixed incomplete Tauri event mocks in two older fixtures; no production error was suppressed.
- Independent auth/installation review and `git diff --check`.
- No GitHub Actions, real Google grant, logout, global installation or live host mutation in this follow-up.

## Release boundary

Companion Runtime change: wesleysimplicio/simplicio-runtime#5260. This Desktop must bundle the exact verified compatible Runtime 3.8.40 before release; 3.8.39 is refused before Google login. Source/tests are not published/installed acceptance. Marketplace packages for all hosts still need the separately reviewed native package plan; MCP registration is not advertised as plugin installation.

