### PR TITLE
fix(plugin): align Gemini manifest version

### DIFF
--- a/plugins/simplicio/gemini-extension.json
+++ b/plugins/simplicio/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Verified Simplicio Runtime MCP bootstrap and governed coding skills for Gemini CLI.",
   "mcpServers": {
     "simplicio-runtime": {

--- a/tests/unit/test_plugin_marketplace.py
+++ b/tests/unit/test_plugin_marketplace.py
@@ -89,7 +89,7 @@ def test_simplicio_plugin_manifests_share_one_version() -> None:
         _load_json("plugins/simplicio/gemini-extension.json"),
     ]
 
-    assert {manifest["version"] for manifest in manifests} == {"0.2.4"}
+    assert {manifest["version"] for manifest in manifests} == {"0.2.5"}
 
 
 def test_host_surface_registry_is_complete_and_honest() -> None:


### PR DESCRIPTION
## Resultado

- alinha `gemini-extension.json` à versão `0.2.5` já usada pelos manifestos Codex, Claude e portable;
- atualiza a asserção de paridade para impedir nova divergência;
- prepara um payload público consistente para o bundle imutável do Runtime.

## Validação

- `python3 -m pytest tests/unit/test_plugin_marketplace.py -q` — 8 passed
- `git diff --check` — pass

Release manual; nenhuma GitHub Action é usada.
