### PR TITLE
fix(installer): preserve consent and exact failure receipts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,15 +40,33 @@ the signed SHA256/Ed25519 Runtime release, and installs the platform binary.
 If the Python script directory is not already on `PATH`, add it before running
 `simplicio install`.
 
-After the Runtime registers MCP/hooks for every detected client, both direct
-installers reconcile every compatible host package. Claude Code, GitHub Copilot
-CLI, and Qwen Code receive all published marketplace plugins (`simplicio`, Loop,
-Prompt, Sprint, and Hermes). Codex and Gemini receive their native package,
-Cursor and Kiro receive the portable Agent Plugin, and Hermes receives the
-enabled native Python plugin with `pre_llm_call` and `post_llm_call` hooks.
-Hosts without a package API remain on the verified Runtime MCP integration. Set
-`SIMPLICIO_INSTALL_HOST_PLUGINS=0` only in managed/bootstrap environments that
-already installed the packages.
+The direct installers install the verified Runtime, register MCP/hooks and then
+stop before changing any host plugin. They capability-check
+`simplicio host-plugins --help`: the structured receipt records
+`host_plugins.state=pending_consent` only when that Runtime command is available,
+and otherwise records `host_plugins.state=unavailable` with no apply command.
+Availability requires the versioned `simplicio.host-plugins/cli-v1` marker and
+the essential plan/apply/pending/reconcile commands; exit code zero, empty output
+or unrelated Runtime help never enables host-plugin installation.
+Review the separate host-plugin plan with
+`simplicio host-plugins plan --all`; only the Runtime may apply or reconcile
+that plan after explicit user consent. The installers never invoke Codex, Claude,
+Gemini, Copilot, Qwen, Hermes, Cursor or Kiro plugin commands, and never fetch a
+mutable source-branch archive for plugin installation.
+
+The durable receipt is written atomically to
+`~/.simplicio/install-receipt.json` (or the configured
+`SIMPLICIO_BUNDLE_DIR`). An exit code `1` after a possible effect records
+`status=partial`, the exact stage, failure code and failure reason so the next
+run can diagnose the original cause instead of collapsing it into a generic
+installer error. For Runtime commands, the installers prefer the structured
+JSON `failure.code`/`failure.reason` (with `code`, `message` and `error`
+fallbacks); non-JSON output is retained only as a bounded diagnostic.
+
+Binary rollback covers download verification and the atomic Runtime activation.
+Once the verified binary is activated, that rollback transaction is closed;
+later MCP, hook, report or receipt failures are recorded as `status=partial`
+with their concrete cause and do not claim a full installation rollback.
 
 Known installer incidents and regression sentinels are tracked in
 [docs/INSTALL_ERROR_REGISTRY.md](docs/INSTALL_ERROR_REGISTRY.md).

--- a/install.ps1
+++ b/install.ps1
@@ -16,8 +16,10 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - Runtime report directory (default: ~/.simplicio)
-#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected host plugins
-#                                    (default: install every compatible package)
+#
+# Host plugins are deliberately outside this installer transaction. The
+# Runtime/MCP/hook install completes first; a separate explicit consent flow
+# owned by `simplicio host-plugins` may be started afterwards.
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem) — target "windows-x64", asset
@@ -37,17 +39,23 @@ $ErrorActionPreference = "Stop"
 
 $Repo = "wesleysimplicio/simplicio"
 $BinName = "simplicio.exe"
-$MarketplacePlugins = @("simplicio", "simplicio-loop", "simplicio-prompt", "simplicio-sprint", "simplicio-hermes")
 $Target = "windows-x64"
 $Asset = "simplicio-windows-x64.exe"
 $Ed25519PublicKey = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 $Ed25519HelperUrl = "https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/scripts/verify_ed25519.py"
 $Ed25519HelperSha256 = "f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
-$PublicRouteRef = "cc9950025baf823cdecc657228ff1e89d7701e7e"
+$PublicRouteRef = "68b4c7f7ac27d07624ffa4ddf0673a43e180c3e5"
 $PublicRouteUrl = "https://raw.githubusercontent.com/$Repo/$PublicRouteRef/codex/mcp-route.ps1"
-$PublicRouteSha256 = "fea2b06c95c9f75bf17fc46b603c8e3817aa6f680af468fa73c066210970c89c"
+$PublicRouteSha256 = "022de213e2b69eda16c89ff3298bc8dd2e0c82ffdfb351665eada46fb83af03c"
 $PinnedPublicKey = ([string]$Ed25519PublicKey).Trim()
 $script:Ed25519VerifyError = ""
+$script:McpFailureCode = ""
+$script:McpFailureReason = ""
+$script:HostPluginsState = "unavailable"
+$script:HostPluginsCommand = $null
+$script:HostPluginsReason = "Runtime host-plugins capability was not checked"
+$script:HookFailureCode = ""
+$script:HookFailureReason = ""
 $SimplicioMcpUrl = if ($env:SIMPLICIO_MCP_URL) { $env:SIMPLICIO_MCP_URL } else { "http://127.0.0.1:8787/mcp" }
 
 if ($env:SIMPLICIO_BIN_DIR) {
@@ -60,7 +68,143 @@ $InstallTransactionActive = $false
 $PreviousPath = ""
 $PurgeDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
 $AuthFile = Join-Path $PurgeDir "login.json"
+$InstallReceipt = Join-Path $PurgeDir "install-receipt.json"
+$script:InstallStage = "preflight"
+$script:InstallEffectStarted = $false
+$script:RuntimeInstalled = $false
+$script:McpRegistered = $false
+$script:HookInstalled = $false
 $AuthFileWasPresent = Test-Path $AuthFile
+
+function New-InstallReceipt(
+  [string]$Status,
+  [int]$ExitCode,
+  [string]$FailureCode,
+  [string]$FailureReason
+) {
+  $failure = $null
+  if (-not [string]::IsNullOrWhiteSpace($FailureCode)) {
+    $failure = [ordered]@{
+      code = $FailureCode
+      reason = $FailureReason
+    }
+  }
+  return [ordered]@{
+    schema = "simplicio-install-receipt/v1"
+    status = $Status
+    exit_code = $ExitCode
+    stage = $script:InstallStage
+    failure = $failure
+    runtime = [ordered]@{ installed = [bool]$script:RuntimeInstalled }
+    mcp = [ordered]@{ registered = [bool]$script:McpRegistered }
+    hook = [ordered]@{ installed = [bool]$script:HookInstalled }
+    host_plugins = [ordered]@{
+      state = $script:HostPluginsState
+      owner = "simplicio-runtime"
+      command = $script:HostPluginsCommand
+      mutated = $false
+      reason = $script:HostPluginsReason
+    }
+  }
+}
+
+function Protect-InstallReceipt([string]$Path) {
+  if ($env:OS -eq "Windows_NT") {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $acl = Get-Acl -Path $Path
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($rule in @($acl.Access)) {
+      [void]$acl.RemoveAccessRuleSpecific($rule)
+    }
+    $ownerRule = New-Object Security.AccessControl.FileSystemAccessRule(
+      $identity.User,
+      [Security.AccessControl.FileSystemRights]::FullControl,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+    $acl.SetAccessRule($ownerRule)
+    Set-Acl -Path $Path -AclObject $acl
+    return
+  }
+  & chmod 600 $Path
+  if ($LASTEXITCODE -ne 0) { throw "Could not set private mode 0600 on $Path" }
+}
+
+function Save-InstallReceipt(
+  [string]$Status,
+  [int]$ExitCode,
+  [string]$FailureCode,
+  [string]$FailureReason
+) {
+    New-Item -ItemType Directory -Force -Path $PurgeDir | Out-Null
+    $receiptTemp = "$InstallReceipt.tmp.$PID"
+    $receiptBackup = $null
+    $receiptActivated = $false
+    try {
+    $json = New-InstallReceipt $Status $ExitCode $FailureCode $FailureReason |
+      ConvertTo-Json -Depth 6 -Compress
+      [IO.File]::WriteAllText(
+      $receiptTemp,
+      $json + [Environment]::NewLine,
+        [Text.UTF8Encoding]::new($false)
+      )
+      # The candidate must already be private before it can become the active
+      # receipt. Keep any previous receipt as a rollback source until the
+      # active path has also passed the ACL check.
+      Protect-InstallReceipt $receiptTemp
+      if (Test-Path $InstallReceipt) {
+        $receiptBackup = "$InstallReceipt.backup.$PID"
+        Remove-Item -Force $receiptBackup -ErrorAction SilentlyContinue
+        [IO.File]::Replace($receiptTemp, $InstallReceipt, $receiptBackup, $true)
+      } else {
+        [IO.File]::Move($receiptTemp, $InstallReceipt)
+      }
+      $receiptActivated = $true
+      Protect-InstallReceipt $InstallReceipt
+      if ($receiptBackup -and (Test-Path $receiptBackup)) {
+        Remove-Item -Force $receiptBackup -ErrorAction Stop
+      }
+      return $json
+    } catch {
+      $receiptFailure = $_.Exception
+      if (Test-Path $receiptTemp) {
+        Remove-Item -Force $receiptTemp -ErrorAction SilentlyContinue
+      }
+      if ($receiptBackup -and (Test-Path $receiptBackup)) {
+        try {
+          if (Test-Path $InstallReceipt) {
+            Remove-Item -Force $InstallReceipt -ErrorAction Stop
+          }
+          [IO.File]::Move($receiptBackup, $InstallReceipt)
+        } catch {
+          throw "Receipt protection failed ($($receiptFailure.Message)); prior receipt restoration also failed ($($_.Exception.Message)); backup retained at $receiptBackup"
+        }
+      } elseif ($receiptActivated -and (Test-Path $InstallReceipt)) {
+        Remove-Item -Force $InstallReceipt -ErrorAction SilentlyContinue
+      }
+      throw $receiptFailure
+    }
+}
+
+function Fail-Install(
+  [string]$FailureReason,
+  [string]$FailureCode = ""
+) {
+  $resolvedFailureCode = if ([string]::IsNullOrWhiteSpace($FailureCode)) {
+    "$($script:InstallStage)_failed"
+  } else {
+    $FailureCode
+  }
+  $status = if ($script:InstallEffectStarted) { "partial" } else { "failed" }
+  try {
+    [void](Save-InstallReceipt $status 1 $resolvedFailureCode $FailureReason)
+  } catch {
+    $fallback = New-InstallReceipt $status 1 $resolvedFailureCode $FailureReason |
+      ConvertTo-Json -Depth 6 -Compress
+    [Console]::Error.WriteLine($fallback)
+  }
+  [Console]::Error.WriteLine("  [FAIL] $FailureReason")
+  exit 1
+}
 
 function Invoke-Rollback {
   if ($InstallTransactionActive) {
@@ -163,21 +307,25 @@ function Test-RuntimeReleaseContract([string]$BinaryPath) {
 function Test-ActiveLogin {
   if (-not (Test-Path $DestPath)) { return $false }
   try {
-    $raw = & $DestPath auth status --json 2>$null | Out-String
-    if ($LASTEXITCODE -ne 0) { return $false }
-    $status = $raw | ConvertFrom-Json
+    $result = Invoke-BoundedNativeCommand $DestPath @("auth", "status", "--json")
+    if ($result.ExitCode -ne 0) { return $false }
+    $status = $result.Stdout | ConvertFrom-Json
     $identity = $status.identity
-    if ($null -eq $identity) { return $false }
+    $entitlement = $status.entitlement
+    $sessionVerification = $status.session_verification
+    if ($null -eq $identity -or $null -eq $entitlement -or $null -eq $sessionVerification) {
+      return $false
+    }
     $identityEmail = if ($null -ne $identity.email) { $identity.email } else { $status.user.email }
     $active = (
       $identity.enabled -eq $true -and
       $identity.login_enabled -eq $true -and
-      $identity.status -notin @("disabled", "logged_out", "revoked") -and
-      -not [string]::IsNullOrWhiteSpace([string]$identityEmail)
+      $identity.status -eq "active" -and
+      -not [string]::IsNullOrWhiteSpace([string]$identityEmail) -and
+      $entitlement.updates_allowed -eq $true -and
+      $sessionVerification.verified -eq $true -and
+      $sessionVerification.cached -eq $false
     )
-    if ($null -ne $status.entitlement -and $null -ne $status.entitlement.updates_allowed) {
-      $active = $active -and ($status.entitlement.updates_allowed -eq $true)
-    }
     return [bool]$active
   } catch {
     return $false
@@ -186,239 +334,346 @@ function Test-ActiveLogin {
 
 function Report-LoginState {
   if (Test-ActiveLogin) {
-    Write-Host "  ✓ active Google session and entitlement verified"
+    Write-Host "  ✓ fresh Google session and entitlement verified"
     return
   }
-  Write-Warning "Google login missing or entitlement inactive; run: `"$DestPath`" auth login"
+  Write-Warning "Google session is not freshly verified (missing, cached, or inactive entitlement); run: `"$DestPath`" auth login"
+}
+
+function Get-ObjectPropertyValue([object]$Object, [string]$Name) {
+  if ($null -eq $Object) { return $null }
+  $property = $Object.PSObject.Properties[$Name]
+  if ($null -eq $property) { return $null }
+  return $property.Value
+}
+
+function Convert-ToFailureText([object]$Value) {
+  if ($null -eq $Value) { return "" }
+  if ($Value -is [string]) { return $Value }
+  if ($Value -is [System.Collections.IDictionary] -or $Value -is [System.Collections.IList]) {
+    return ""
+  }
+  return [string]$Value
+}
+
+function Limit-FailureText([string]$Text, [int]$Limit = 8192) {
+  $bytes = [Text.Encoding]::UTF8.GetBytes($Text)
+  if ($bytes.Length -le $Limit) { return $Text }
+  return [Text.Encoding]::UTF8.GetString($bytes, 0, $Limit) +
+    "`n...[output truncated at 8192 bytes]"
+}
+
+function Resolve-RuntimeFailure(
+  [string]$Stdout,
+  [string]$Stderr,
+  [int]$ExitCode
+) {
+  $payload = $null
+  $candidates = @()
+  if (-not [string]::IsNullOrWhiteSpace($Stdout)) {
+    $candidates += $Stdout.Trim()
+    $lines = @($Stdout -split "`r?`n")
+    [array]::Reverse($lines)
+    $candidates += @($lines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  }
+  foreach ($candidate in $candidates) {
+    try {
+      $decoded = $candidate | ConvertFrom-Json -ErrorAction Stop
+      if ($null -ne $decoded -and $null -ne $decoded.PSObject) {
+        $payload = $decoded
+        break
+      }
+    } catch {
+      continue
+    }
+  }
+
+  $failure = Get-ObjectPropertyValue $payload "failure"
+  $errorValue = Get-ObjectPropertyValue $payload "error"
+  $code = Convert-ToFailureText (Get-ObjectPropertyValue $failure "code")
+  if ([string]::IsNullOrWhiteSpace($code)) {
+    $code = Convert-ToFailureText (Get-ObjectPropertyValue $payload "code")
+  }
+  if ([string]::IsNullOrWhiteSpace($code)) {
+    $code = Convert-ToFailureText (Get-ObjectPropertyValue $payload "error_code")
+  }
+  if ([string]::IsNullOrWhiteSpace($code)) {
+    $code = Convert-ToFailureText (Get-ObjectPropertyValue $errorValue "code")
+  }
+  if ([string]::IsNullOrWhiteSpace($code)) { $code = "mcp_registration_failed" }
+
+  $reason = Convert-ToFailureText (Get-ObjectPropertyValue $failure "reason")
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $reason = Convert-ToFailureText (Get-ObjectPropertyValue $payload "reason")
+  }
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $reason = Convert-ToFailureText (Get-ObjectPropertyValue $payload "message")
+  }
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $reason = Convert-ToFailureText (Get-ObjectPropertyValue $errorValue "reason")
+  }
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $reason = Convert-ToFailureText (Get-ObjectPropertyValue $errorValue "message")
+  }
+  if ([string]::IsNullOrWhiteSpace($reason) -and $errorValue -is [string]) {
+    $reason = $errorValue
+  }
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $fallback = @()
+    if (-not [string]::IsNullOrWhiteSpace($Stderr)) { $fallback += $Stderr.Trim() }
+    if (-not [string]::IsNullOrWhiteSpace($Stdout) -and $Stdout.Trim() -notin $fallback) {
+      $fallback += $Stdout.Trim()
+    }
+    $reason = $fallback -join "`n"
+  }
+  if ([string]::IsNullOrWhiteSpace($reason)) {
+    $reason = "Runtime MCP registration failed with exit code $ExitCode"
+  }
+
+  return [pscustomobject]@{
+    Code = Limit-FailureText $code
+    Reason = Limit-FailureText $reason
+  }
+}
+
+function Convert-ToProcessArgument([string]$Argument) {
+  if ($Argument.Length -eq 0) { return '""' }
+  if ($Argument -notmatch '[\s"]') { return $Argument }
+  $builder = New-Object Text.StringBuilder
+  [void]$builder.Append('"')
+  $backslashes = 0
+  foreach ($character in $Argument.ToCharArray()) {
+    if ($character -eq '\') {
+      $backslashes += 1
+      continue
+    }
+    if ($character -eq '"') {
+      if ($backslashes -gt 0) { [void]$builder.Append(('\' * ($backslashes * 2))) }
+      [void]$builder.Append('\"')
+      $backslashes = 0
+      continue
+    }
+    if ($backslashes -gt 0) { [void]$builder.Append(('\' * $backslashes)) }
+    [void]$builder.Append($character)
+    $backslashes = 0
+  }
+  if ($backslashes -gt 0) { [void]$builder.Append(('\' * ($backslashes * 2))) }
+  [void]$builder.Append('"')
+  return $builder.ToString()
+}
+
+function Invoke-BoundedNativeCommand(
+  [string]$FilePath,
+  [string[]]$Arguments,
+  [hashtable]$Environment = @{},
+  [int]$Limit = 8192
+) {
+  $startInfo = New-Object Diagnostics.ProcessStartInfo
+  $startInfo.FileName = $FilePath
+  $startInfo.UseShellExecute = $false
+  $startInfo.CreateNoWindow = $true
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  if ($startInfo.PSObject.Properties.Name -contains "ArgumentList") {
+    foreach ($argument in $Arguments) { [void]$startInfo.ArgumentList.Add($argument) }
+  } else {
+    $startInfo.Arguments = (($Arguments | ForEach-Object { Convert-ToProcessArgument $_ }) -join " ")
+  }
+  foreach ($name in $Environment.Keys) {
+    $startInfo.EnvironmentVariables[[string]$name] = [string]$Environment[$name]
+  }
+
+  $process = New-Object Diagnostics.Process
+  $process.StartInfo = $startInfo
+  $stdout = New-Object IO.MemoryStream
+  $stderr = New-Object IO.MemoryStream
+  $stdoutTruncated = $false
+  $stderrTruncated = $false
+  try {
+    if (-not $process.Start()) { throw "Could not start $FilePath" }
+    $stdoutBuffer = New-Object byte[] 4096
+    $stderrBuffer = New-Object byte[] 4096
+    $stdoutTask = $process.StandardOutput.BaseStream.ReadAsync($stdoutBuffer, 0, $stdoutBuffer.Length)
+    $stderrTask = $process.StandardError.BaseStream.ReadAsync($stderrBuffer, 0, $stderrBuffer.Length)
+    while ($null -ne $stdoutTask -or $null -ne $stderrTask) {
+      $tasks = New-Object 'System.Collections.Generic.List[System.Threading.Tasks.Task]'
+      if ($null -ne $stdoutTask) { [void]$tasks.Add($stdoutTask) }
+      if ($null -ne $stderrTask) { [void]$tasks.Add($stderrTask) }
+      $completedIndex = [Threading.Tasks.Task]::WaitAny($tasks.ToArray())
+      $completed = $tasks[$completedIndex]
+      if ($null -ne $stdoutTask -and [object]::ReferenceEquals($completed, $stdoutTask)) {
+        $count = $stdoutTask.Result
+        if ($count -eq 0) {
+          $stdoutTask = $null
+        } else {
+          $remaining = [Math]::Max(0, $Limit - [int]$stdout.Length)
+          $kept = [Math]::Min($remaining, $count)
+          if ($kept -gt 0) { $stdout.Write($stdoutBuffer, 0, $kept) }
+          if ($count -gt $kept) { $stdoutTruncated = $true }
+          $stdoutTask = $process.StandardOutput.BaseStream.ReadAsync($stdoutBuffer, 0, $stdoutBuffer.Length)
+        }
+      } elseif ($null -ne $stderrTask) {
+        $count = $stderrTask.Result
+        if ($count -eq 0) {
+          $stderrTask = $null
+        } else {
+          $remaining = [Math]::Max(0, $Limit - [int]$stderr.Length)
+          $kept = [Math]::Min($remaining, $count)
+          if ($kept -gt 0) { $stderr.Write($stderrBuffer, 0, $kept) }
+          if ($count -gt $kept) { $stderrTruncated = $true }
+          $stderrTask = $process.StandardError.BaseStream.ReadAsync($stderrBuffer, 0, $stderrBuffer.Length)
+        }
+      }
+    }
+    $process.WaitForExit()
+    $stdoutText = [Text.Encoding]::UTF8.GetString($stdout.ToArray())
+    $stderrText = [Text.Encoding]::UTF8.GetString($stderr.ToArray())
+    if ($stdoutTruncated) { $stdoutText += "`n...[output truncated at 8192 bytes]" }
+    if ($stderrTruncated) { $stderrText += "`n...[output truncated at 8192 bytes]" }
+    return [pscustomobject]@{
+      ExitCode = $process.ExitCode
+      Stdout = $stdoutText
+      Stderr = $stderrText
+      StdoutBytesStored = $stdout.Length
+      StderrBytesStored = $stderr.Length
+    }
+  } finally {
+    $stdout.Dispose()
+    $stderr.Dispose()
+    $process.Dispose()
+  }
 }
 
 function Test-McpToolSurface([string]$BinaryPath) {
-  if (-not (Test-Path $BinaryPath)) { return $false }
-  try {
-    $env:SIMPLICIO_MCP_URL = $SimplicioMcpUrl
-    & $BinaryPath mcp register --binary $BinaryPath --json | Out-Null
-    return ($LASTEXITCODE -eq 0)
-  } catch {
+  $script:McpFailureCode = ""
+  $script:McpFailureReason = ""
+  if (-not (Test-Path $BinaryPath)) {
+    $script:McpFailureCode = "mcp_binary_missing"
+    $script:McpFailureReason = "Runtime binary is missing: $BinaryPath"
     return $false
   }
-}
-
-function Invoke-NativeHostCommand([string]$Command, [string[]]$Arguments) {
   try {
-    & $Command @Arguments *> $null
-    return ($LASTEXITCODE -eq 0)
+      # Runtime argv contract: mcp register --binary $BinaryPath --json
+      $result = Invoke-BoundedNativeCommand `
+      $BinaryPath `
+      @("mcp", "register", "--binary", $BinaryPath, "--json") `
+      @{ SIMPLICIO_MCP_URL = $SimplicioMcpUrl }
+    if ($result.ExitCode -eq 0) { return $true }
+    $failure = Resolve-RuntimeFailure `
+      $result.Stdout `
+      $result.Stderr `
+      $result.ExitCode
+    $script:McpFailureCode = $failure.Code
+    $script:McpFailureReason = $failure.Reason
+    return $false
   } catch {
+    $script:McpFailureCode = "mcp_registration_failed"
+    $script:McpFailureReason = Limit-FailureText $_.Exception.Message
     return $false
   }
 }
 
 function Sync-PublicRouteOverlay {
+  $script:HookFailureCode = ""
+  $script:HookFailureReason = ""
   $hookDir = Join-Path $PurgeDir "hooks"
   $hookPath = Join-Path $hookDir "mcp-route.ps1"
-  if (Test-Path $hookPath) {
-    $currentHash = (Get-FileHash -Algorithm SHA256 -Path $hookPath).Hash.ToLowerInvariant()
-    if ($currentHash -eq $PublicRouteSha256) { return $true }
-  }
-
-  New-Item -ItemType Directory -Force -Path $hookDir | Out-Null
   $hookTemp = Join-Path $hookDir (".mcp-route.ps1.download-$PID")
+  $hookStage = "existing_checksum"
   try {
+    if (Test-Path $hookPath) {
+      $currentHash = (Get-FileHash -Algorithm SHA256 -Path $hookPath).Hash.ToLowerInvariant()
+      if ($currentHash -eq $PublicRouteSha256) { return $true }
+    }
+    $hookStage = "directory_create"
+    New-Item -ItemType Directory -Force -Path $hookDir | Out-Null
+    $hookStage = "download"
     Invoke-WebRequest -Uri $PublicRouteUrl -OutFile $hookTemp -UseBasicParsing
+    $hookStage = "download_checksum"
     $downloadHash = (Get-FileHash -Algorithm SHA256 -Path $hookTemp).Hash.ToLowerInvariant()
-    $downloadText = Get-Content -Raw -Path $hookTemp
-    if ($downloadHash -ne $PublicRouteSha256 -or
-        $downloadText -notmatch 'simplicio-hook-version: 3240-v11') {
+    if ($downloadHash -ne $PublicRouteSha256) {
+      $script:HookFailureCode = "hook_checksum_mismatch"
+      $script:HookFailureReason = "Downloaded hook SHA256 mismatch: expected $PublicRouteSha256, got $downloadHash"
       return $false
     }
+    $hookStage = "marker_check"
+    $downloadText = Get-Content -Raw -Path $hookTemp
+    if ($downloadText -notmatch 'simplicio-hook-version: 3240-v12') {
+      $script:HookFailureCode = "hook_marker_missing"
+      $script:HookFailureReason = "Downloaded hook is missing simplicio-hook-version: 3240-v12"
+      return $false
+    }
+    $hookStage = "activation"
     Move-Item -Force -Path $hookTemp -Destination $hookPath
     return $true
   } catch {
+    $errorBody = if ($null -ne $_.ErrorDetails) { Limit-FailureText $_.ErrorDetails.Message } else { "" }
+    $exceptionReason = Limit-FailureText $_.Exception.Message
+    if ($hookStage -eq "download" -and -not [string]::IsNullOrWhiteSpace($errorBody)) {
+      $failure = Resolve-RuntimeFailure $errorBody $exceptionReason 1
+      $script:HookFailureCode = if ($failure.Code -eq "mcp_registration_failed") { "hook_download_failed" } else { $failure.Code }
+      $script:HookFailureReason = $failure.Reason
+    } else {
+      $script:HookFailureCode = "hook_$($hookStage)_failed"
+      $script:HookFailureReason = $exceptionReason
+    }
     return $false
   } finally {
     if (Test-Path $hookTemp) { Remove-Item -Force $hookTemp -ErrorAction SilentlyContinue }
   }
 }
 
-function Test-AnyPath([string[]]$Paths) {
-  foreach ($path in $Paths) {
-    if (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path $path)) { return $true }
-  }
-  return $false
-}
-
-function Install-PortableAgentPlugin([string]$TargetDir, [string]$HostName) {
-  $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("simplicio-agent-plugin-" + [guid]::NewGuid().ToString("N"))
-  $archive = Join-Path $tempRoot "simplicio-master.zip"
-  $unpacked = Join-Path $tempRoot "unpacked"
-  try {
-    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
-    Invoke-WebRequest -Uri "https://github.com/$Repo/archive/refs/heads/master.zip" -OutFile $archive -UseBasicParsing
-    Expand-Archive -Path $archive -DestinationPath $unpacked -Force
-    $manifest = Get-ChildItem -Path $unpacked -Recurse -File -Filter "plugin.json" |
-      Where-Object { $_.FullName -match "[\\/]plugins[\\/]simplicio[\\/]plugin\.json$" } |
-      Select-Object -First 1
-    if ($null -eq $manifest) { return $false }
-    New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
-    Get-ChildItem -Force -Path $manifest.DirectoryName | Copy-Item -Destination $TargetDir -Recurse -Force
-    if (-not (Test-Path (Join-Path $TargetDir "plugin.json"))) { return $false }
-    Write-Host "  ✓ Simplicio Agent Plugin installed for $HostName"
-    return $true
-  } catch {
-    return $false
-  } finally {
-    if (Test-Path $tempRoot) {
-      Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
+  function Test-HostPluginHelpContract([string]$Stdout, [string]$Stderr) {
+    $helpText = "$Stdout`n$Stderr"
+    $required = @(
+      "simplicio.host-plugins/cli-v1",
+      "simplicio host-plugins plan",
+      "simplicio host-plugins apply",
+      "simplicio host-plugins pending",
+      "simplicio host-plugins reconcile"
+    )
+    foreach ($marker in $required) {
+      if (-not $helpText.Contains($marker)) { return $false }
     }
-  }
-}
-
-function Install-GeminiExtension {
-  $installedManifest = Join-Path $env:USERPROFILE ".gemini\extensions\simplicio\gemini-extension.json"
-  if (Test-Path $installedManifest) {
-    Write-Host "  ✓ Gemini CLI native extension already installed"
     return $true
   }
 
-  $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("simplicio-plugin-" + [guid]::NewGuid().ToString("N"))
-  $archive = Join-Path $tempRoot "simplicio-master.zip"
-  $unpacked = Join-Path $tempRoot "unpacked"
+  function Test-HostPluginCapability {
+  $script:HostPluginsState = "unavailable"
+  $script:HostPluginsCommand = $null
+  $script:HostPluginsReason = "Runtime host-plugins capability is unavailable"
+  if (-not (Test-Path $DestPath)) {
+    $script:HostPluginsReason = "Runtime binary is missing; host-plugins capability was not checked"
+    return $false
+  }
   try {
-    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
-    Invoke-WebRequest -Uri "https://github.com/$Repo/archive/refs/heads/master.zip" -OutFile $archive -UseBasicParsing
-    Expand-Archive -Path $archive -DestinationPath $unpacked -Force
-    $manifest = Get-ChildItem -Path $unpacked -Recurse -File -Filter "gemini-extension.json" |
-      Where-Object { $_.FullName -match "[\\/]plugins[\\/]simplicio[\\/]gemini-extension\.json$" } |
-      Select-Object -First 1
-    if ($null -eq $manifest) { return $false }
-    if (Invoke-NativeHostCommand "gemini" @("extensions", "install", $manifest.DirectoryName, "--consent")) {
-      Write-Host "  ✓ Gemini CLI native extension installed"
+    $result = Invoke-BoundedNativeCommand $DestPath @("host-plugins", "--help")
+      if ($result.ExitCode -eq 0 -and (Test-HostPluginHelpContract $result.Stdout $result.Stderr)) {
+      $script:HostPluginsState = "pending_consent"
+        $script:HostPluginsCommand = "simplicio host-plugins plan --all"
+      $script:HostPluginsReason = "Host plugins require separate explicit user consent."
       return $true
     }
+      if ($result.ExitCode -eq 0) {
+        $script:HostPluginsReason = "Runtime host-plugins capability unavailable: Runtime returned exit code 0 without the required simplicio.host-plugins/cli-v1 contract marker and commands"
+      } else {
+        $failure = Resolve-RuntimeFailure $result.Stdout $result.Stderr $result.ExitCode
+        $script:HostPluginsReason = "Runtime host-plugins capability unavailable: $($failure.Reason)"
+      }
     return $false
   } catch {
+    $script:HostPluginsReason = "Runtime host-plugins capability unavailable: $(Limit-FailureText $_.Exception.Message)"
     return $false
-  } finally {
-    if (Test-Path $tempRoot) {
-      Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
-    }
   }
 }
 
-function Install-DetectedHostPlugins {
-  if ($env:SIMPLICIO_INSTALL_HOST_PLUGINS -eq "0") {
-    Write-Host "  - native host plugin installation skipped by SIMPLICIO_INSTALL_HOST_PLUGINS=0"
-    return $true
+function Report-HostPluginConsent {
+  if ($script:HostPluginsState -eq "pending_consent") {
+    Write-Host "  - host plugins are pending separate consent; no host plugin was changed"
+      Write-Host "  - review the plan only through Runtime: `"$DestPath`" host-plugins plan --all"
+  } else {
+    Write-Warning "Runtime host-plugins capability is unavailable; no host plugin was changed"
   }
-
-  $detected = 0
-  $failures = 0
-  if (Get-Command codex -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    [void](Invoke-NativeHostCommand "codex" @(
-      "plugin", "marketplace", "add", $Repo, "--ref", "master",
-      "--sparse", ".agents/plugins", "--sparse", "plugins/simplicio"
-    ))
-    if (Invoke-NativeHostCommand "codex" @("plugin", "add", "simplicio@simplicio-codex")) {
-      Write-Host "  ✓ Codex native plugin installed"
-    } else {
-      Write-Warning "Codex detected, but simplicio@simplicio-codex could not be installed"
-      $failures += 1
-    }
-  }
-
-  if (Get-Command claude -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    [void](Invoke-NativeHostCommand "claude" @("plugin", "marketplace", "add", $Repo))
-    foreach ($pluginName in $MarketplacePlugins) {
-      if (Invoke-NativeHostCommand "claude" @("plugin", "install", "$pluginName@simplicio", "--scope", "user")) {
-        Write-Host "  ✓ plugin $pluginName installed in Claude Code"
-      } else {
-        Write-Warning "Claude Code detected, but $pluginName@simplicio could not be installed"
-        $failures += 1
-      }
-    }
-  }
-
-  if (Get-Command gemini -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    if (-not (Install-GeminiExtension)) {
-      Write-Warning "Gemini CLI detected, but the Simplicio native extension could not be installed"
-      $failures += 1
-    }
-  }
-
-  if (Get-Command copilot -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    [void](Invoke-NativeHostCommand "copilot" @("plugin", "marketplace", "add", $Repo))
-    foreach ($pluginName in $MarketplacePlugins) {
-      if (Invoke-NativeHostCommand "copilot" @("plugin", "install", "$pluginName@simplicio")) {
-        Write-Host "  ✓ plugin $pluginName installed in GitHub Copilot CLI"
-      } else {
-        Write-Warning "GitHub Copilot CLI detected, but $pluginName@simplicio could not be installed"
-        $failures += 1
-      }
-    }
-  }
-
-  if (Get-Command qwen -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    foreach ($pluginName in $MarketplacePlugins) {
-      if (Invoke-NativeHostCommand "qwen" @("extensions", "install", "${Repo}:$pluginName")) {
-        Write-Host "  ✓ extension $pluginName installed in Qwen Code"
-      } else {
-        Write-Warning "Qwen Code detected, but $pluginName could not be installed"
-        $failures += 1
-      }
-    }
-  }
-
-  if (Get-Command hermes -CommandType Application -ErrorAction SilentlyContinue) {
-    $detected += 1
-    $installed = Invoke-NativeHostCommand "hermes" @("plugins", "install", "$Repo/plugins/simplicio-hermes", "--force", "--enable")
-    $valid = $installed -and (Invoke-NativeHostCommand "hermes" @("plugins", "doctor", "simplicio-hermes", "--ci"))
-    if ($valid) {
-      Write-Host "  ✓ simplicio-hermes plugin installed, enabled, and validated"
-    } else {
-      Write-Warning "Hermes detected, but simplicio-hermes could not be installed and enabled"
-      $failures += 1
-    }
-  }
-
-  $cursorPaths = @(
-    (Join-Path $env:USERPROFILE ".cursor"),
-    $(if ($env:APPDATA) { Join-Path $env:APPDATA "Cursor" } else { "" }),
-    $(if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "Programs\cursor" } else { "" })
-  )
-  $cursorDetected = [bool](
-    (Get-Command cursor -ErrorAction SilentlyContinue) -or
-    (Get-Command cursor-agent -ErrorAction SilentlyContinue) -or
-    (Test-AnyPath $cursorPaths)
-  )
-  if ($cursorDetected) {
-    $detected += 1
-    $target = Join-Path $env:USERPROFILE ".cursor\plugins\local\simplicio"
-    if (-not (Install-PortableAgentPlugin $target "Cursor")) { $failures += 1 }
-  }
-
-  $kiroPaths = @(
-    (Join-Path $env:USERPROFILE ".kiro"),
-    $(if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "Programs\Kiro" } else { "" })
-  )
-  $kiroDetected = [bool](
-    (Get-Command kiro -ErrorAction SilentlyContinue) -or
-    (Get-Command kiro-cli -ErrorAction SilentlyContinue) -or
-    (Test-AnyPath $kiroPaths)
-  )
-  if ($kiroDetected) {
-    $detected += 1
-    $target = Join-Path $env:USERPROFILE ".kiro\powers\simplicio"
-    if (-not (Install-PortableAgentPlugin $target "Kiro")) { $failures += 1 }
-  }
-
-  if ($detected -eq 0) {
-    Write-Host "  - no compatible plugin-package host detected; Runtime MCP registration covers the other clients"
-  }
-  return ($failures -eq 0)
 }
 
 # ─── -Doctor: idempotent, read-only health check ───────────────────────────
@@ -457,9 +712,9 @@ if ($Doctor) {
     }
 
     if (Test-ActiveLogin) {
-      Write-Host "  [OK] active Google session and entitlement"
+      Write-Host "  [OK] fresh Google session and entitlement verified"
     } else {
-      Write-Host "  [FAIL] missing, expired, revoked, or inactive Google session"
+      Write-Host "  [FAIL] Google session is missing, cached, expired, revoked, or lacks entitlement"
       $ok = $false
     }
   }
@@ -512,6 +767,8 @@ if ($Uninstall) {
 }
 
 # ─── Install / update ───────────────────────────────────────────────────────
+try {
+$script:InstallStage = "runtime_download"
 Write-Host "==> simplicio installer for Windows ($Target)"
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
@@ -568,25 +825,25 @@ if ($Manifest) {
 
 if ($SignatureRequired -or $ExpectedSigned) {
   if ([string]::IsNullOrWhiteSpace($ExpectedPublicKey)) {
-    Write-Error "Refusing to install: manifest requires Ed25519 signatures but signing_pubkey is missing."
+    Fail-Install "Refusing to install: manifest requires Ed25519 signatures but signing_pubkey is missing."
     exit 1
   }
   if ($SignatureRequired -and $ExpectedPublicKey -cne $PinnedPublicKey) {
-    Write-Error "Refusing to install: manifest Ed25519 public key does not match the pinned installer key."
+    Fail-Install "Refusing to install: manifest Ed25519 public key does not match the pinned installer key."
     exit 1
   }
 }
 if ($SignatureRequired -and (-not $ExpectedSigned -or [string]::IsNullOrWhiteSpace($ExpectedSignature))) {
-  Write-Error "Refusing to install: the manifest requires an Ed25519 signature, but target '$Target' has no published signature."
+  Fail-Install "Refusing to install: the manifest requires an Ed25519 signature, but target '$Target' has no published signature."
   exit 1
 } elseif (-not $ExpectedSha256) {
   if ($ExpectedSigned) {
-    Write-Error "Refusing to install: published Ed25519 signature has no verifiable SHA256 digest."
+    Fail-Install "Refusing to install: published Ed25519 signature has no verifiable SHA256 digest."
     exit 1
   } elseif ($env:SIMPLICIO_ALLOW_UNVERIFIED -eq "1" -and $env:SIMPLICIO_CHANNEL -eq "unofficial") {
     Write-Host "  ! no published checksum for target '$Target' — proceeding UNVERIFIED (SIMPLICIO_ALLOW_UNVERIFIED=1, unofficial channel)"
   } else {
-    Write-Error "Refusing to install: no published SHA256 checksum for target '$Target' in the update manifest."
+    Fail-Install "Refusing to install: no published SHA256 checksum for target '$Target' in the update manifest."
     exit 1
   }
 } elseif (-not $ExpectedSigned) {
@@ -601,13 +858,13 @@ Write-Host "==> downloading $DownloadUrl"
 try {
   Invoke-WebRequest -Uri $DownloadUrl -OutFile $StagingPath -UseBasicParsing -ErrorAction Stop
 } catch {
-  Write-Error "Download failed for $Asset from $DownloadUrl : $($_.Exception.Message)"
+  Fail-Install "Download failed for $Asset from $DownloadUrl : $($_.Exception.Message)"
   if (Test-Path $StagingPath) { Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue }
   exit 1
 }
 
 if (-not (Test-Path $StagingPath) -or (Get-Item $StagingPath).Length -eq 0) {
-  Write-Error "Downloaded file is missing or empty: $StagingPath"
+  Fail-Install "Downloaded file is missing or empty: $StagingPath"
   if (Test-Path $StagingPath) { Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue }
   exit 1
 }
@@ -616,7 +873,7 @@ if ($ExpectedSha256) {
   $actualSha256 = (Get-FileHash -Path $StagingPath -Algorithm SHA256).Hash.ToLowerInvariant()
   if ($actualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
     Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
-    Write-Error "Checksum mismatch for $Asset. Expected $ExpectedSha256, got $actualSha256. Refusing to install a tampered or corrupt binary."
+    Fail-Install "Checksum mismatch for $Asset. Expected $ExpectedSha256, got $actualSha256. Refusing to install a tampered or corrupt binary."
     exit 1
   }
   Write-Host "  ✓ SHA256 verified: $actualSha256"
@@ -626,9 +883,9 @@ if ($ExpectedSigned) {
   if (-not (Test-Ed25519Signature $StagingPath $ExpectedSignature $PinnedPublicKey $ExpectedSha256)) {
     Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
     if ([string]::IsNullOrWhiteSpace($script:Ed25519VerifyError)) {
-      Write-Error "Ed25519 signature verification failed; refusing to install."
+      Fail-Install "Ed25519 signature verification failed; refusing to install."
     } else {
-      Write-Error "Ed25519 signature verification failed: $script:Ed25519VerifyError; refusing to install."
+      Fail-Install "Ed25519 signature verification failed: $script:Ed25519VerifyError; refusing to install."
     }
     exit 1
   }
@@ -640,7 +897,7 @@ if ($ExpectedSigned) {
 # replace a working installation and then fail its post-install checks.
 if (-not (Test-RuntimeReleaseContract $StagingPath)) {
   Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
-  Write-Error "Runtime release does not meet the distribution contract (embedded sources, Google login, and signed-update key); installation aborted."
+  Fail-Install "Runtime release does not meet the distribution contract (embedded sources, Google login, and signed-update key); installation aborted."
   exit 1
 }
 
@@ -652,61 +909,65 @@ if (Test-Path $DestPath) {
   Copy-Item -Force -Path $DestPath -Destination $PreviousPath
 }
 $InstallTransactionActive = $true
+$script:InstallStage = "runtime_activation"
+$script:InstallEffectStarted = $true
 try {
   Move-Item -Force -Path $StagingPath -Destination $DestPath
+  $script:RuntimeInstalled = $true
   $InstallTransactionActive = $false
   if (Test-Path $PreviousPath) { Remove-Item -Force $PreviousPath -ErrorAction SilentlyContinue }
 } catch {
   Invoke-Rollback
   Remove-Item -Force $StagingPath -ErrorAction SilentlyContinue
-  Write-Error "Could not move verified binary into place: $($_.Exception.Message)"
+  Fail-Install "Could not move verified binary into place: $($_.Exception.Message)"
   exit 1
 }
 Write-Host "  ✓ installed: $DestPath"
 
 # ─── Verify the downloaded Runtime ──────────────────────────────────────────
+$script:InstallStage = "runtime_contract"
 try {
   $output = & $DestPath version 2>&1 | Out-String
   if ($LASTEXITCODE -ne 0) { throw "version command returned $LASTEXITCODE" }
 } catch {
-  Write-Error "Binary installed but version verification failed: $($_.Exception.Message)"
+  Fail-Install "Binary installed but version verification failed: $($_.Exception.Message)"
   exit 1
 }
 
 if (-not (Test-RuntimeReleaseContract $DestPath)) {
-  Write-Error "This Runtime does not meet the distribution contract; refusing to finish installation. Install a compatible Runtime release."
+  Fail-Install "This Runtime does not meet the distribution contract; refusing to finish installation. Install a compatible Runtime release."
   exit 1
 }
 Write-Host "  ✓ Runtime release contract verified"
 
 # ─── Register MCP and native hooks for every detected client ──────────────
+$script:InstallStage = "mcp_registration"
 if (Test-McpToolSurface $DestPath) {
+  $script:McpRegistered = $true
   Write-Host "  ✓ MCP and hooks registered automatically for detected clients"
 } else {
-  Write-Error "Runtime installed, but automatic MCP/hooks registration failed: $DestPath mcp register --binary $DestPath --json"
+  Fail-Install $script:McpFailureReason $script:McpFailureCode
   exit 1
 }
+$script:InstallStage = "hook_registration"
 if (Sync-PublicRouteOverlay) {
-  Write-Host "  ✓ verified public v11 hook reconciled after Runtime registration"
+  $script:HookInstalled = $true
+  Write-Host "  ✓ verified public v12 hook reconciled after Runtime registration"
 } else {
-  Write-Error "Runtime registered MCP, but the public v11 hook could not be verified and activated"
+  Fail-Install $script:HookFailureReason $script:HookFailureCode
   exit 1
 }
 
-# Host packages add skills, commands and host-specific lifecycle behavior on
-# top of Runtime MCP registration. Every detected host with a documented
-# package surface is installed automatically; MCP remains the compatibility
-# path for clients without a package API.
-if (Install-DetectedHostPlugins) {
-  Write-Host "  ✓ native plugins reconciled for detected hosts"
-} else {
-  Write-Error "Runtime/MCP are ready, but automatic installation of one or more detected plugins failed; see PLUGIN.md"
-  exit 1
-}
+# Host-specific plugin changes require a second, explicit consent transaction.
+# This installer never invokes host CLIs and never downloads a mutable plugin
+# archive. Runtime owns planning, application, receipts and reconciliation.
+[void](Test-HostPluginCapability)
+Report-HostPluginConsent
 Report-LoginState
 Write-Host "  ✓ Direct MCP: $DestPath serve --mcp --stdio; SIMPLICIO_MCP_URL=$SimplicioMcpUrl"
 
 $BundleDir = if ($env:SIMPLICIO_BUNDLE_DIR) { $env:SIMPLICIO_BUNDLE_DIR } else { Join-Path $env:USERPROFILE ".simplicio" }
+$script:InstallStage = "runtime_report"
 New-Item -ItemType Directory -Force -Path $BundleDir | Out-Null
 $RuntimeReport = Join-Path $BundleDir "runtime-release.json"
 try {
@@ -716,8 +977,17 @@ try {
   Write-Host "  ✓ Runtime release report: $RuntimeReport"
 } catch {
   if (Test-Path $RuntimeReport) { Remove-Item -Force $RuntimeReport -ErrorAction SilentlyContinue }
-  Write-Error "Could not persist the Runtime release report: $($_.Exception.Message)"
+  Fail-Install "Could not persist the Runtime release report: $($_.Exception.Message)"
   exit 1
+}
+
+$script:InstallStage = "complete"
+try {
+  [void](Save-InstallReceipt "succeeded" 0 "" "")
+  Write-Host "  ✓ structured install receipt: $InstallReceipt"
+} catch {
+  $script:InstallStage = "receipt_persistence"
+  Fail-Install "Runtime/MCP/hook were installed, but the structured install receipt could not be persisted: $($_.Exception.Message)"
 }
 
 # PATH is optional for MCP because host configs point at $DestPath directly.
@@ -733,8 +1003,17 @@ Write-Host ""
 Write-Host "  ✓ simplicio Runtime $Version (windows-x64) installed successfully"
 Write-Host "  ✓ Runtime release contract is active"
 Write-Host "  ✓ no pip packages or sibling checkouts were installed"
-Write-Host "  ✓ active Google login is verified after auth login"
+if (Test-ActiveLogin) {
+  Write-Host "  ✓ fresh Google session verified"
+} else {
+  Write-Warning "Google login is pending; run: `"$DestPath`" auth login"
+}
 Write-Host "  ✓ MCP command points at $DestPath"
+if ($script:HostPluginsState -eq "pending_consent") {
+  Write-Host "  - host plugins are pending separate consent"
+} else {
+  Write-Warning "host plugins are unavailable in this Runtime"
+}
 Write-Host "  ✓ SIMPLICIO_MCP_URL=$SimplicioMcpUrl"
 Write-Host ""
 Write-Host "  Run:     simplicio chat 'hello' --repo ."
@@ -742,3 +1021,6 @@ Write-Host "  REPL:    simplicio chat --repl --repo ."
 Write-Host "  Doctor:  pwsh install.ps1 -Doctor"
 Write-Host "  Remove:  pwsh install.ps1 -Uninstall"
 Write-Host ""
+} catch {
+  Fail-Install $_.Exception.Message
+}

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,10 @@
 #   SIMPLICIO_ALLOW_UNVERIFIED  - "1" to proceed even if no checksum is
 #                                 published for this target (default: refuse)
 #   SIMPLICIO_BUNDLE_DIR       - bundle report directory (default: ~/.simplicio)
-#   SIMPLICIO_INSTALL_HOST_PLUGINS - "0" skips detected host plugins
-#                                    (default: install every compatible package)
+#
+# Host plugins are deliberately outside this installer transaction. The
+# Runtime/MCP/hook install completes first; a separate explicit consent flow
+# owned by `simplicio host-plugins` may be started afterwards.
 #
 # Asset naming follows distribution/targets.json (the canonical target
 # triplet table for the whole ecosystem): id "macos-arm64" -> asset
@@ -36,22 +38,16 @@ GITHUB="https://github.com/$REPO"
 ED25519_PUBLIC_KEY="2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
 ED25519_HELPER_URL="https://raw.githubusercontent.com/$REPO/master/scripts/verify_ed25519.py"
 ED25519_HELPER_SHA256="f03a0719dd557ddea27dc4cf1456d6f06a47b9056505e4d4b8453090697600d0"
-PUBLIC_ROUTE_REF="cc9950025baf823cdecc657228ff1e89d7701e7e"
+PUBLIC_ROUTE_REF="68b4c7f7ac27d07624ffa4ddf0673a43e180c3e5"
 PUBLIC_ROUTE_URL="https://raw.githubusercontent.com/$REPO/$PUBLIC_ROUTE_REF/codex/mcp-route.sh"
-PUBLIC_ROUTE_SHA256="0f3a6a32c6f224fb3aedea5336f60c5c63917b134113d4c4e524e8ae7b4a31a4"
+PUBLIC_ROUTE_SHA256="d91200cae4816c79fe0c903fc6eedc01835a557827e8d3d0480304f3bdce5118"
 BIN_NAME="simplicio"
-MARKETPLACE_PLUGINS="simplicio simplicio-loop simplicio-prompt simplicio-sprint simplicio-hermes"
 
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
-
-info()  { printf "${CYAN}==>${NC} %s\n" "$*"; }
-ok()    { printf "${GREEN}  ✓${NC} %s\n" "$*"; }
-warn()  { printf "${YELLOW}  ⚠${NC} %s\n" "$*"; }
-err()   { printf "${RED}  ✗${NC} %s\n" "$*"; exit 1; }
 
 SIMPLICIO_MCP_URL="${SIMPLICIO_MCP_URL:-http://127.0.0.1:8787/mcp}"
 BIN_DIR="${SIMPLICIO_BIN_DIR:-$HOME/.simplicio/bin}"
@@ -60,10 +56,164 @@ INSTALL_TRANSACTION_ACTIVE="false"
 PREVIOUS_PATH=""
 PURGE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
 AUTH_FILE="$PURGE_DIR/login.json"
+INSTALL_RECEIPT="$PURGE_DIR/install-receipt.json"
+INSTALL_STAGE="preflight"
+INSTALL_EFFECT_STARTED="false"
+RUNTIME_INSTALLED="false"
+MCP_REGISTERED="false"
+HOOK_INSTALLED="false"
+HOST_PLUGINS_STATE="unavailable"
+HOST_PLUGINS_COMMAND=""
+HOST_PLUGINS_REASON="Runtime host-plugins capability was not checked"
 AUTH_FILE_WAS_PRESENT="false"
 if [ -e "$AUTH_FILE" ]; then
   AUTH_FILE_WAS_PRESENT="true"
 fi
+
+info()  { printf "${CYAN}==>${NC} %s\n" "$*"; }
+ok()    { printf "${GREEN}  ✓${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}  ⚠${NC} %s\n" "$*"; }
+
+json_escape() {
+  # POSIX od is available before Python and lets the fallback produce valid
+  # JSON even when a user-controlled path contains a newline or control byte.
+  for json_byte in $(printf '%s' "$1" | od -An -tu1 -v); do
+    case "$json_byte" in
+      8) printf '%s' '\b' ;;
+      9) printf '%s' '\t' ;;
+      10) printf '%s' '\n' ;;
+      12) printf '%s' '\f' ;;
+      13) printf '%s' '\r' ;;
+      34) printf '%s' '\"' ;;
+      92) printf '%s' "\\\\" ;;
+      [0-9]|[12][0-9]|3[01]) printf '\\u%04x' "$json_byte" ;;
+      *)
+        json_octal="$(printf '%03o' "$json_byte")"
+        printf '%b' "\\$json_octal"
+        ;;
+    esac
+  done
+}
+
+render_install_receipt() {
+  receipt_status="$1"
+  receipt_exit_code="$2"
+  receipt_failure_code="$3"
+  receipt_failure_reason="$4"
+  if command -v python3 >/dev/null 2>&1; then
+    if RECEIPT_STATUS="$receipt_status" \
+      RECEIPT_EXIT_CODE="$receipt_exit_code" \
+      RECEIPT_STAGE="$INSTALL_STAGE" \
+      RECEIPT_FAILURE_CODE="$receipt_failure_code" \
+      RECEIPT_FAILURE_REASON="$receipt_failure_reason" \
+      RECEIPT_RUNTIME_INSTALLED="$RUNTIME_INSTALLED" \
+      RECEIPT_MCP_REGISTERED="$MCP_REGISTERED" \
+      RECEIPT_HOOK_INSTALLED="$HOOK_INSTALLED" \
+      RECEIPT_HOST_PLUGINS_STATE="$HOST_PLUGINS_STATE" \
+      RECEIPT_HOST_PLUGINS_COMMAND="$HOST_PLUGINS_COMMAND" \
+      RECEIPT_HOST_PLUGINS_REASON="$HOST_PLUGINS_REASON" \
+      python3 - <<'PY'
+import json
+import os
+
+
+def env_bool(name):
+    return os.environ.get(name) == "true"
+
+
+failure_code = os.environ.get("RECEIPT_FAILURE_CODE", "")
+failure = None
+if failure_code:
+    failure = {
+        "code": failure_code,
+        "reason": os.environ.get("RECEIPT_FAILURE_REASON", ""),
+    }
+
+receipt = {
+    "schema": "simplicio-install-receipt/v1",
+    "status": os.environ["RECEIPT_STATUS"],
+    "exit_code": int(os.environ["RECEIPT_EXIT_CODE"]),
+    "stage": os.environ["RECEIPT_STAGE"],
+    "failure": failure,
+    "runtime": {"installed": env_bool("RECEIPT_RUNTIME_INSTALLED")},
+    "mcp": {"registered": env_bool("RECEIPT_MCP_REGISTERED")},
+    "hook": {"installed": env_bool("RECEIPT_HOOK_INSTALLED")},
+    "host_plugins": {
+        "state": os.environ["RECEIPT_HOST_PLUGINS_STATE"],
+        "owner": "simplicio-runtime",
+        "command": os.environ.get("RECEIPT_HOST_PLUGINS_COMMAND") or None,
+        "mutated": False,
+        "reason": os.environ["RECEIPT_HOST_PLUGINS_REASON"],
+    },
+}
+print(json.dumps(receipt, ensure_ascii=False, separators=(",", ":")))
+PY
+    then
+      return 0
+    fi
+  fi
+
+  # Pre-Python failures still get valid JSON through the byte-safe POSIX
+  # fallback above, without relying on the missing prerequisite.
+  if [ -n "$receipt_failure_code" ]; then
+    receipt_failure="{\"code\":\"$(json_escape "$receipt_failure_code")\",\"reason\":\"$(json_escape "$receipt_failure_reason")\"}"
+  else
+    receipt_failure="null"
+  fi
+  if [ -n "$HOST_PLUGINS_COMMAND" ]; then
+    receipt_host_command="\"$(json_escape "$HOST_PLUGINS_COMMAND")\""
+  else
+    receipt_host_command="null"
+  fi
+  printf '{"schema":"simplicio-install-receipt/v1","status":"%s","exit_code":%s,"stage":"%s","failure":%s,"runtime":{"installed":%s},"mcp":{"registered":%s},"hook":{"installed":%s},"host_plugins":{"state":"%s","owner":"simplicio-runtime","command":%s,"mutated":false,"reason":"%s"}}\n' \
+    "$(json_escape "$receipt_status")" \
+    "$receipt_exit_code" \
+    "$(json_escape "$INSTALL_STAGE")" \
+    "$receipt_failure" \
+    "$RUNTIME_INSTALLED" \
+    "$MCP_REGISTERED" \
+    "$HOOK_INSTALLED" \
+    "$(json_escape "$HOST_PLUGINS_STATE")" \
+    "$receipt_host_command" \
+    "$(json_escape "$HOST_PLUGINS_REASON")"
+}
+
+persist_install_receipt() {
+  receipt_status="$1"
+  receipt_exit_code="$2"
+  receipt_failure_code="$3"
+  receipt_failure_reason="$4"
+  if ! mkdir -p "$PURGE_DIR"; then
+    return 1
+  fi
+  receipt_tmp="$INSTALL_RECEIPT.tmp.$$"
+  if ! (umask 077; render_install_receipt "$receipt_status" "$receipt_exit_code" "$receipt_failure_code" "$receipt_failure_reason" >"$receipt_tmp"); then
+    rm -f "$receipt_tmp"
+    return 1
+  fi
+  if ! chmod 0600 "$receipt_tmp" || ! mv -f "$receipt_tmp" "$INSTALL_RECEIPT"; then
+    rm -f "$receipt_tmp"
+    return 1
+  fi
+}
+
+fail_install() {
+  failure_code="$1"
+  shift
+  failure_reason="$*"
+  failure_status="failed"
+  if [ "$INSTALL_EFFECT_STARTED" = "true" ]; then
+    failure_status="partial"
+  fi
+  if ! persist_install_receipt "$failure_status" 1 "$failure_code" "$failure_reason"; then
+    render_install_receipt "$failure_status" 1 "$failure_code" "$failure_reason" >&2
+  fi
+  printf "${RED}  ✗${NC} %s\n" "$failure_reason" >&2
+  exit 1
+}
+err() {
+  fail_install "${INSTALL_STAGE}_failed" "$*"
+}
 
 rollback_install() {
   if [ "$INSTALL_TRANSACTION_ACTIVE" = "true" ]; then
@@ -101,31 +251,183 @@ sha256_of() {
   fi
 }
 
-reconcile_public_route_overlay() {
-  hook_dir="$PURGE_DIR/hooks"
-  hook_path="$hook_dir/mcp-route.sh"
-
-  if [ -f "$hook_path" ] && [ "$(sha256_of "$hook_path")" = "$PUBLIC_ROUTE_SHA256" ]; then
-    return 0
-  fi
-
-  mkdir -p "$hook_dir" || return 1
-  hook_tmp="$hook_dir/.mcp-route.sh.download-$$"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$PUBLIC_ROUTE_URL" -o "$hook_tmp" || { rm -f "$hook_tmp"; return 1; }
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$PUBLIC_ROUTE_URL" -O "$hook_tmp" || { rm -f "$hook_tmp"; return 1; }
+HOOK_FAILURE_CODE=""
+HOOK_FAILURE_REASON=""
+hook_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
   else
     return 1
   fi
+}
 
-  if [ "$(sha256_of "$hook_tmp")" != "$PUBLIC_ROUTE_SHA256" ] ||
-     ! grep -q 'simplicio-hook-version: 3240-v11' "$hook_tmp"; then
-    rm -f "$hook_tmp"
+reconcile_public_route_overlay() {
+  HOOK_FAILURE_CODE=""
+  HOOK_FAILURE_REASON=""
+  hook_dir="$PURGE_DIR/hooks"
+  hook_path="$hook_dir/mcp-route.sh"
+
+  if [ -f "$hook_path" ]; then
+    if ! hook_current_sha="$(hook_sha256 "$hook_path")"; then
+      HOOK_FAILURE_CODE="hook_checksum_tool_missing"
+      HOOK_FAILURE_REASON="Could not calculate SHA256 for existing hook: $hook_path"
+      return 1
+    fi
+    if [ "$hook_current_sha" = "$PUBLIC_ROUTE_SHA256" ]; then
+      return 0
+    fi
+  fi
+
+  if ! mkdir -p "$hook_dir"; then
+    HOOK_FAILURE_CODE="hook_directory_create_failed"
+    HOOK_FAILURE_REASON="Could not create hook directory: $hook_dir"
     return 1
   fi
-  chmod 0755 "$hook_tmp" || { rm -f "$hook_tmp"; return 1; }
-  mv -f "$hook_tmp" "$hook_path"
+  hook_tmp="$hook_dir/.mcp-route.sh.download-$$"
+  hook_capture_dir="$(mktemp -d "${TMPDIR:-/tmp}/simplicio-hook.XXXXXX")" || {
+    HOOK_FAILURE_CODE="hook_output_capture_failed"
+    HOOK_FAILURE_REASON="Could not create bounded hook download capture"
+    return 1
+  }
+  hook_stdout="$hook_capture_dir/stdout"
+  hook_stderr="$hook_capture_dir/stderr"
+  hook_stdout_fifo="$hook_capture_dir/stdout.fifo"
+  hook_stderr_fifo="$hook_capture_dir/stderr.fifo"
+  hook_code_path="$hook_capture_dir/code"
+  hook_reason_path="$hook_capture_dir/reason"
+  if ! mkfifo "$hook_stdout_fifo" "$hook_stderr_fifo"; then
+    rm -f "$hook_tmp" "$hook_stdout_fifo" "$hook_stderr_fifo" || true
+    rmdir "$hook_capture_dir" 2>/dev/null || true
+    HOOK_FAILURE_CODE="hook_output_capture_failed"
+    HOOK_FAILURE_REASON="Could not create bounded hook download streams"
+    return 1
+  fi
+  if command -v curl >/dev/null 2>&1; then
+    hook_downloader="curl"
+  elif command -v wget >/dev/null 2>&1; then
+    hook_downloader="wget"
+  else
+    rm -f "$hook_tmp" "$hook_stdout_fifo" "$hook_stderr_fifo" || true
+    rmdir "$hook_capture_dir" 2>/dev/null || true
+    HOOK_FAILURE_CODE="hook_downloader_missing"
+    HOOK_FAILURE_REASON="Neither curl nor wget is available to download the public hook"
+    return 1
+  fi
+  capture_stream_bounded "$hook_stdout" "$hook_stdout.truncated" 8192 <"$hook_stdout_fifo" &
+  hook_stdout_pid=$!
+  capture_stream_bounded "$hook_stderr" "$hook_stderr.truncated" 8192 <"$hook_stderr_fifo" &
+  hook_stderr_pid=$!
+  if [ "$hook_downloader" = "curl" ]; then
+    if curl -fsSL "$PUBLIC_ROUTE_URL" -o "$hook_tmp" >"$hook_stdout_fifo" 2>"$hook_stderr_fifo"; then
+      hook_download_exit=0
+    else
+      hook_download_exit=$?
+    fi
+  else
+    if wget -q "$PUBLIC_ROUTE_URL" -O "$hook_tmp" >"$hook_stdout_fifo" 2>"$hook_stderr_fifo"; then
+      hook_download_exit=0
+    else
+      hook_download_exit=$?
+    fi
+  fi
+  if wait "$hook_stdout_pid"; then hook_stdout_ok=true; else hook_stdout_ok=false; fi
+  if wait "$hook_stderr_pid"; then hook_stderr_ok=true; else hook_stderr_ok=false; fi
+  rm -f "$hook_stdout_fifo" "$hook_stderr_fifo" || true
+
+  if [ "$hook_stdout_ok" != "true" ] || [ "$hook_stderr_ok" != "true" ]; then
+    HOOK_FAILURE_CODE="hook_output_capture_failed"
+    HOOK_FAILURE_REASON="Hook download output could not be drained safely"
+    hook_download_exit=125
+  elif [ "$hook_download_exit" -ne 0 ]; then
+    if python3 - "$hook_stdout" "$hook_stderr" "$hook_code_path" "$hook_reason_path" "$hook_download_exit" <<'PY'
+import json
+import os
+import sys
+
+marker = "\n...[output truncated at 8192 bytes]"
+
+
+def captured(path):
+    with open(path, "rb") as handle:
+        text = handle.read(8192).decode("utf-8", errors="replace")
+    return text + (marker if os.path.exists(path + ".truncated") else "")
+
+
+stdout = captured(sys.argv[1])
+stderr = captured(sys.argv[2])
+payload = None
+for candidate in [stdout.strip(), *reversed([line.strip() for line in stdout.splitlines() if line.strip()])]:
+    try:
+        decoded = json.loads(candidate)
+    except (TypeError, ValueError):
+        continue
+    if isinstance(decoded, dict):
+        payload = decoded
+        break
+failure = payload.get("failure") if isinstance(payload, dict) else None
+error = payload.get("error") if isinstance(payload, dict) else None
+failure = failure if isinstance(failure, dict) else {}
+error_object = error if isinstance(error, dict) else {}
+code = failure.get("code") or (payload.get("code") if payload else None) or (payload.get("error_code") if payload else None) or error_object.get("code") or "hook_download_failed"
+reason = failure.get("reason") or (payload.get("reason") if payload else None) or (payload.get("message") if payload else None) or error_object.get("reason") or error_object.get("message") or (error if isinstance(error, str) else None)
+if not isinstance(reason, str) or not reason:
+    reason = stderr.strip() or stdout.strip() or f"Hook download failed with exit code {sys.argv[5]}"
+with open(sys.argv[3], "w", encoding="utf-8", newline="") as handle:
+    handle.write(str(code))
+with open(sys.argv[4], "w", encoding="utf-8", newline="") as handle:
+    handle.write(reason[:8192])
+PY
+    then
+      capture_sentinel="__SIMPLICIO_CAPTURE_EOF__"
+      HOOK_FAILURE_CODE="$(cat "$hook_code_path"; printf '%s' "$capture_sentinel")"
+      HOOK_FAILURE_CODE="${HOOK_FAILURE_CODE%"$capture_sentinel"}"
+      HOOK_FAILURE_REASON="$(cat "$hook_reason_path"; printf '%s' "$capture_sentinel")"
+      HOOK_FAILURE_REASON="${HOOK_FAILURE_REASON%"$capture_sentinel"}"
+    else
+      HOOK_FAILURE_CODE="hook_download_failed"
+      HOOK_FAILURE_REASON="Hook download failed with exit code $hook_download_exit"
+    fi
+  fi
+
+  rm -f "$hook_stdout" "$hook_stderr" "$hook_stdout.truncated" "$hook_stderr.truncated" "$hook_code_path" "$hook_reason_path" || true
+  rmdir "$hook_capture_dir" 2>/dev/null || true
+  if [ "$hook_download_exit" -ne 0 ]; then
+    rm -f "$hook_tmp" || true
+    return 1
+  fi
+  if ! hook_download_sha="$(hook_sha256 "$hook_tmp")"; then
+    rm -f "$hook_tmp" || true
+    HOOK_FAILURE_CODE="hook_checksum_failed"
+    HOOK_FAILURE_REASON="Could not calculate SHA256 for downloaded hook"
+    return 1
+  fi
+  if [ "$hook_download_sha" != "$PUBLIC_ROUTE_SHA256" ]; then
+    rm -f "$hook_tmp" || true
+    HOOK_FAILURE_CODE="hook_checksum_mismatch"
+    HOOK_FAILURE_REASON="Downloaded hook SHA256 mismatch: expected $PUBLIC_ROUTE_SHA256, got $hook_download_sha"
+    return 1
+  fi
+  if ! grep -q 'simplicio-hook-version: 3240-v12' "$hook_tmp"; then
+    rm -f "$hook_tmp" || true
+    HOOK_FAILURE_CODE="hook_marker_missing"
+    HOOK_FAILURE_REASON="Downloaded hook is missing simplicio-hook-version: 3240-v12"
+    return 1
+  fi
+  if ! chmod 0755 "$hook_tmp"; then
+    rm -f "$hook_tmp" || true
+    HOOK_FAILURE_CODE="hook_permission_failed"
+    HOOK_FAILURE_REASON="Could not make downloaded hook executable: $hook_tmp"
+    return 1
+  fi
+  if ! mv -f "$hook_tmp" "$hook_path"; then
+    rm -f "$hook_tmp" || true
+    HOOK_FAILURE_CODE="hook_activation_failed"
+    HOOK_FAILURE_REASON="Could not activate verified hook at $hook_path"
+    return 1
+  fi
+  return 0
 }
 
 verify_ed25519_signature() {
@@ -229,238 +531,316 @@ except Exception:
     raise SystemExit(1)
 identity = payload.get("identity") or {}
 entitlement = payload.get("entitlement") or {}
+session_verification = payload.get("session_verification") or {}
 identity_email = identity.get("email") or (payload.get("user") or {}).get("email")
 active = (
     identity.get("enabled") is True
     and identity.get("login_enabled") is True
-    and identity.get("status") not in {"disabled", "logged_out", "revoked"}
+    and identity.get("status") == "active"
     and bool(identity_email)
+    and entitlement.get("updates_allowed") is True
+    and session_verification.get("verified") is True
+    and session_verification.get("cached") is False
 )
-if "updates_allowed" in entitlement:
-    active = active and entitlement.get("updates_allowed") is True
 raise SystemExit(0 if active else 1)
 '
 }
 
 report_login_state() {
   if verify_active_login; then
-    ok "login Google ativo e entitlement válido"
+    ok "sessão Google verificada de forma fresh e entitlement válido"
     return 0
   fi
-  warn "login Google ausente ou sem entitlement ativo; rode: ${DEST_PATH} auth login"
+  warn "sessão Google não verificada de forma fresh (ausente, cacheada ou sem entitlement); rode: ${DEST_PATH} auth login"
   return 0
 }
 
+capture_stream_bounded() {
+  capture_output_path="$1"
+  capture_truncated_path="$2"
+  capture_limit="$3"
+  python3 -c '
+import os
+import sys
+
+output_path, truncated_path, raw_limit = sys.argv[1:]
+limit = int(raw_limit)
+remaining = limit
+truncated = False
+with open(output_path, "wb") as output:
+    while True:
+        chunk = sys.stdin.buffer.read(65536)
+        if not chunk:
+            break
+        kept_length = 0
+        if remaining:
+            kept = chunk[:remaining]
+            output.write(kept)
+            remaining -= len(kept)
+            kept_length = len(kept)
+        if len(chunk) > kept_length:
+            truncated = True
+if truncated:
+    with open(truncated_path, "wb"):
+        pass
+' "$capture_output_path" "$capture_truncated_path" "$capture_limit"
+}
+
+MCP_FAILURE_CODE=""
+MCP_FAILURE_REASON=""
 verify_mcp_tools() {
   binary_path="$1"
-  [ -x "$binary_path" ] || return 1
-  SIMPLICIO_MCP_URL="$SIMPLICIO_MCP_URL" "$binary_path" mcp register --binary "$binary_path" --json >/dev/null 2>&1
-}
-
-
-install_gemini_extension() {
-  installed_manifest="$HOME/.gemini/extensions/simplicio/gemini-extension.json"
-  if [ -f "$installed_manifest" ]; then
-    ok "extensão nativa do Gemini CLI já instalada"
-    return 0
-  fi
-  if ! command -v python3 >/dev/null 2>&1; then
-    warn "Gemini CLI detectado, mas Python 3 é necessário para preparar a extensão"
+  MCP_FAILURE_CODE=""
+  MCP_FAILURE_REASON=""
+  if [ ! -x "$binary_path" ]; then
+    MCP_FAILURE_CODE="mcp_binary_missing"
+    MCP_FAILURE_REASON="Runtime binary is missing or not executable: $binary_path"
     return 1
   fi
 
-  plugin_tmp="$(mktemp -d)"
-  plugin_zip="$plugin_tmp/simplicio-master.zip"
-  plugin_url="$GITHUB/archive/refs/heads/master.zip"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$plugin_url" -o "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$plugin_url" -O "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  capture_dir="$(mktemp -d "${TMPDIR:-/tmp}/simplicio-mcp-register.XXXXXX")" || {
+    MCP_FAILURE_CODE="mcp_output_capture_failed"
+    MCP_FAILURE_REASON="Could not create a bounded capture directory for Runtime MCP registration output"
+    return 1
+  }
+  stdout_path="$capture_dir/stdout"
+  stderr_path="$capture_dir/stderr"
+  stdout_fifo="$capture_dir/stdout.fifo"
+  stderr_fifo="$capture_dir/stderr.fifo"
+  code_path="$capture_dir/code"
+  reason_path="$capture_dir/reason"
+  if ! mkfifo "$stdout_fifo" "$stderr_fifo"; then
+    rm -f "$stdout_fifo" "$stderr_fifo"
+    rmdir "$capture_dir" 2>/dev/null || true
+    MCP_FAILURE_CODE="mcp_output_capture_failed"
+    MCP_FAILURE_REASON="Could not create bounded Runtime MCP output streams"
+    return 1
+  fi
+
+  capture_stream_bounded "$stdout_path" "$stdout_path.truncated" 8192 <"$stdout_fifo" &
+  stdout_drain_pid=$!
+  capture_stream_bounded "$stderr_path" "$stderr_path.truncated" 8192 <"$stderr_fifo" &
+  stderr_drain_pid=$!
+
+  if SIMPLICIO_MCP_URL="$SIMPLICIO_MCP_URL" "$binary_path" mcp register --binary "$binary_path" --json >"$stdout_fifo" 2>"$stderr_fifo"; then
+    mcp_exit_code=0
   else
-    rm -rf "$plugin_tmp"
+    mcp_exit_code=$?
+  fi
+  if wait "$stdout_drain_pid"; then stdout_drain_ok=true; else stdout_drain_ok=false; fi
+  if wait "$stderr_drain_pid"; then stderr_drain_ok=true; else stderr_drain_ok=false; fi
+  rm -f "$stdout_fifo" "$stderr_fifo"
+  if [ "$stdout_drain_ok" != "true" ] || [ "$stderr_drain_ok" != "true" ]; then
+    rm -f "$stdout_path" "$stderr_path" "$stdout_path.truncated" "$stderr_path.truncated" "$code_path" "$reason_path"
+    rmdir "$capture_dir" 2>/dev/null || true
+    MCP_FAILURE_CODE="mcp_output_capture_failed"
+    MCP_FAILURE_REASON="Runtime MCP output could not be drained safely"
     return 1
   fi
-
-  plugin_dir="$(python3 - "$plugin_zip" "$plugin_tmp/unpacked" <<'PY'
-import pathlib, sys, zipfile
-archive, destination = sys.argv[1:]
-root = pathlib.Path(destination).resolve()
-root.mkdir(parents=True, exist_ok=True)
-with zipfile.ZipFile(archive) as bundle:
-    for member in bundle.infolist():
-        target = (root / member.filename).resolve()
-        if target != root and root not in target.parents:
-            raise SystemExit("unsafe plugin archive path")
-    bundle.extractall(root)
-matches = list(root.glob("*/plugins/simplicio/gemini-extension.json"))
-if len(matches) != 1:
-    raise SystemExit("Gemini extension manifest not found exactly once")
-print(matches[0].parent)
-PY
-)" || { rm -rf "$plugin_tmp"; return 1; }
-
-  if gemini extensions install "$plugin_dir" --consent >/dev/null 2>&1; then
-    rm -rf "$plugin_tmp"
-    ok "extensão nativa do Gemini CLI instalada"
+  if [ "$mcp_exit_code" -eq 0 ]; then
+    rm -f "$stdout_path" "$stderr_path" "$stdout_path.truncated" "$stderr_path.truncated" "$code_path" "$reason_path"
+    rmdir "$capture_dir" 2>/dev/null || true
     return 0
   fi
-  rm -rf "$plugin_tmp"
+
+  if python3 - "$stdout_path" "$stderr_path" "$code_path" "$reason_path" "$mcp_exit_code" <<'PY'
+import json
+import os
+import sys
+
+
+LIMIT = 8192
+TRUNCATED = "\n...[output truncated at 8192 bytes]"
+
+
+def read_bounded(path):
+    with open(path, "rb") as handle:
+        payload = handle.read(LIMIT)
+    truncated = os.path.exists(path + ".truncated")
+    text = payload.decode("utf-8", errors="replace")
+    return text + (TRUNCATED if truncated else "")
+
+
+def text_value(value):
+    if isinstance(value, str) and value:
+        return value
+    if value is not None and not isinstance(value, (dict, list)):
+        return str(value)
+    return ""
+
+
+stdout = read_bounded(sys.argv[1])
+stderr = read_bounded(sys.argv[2])
+payload = None
+candidates = [stdout.strip()]
+candidates.extend(line.strip() for line in reversed(stdout.splitlines()) if line.strip())
+for candidate in candidates:
+    try:
+        decoded = json.loads(candidate)
+    except (TypeError, ValueError):
+        continue
+    if isinstance(decoded, dict):
+        payload = decoded
+        break
+
+failure = payload.get("failure") if isinstance(payload, dict) else None
+error = payload.get("error") if isinstance(payload, dict) else None
+failure = failure if isinstance(failure, dict) else {}
+error_object = error if isinstance(error, dict) else {}
+
+code = (
+    text_value(failure.get("code"))
+    or (text_value(payload.get("code")) if payload else "")
+    or (text_value(payload.get("error_code")) if payload else "")
+    or text_value(error_object.get("code"))
+    or "mcp_registration_failed"
+)
+reason = (
+    text_value(failure.get("reason"))
+    or (text_value(payload.get("reason")) if payload else "")
+    or (text_value(payload.get("message")) if payload else "")
+    or text_value(error_object.get("reason"))
+    or text_value(error_object.get("message"))
+    or (text_value(error) if not isinstance(error, dict) else "")
+)
+if not reason:
+    fallback = []
+    if stderr.strip():
+        fallback.append(stderr.strip())
+    if stdout.strip() and stdout.strip() not in fallback:
+        fallback.append(stdout.strip())
+    reason = "\n".join(fallback)
+if not reason:
+    reason = f"Runtime MCP registration failed with exit code {sys.argv[5]}"
+
+reason_bytes = reason.encode("utf-8")
+if len(reason_bytes) > LIMIT:
+    reason = reason_bytes[:LIMIT].decode("utf-8", errors="ignore") + TRUNCATED
+
+with open(sys.argv[3], "w", encoding="utf-8", newline="") as handle:
+    handle.write(code)
+with open(sys.argv[4], "w", encoding="utf-8", newline="") as handle:
+    handle.write(reason)
+PY
+  then
+    capture_sentinel="__SIMPLICIO_CAPTURE_EOF__"
+    MCP_FAILURE_CODE="$(cat "$code_path"; printf '%s' "$capture_sentinel")"
+    MCP_FAILURE_CODE="${MCP_FAILURE_CODE%"$capture_sentinel"}"
+    MCP_FAILURE_REASON="$(cat "$reason_path"; printf '%s' "$capture_sentinel")"
+    MCP_FAILURE_REASON="${MCP_FAILURE_REASON%"$capture_sentinel"}"
+  else
+    MCP_FAILURE_CODE="mcp_registration_failed"
+    capture_sentinel="__SIMPLICIO_CAPTURE_EOF__"
+    MCP_FAILURE_REASON="$(head -c 8192 "$stderr_path"; printf '%s' "$capture_sentinel")"
+    MCP_FAILURE_REASON="${MCP_FAILURE_REASON%"$capture_sentinel"}"
+    if [ -z "$MCP_FAILURE_REASON" ]; then
+      MCP_FAILURE_REASON="$(head -c 8192 "$stdout_path"; printf '%s' "$capture_sentinel")"
+      MCP_FAILURE_REASON="${MCP_FAILURE_REASON%"$capture_sentinel"}"
+    fi
+    if [ -z "$MCP_FAILURE_REASON" ]; then
+      MCP_FAILURE_REASON="Runtime MCP registration failed with exit code $mcp_exit_code"
+    fi
+  fi
+
+  rm -f "$stdout_path" "$stderr_path" "$stdout_path.truncated" "$stderr_path.truncated" "$code_path" "$reason_path"
+  rmdir "$capture_dir" 2>/dev/null || true
   return 1
 }
 
-install_portable_agent_plugin() {
-  target_dir="$1"
-  host_name="$2"
-  if ! command -v python3 >/dev/null 2>&1; then
-    warn "$host_name detectado, mas Python 3 é necessário para preparar o Agent Plugin"
+
+probe_host_plugins_capability() {
+  HOST_PLUGINS_STATE="unavailable"
+  HOST_PLUGINS_COMMAND=""
+  HOST_PLUGINS_REASON="Runtime host-plugins capability is unavailable"
+  if [ ! -x "$DEST_PATH" ]; then
+    HOST_PLUGINS_REASON="Runtime binary is missing; host-plugins capability was not checked"
     return 1
   fi
-
-  plugin_tmp="$(mktemp -d)"
-  plugin_zip="$plugin_tmp/simplicio-master.zip"
-  plugin_url="$GITHUB/archive/refs/heads/master.zip"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$plugin_url" -o "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$plugin_url" -O "$plugin_zip" || { rm -rf "$plugin_tmp"; return 1; }
+  host_capture_dir="$(mktemp -d "${TMPDIR:-/tmp}/simplicio-host-plugins.XXXXXX")" || {
+    HOST_PLUGINS_REASON="Could not create bounded host-plugins capability capture"
+    return 1
+  }
+  host_stdout="$host_capture_dir/stdout"
+  host_stderr="$host_capture_dir/stderr"
+  host_stdout_fifo="$host_capture_dir/stdout.fifo"
+  host_stderr_fifo="$host_capture_dir/stderr.fifo"
+  if ! mkfifo "$host_stdout_fifo" "$host_stderr_fifo"; then
+    rm -f "$host_stdout_fifo" "$host_stderr_fifo"
+    rmdir "$host_capture_dir" 2>/dev/null || true
+    HOST_PLUGINS_REASON="Could not create bounded host-plugins capability streams"
+    return 1
+  fi
+  capture_stream_bounded "$host_stdout" "$host_stdout.truncated" 8192 <"$host_stdout_fifo" &
+  host_stdout_pid=$!
+  capture_stream_bounded "$host_stderr" "$host_stderr.truncated" 8192 <"$host_stderr_fifo" &
+  host_stderr_pid=$!
+  if "$DEST_PATH" host-plugins --help >"$host_stdout_fifo" 2>"$host_stderr_fifo"; then
+    host_exit_code=0
   else
-    rm -rf "$plugin_tmp"
-    return 1
+    host_exit_code=$?
   fi
+  if wait "$host_stdout_pid"; then host_stdout_ok=true; else host_stdout_ok=false; fi
+  if wait "$host_stderr_pid"; then host_stderr_ok=true; else host_stderr_ok=false; fi
+  rm -f "$host_stdout_fifo" "$host_stderr_fifo"
 
-  plugin_dir="$(python3 - "$plugin_zip" "$plugin_tmp/unpacked" <<'PY'
-import pathlib, sys, zipfile
-archive, destination = sys.argv[1:]
-root = pathlib.Path(destination).resolve()
-root.mkdir(parents=True, exist_ok=True)
-with zipfile.ZipFile(archive) as bundle:
-    for member in bundle.infolist():
-        target = (root / member.filename).resolve()
-        if target != root and root not in target.parents:
-            raise SystemExit("unsafe plugin archive path")
-    bundle.extractall(root)
-matches = list(root.glob("*/plugins/simplicio/plugin.json"))
-if len(matches) != 1:
-    raise SystemExit("Agent Plugin manifest not found exactly once")
-print(matches[0].parent)
+  host_contract_valid=false
+  if [ "$host_exit_code" -eq 0 ] && [ "$host_stdout_ok" = "true" ] && [ "$host_stderr_ok" = "true" ]; then
+    if python3 - "$host_stdout" "$host_stderr" <<'PY'
+import sys
+
+help_text = "\n".join(
+    open(path, "rb").read(8192).decode("utf-8", errors="replace")
+    for path in sys.argv[1:]
+)
+required = (
+    "simplicio.host-plugins/cli-v1",
+    "simplicio host-plugins plan",
+    "simplicio host-plugins apply",
+    "simplicio host-plugins pending",
+    "simplicio host-plugins reconcile",
+)
+raise SystemExit(0 if all(marker in help_text for marker in required) else 1)
 PY
-)" || { rm -rf "$plugin_tmp"; return 1; }
-
-  mkdir -p "$target_dir" || { rm -rf "$plugin_tmp"; return 1; }
-  if cp -R "$plugin_dir/." "$target_dir/"; then
-    rm -rf "$plugin_tmp"
-    ok "Agent Plugin do Simplicio instalado para $host_name"
-    return 0
+    then
+      host_contract_valid=true
+    fi
   fi
-  rm -rf "$plugin_tmp"
-  return 1
+
+  if [ "$host_contract_valid" = "true" ]; then
+    HOST_PLUGINS_STATE="pending_consent"
+    HOST_PLUGINS_COMMAND="simplicio host-plugins plan --all"
+    HOST_PLUGINS_REASON="Host plugins require separate explicit user consent."
+    host_supported=true
+  else
+    if [ "$host_exit_code" -eq 0 ] && [ "$host_stdout_ok" = "true" ] && [ "$host_stderr_ok" = "true" ]; then
+      host_diagnostic="Runtime returned exit code 0 without the required simplicio.host-plugins/cli-v1 contract marker and commands"
+    else
+      capture_sentinel="__SIMPLICIO_CAPTURE_EOF__"
+      host_diagnostic="$(cat "$host_stderr"; printf '%s' "$capture_sentinel")"
+      host_diagnostic="${host_diagnostic%"$capture_sentinel"}"
+      if [ -z "$host_diagnostic" ]; then
+        host_diagnostic="$(cat "$host_stdout"; printf '%s' "$capture_sentinel")"
+        host_diagnostic="${host_diagnostic%"$capture_sentinel"}"
+      fi
+      if [ -z "$host_diagnostic" ]; then
+        host_diagnostic="Runtime exited with code $host_exit_code"
+      fi
+    fi
+    HOST_PLUGINS_REASON="Runtime host-plugins capability unavailable: $host_diagnostic"
+    host_supported=false
+  fi
+  rm -f "$host_stdout" "$host_stderr" "$host_stdout.truncated" "$host_stderr.truncated"
+  rmdir "$host_capture_dir" 2>/dev/null || true
+  [ "$host_supported" = "true" ]
 }
 
-install_detected_host_plugins() {
-  if [ "${SIMPLICIO_INSTALL_HOST_PLUGINS:-1}" = "0" ]; then
-    info "instalação de plugins nativos ignorada por SIMPLICIO_INSTALL_HOST_PLUGINS=0"
-    return 0
+report_host_plugin_consent() {
+  if [ "$HOST_PLUGINS_STATE" = "pending_consent" ]; then
+    info "plugins de hosts aguardam consentimento separado; nenhum plugin de host foi alterado"
+    info "revise o plano somente pelo Runtime: $DEST_PATH host-plugins plan --all"
+  else
+    warn "capacidade host-plugins indisponível neste Runtime; nenhum plugin de host foi alterado"
   fi
-
-  detected=0
-  failures=0
-  if command -v codex >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    codex plugin marketplace add "$REPO" --ref master \
-      --sparse .agents/plugins --sparse plugins/simplicio >/dev/null 2>&1 || true
-    if codex plugin add simplicio@simplicio-codex >/dev/null 2>&1; then
-      ok "plugin nativo do Codex instalado"
-    else
-      warn "Codex detectado, mas o plugin simplicio@simplicio-codex não pôde ser instalado"
-      failures=$((failures + 1))
-    fi
-  fi
-
-  if command -v claude >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    claude plugin marketplace add "$REPO" >/dev/null 2>&1 || true
-    for plugin_name in $MARKETPLACE_PLUGINS; do
-      if claude plugin install "$plugin_name@simplicio" --scope user >/dev/null 2>&1; then
-        ok "plugin $plugin_name instalado no Claude Code"
-      else
-        warn "Claude Code detectado, mas $plugin_name@simplicio não pôde ser instalado"
-        failures=$((failures + 1))
-      fi
-    done
-  fi
-
-  if command -v gemini >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    if ! install_gemini_extension; then
-      warn "Gemini CLI detectado, mas a extensão nativa do Simplicio não pôde ser instalada"
-      failures=$((failures + 1))
-    fi
-  fi
-
-  if command -v copilot >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    copilot plugin marketplace add "$REPO" >/dev/null 2>&1 || true
-    for plugin_name in $MARKETPLACE_PLUGINS; do
-      if copilot plugin install "$plugin_name@simplicio" >/dev/null 2>&1; then
-        ok "plugin $plugin_name instalado no GitHub Copilot CLI"
-      else
-        warn "GitHub Copilot CLI detectado, mas $plugin_name@simplicio não pôde ser instalado"
-        failures=$((failures + 1))
-      fi
-    done
-  fi
-
-  if command -v qwen >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    for plugin_name in $MARKETPLACE_PLUGINS; do
-      if qwen extensions install "$REPO:$plugin_name" >/dev/null 2>&1; then
-        ok "extensão $plugin_name instalada no Qwen Code"
-      else
-        warn "Qwen Code detectado, mas $plugin_name não pôde ser instalado"
-        failures=$((failures + 1))
-      fi
-    done
-  fi
-
-  if command -v hermes >/dev/null 2>&1; then
-    detected=$((detected + 1))
-    if hermes plugins install "$REPO/plugins/simplicio-hermes" --force --enable >/dev/null 2>&1 &&
-       hermes plugins doctor simplicio-hermes --ci >/dev/null 2>&1; then
-      ok "plugin simplicio-hermes instalado, habilitado e validado"
-    else
-      warn "Hermes detectado, mas o plugin simplicio-hermes não pôde ser instalado e habilitado"
-      failures=$((failures + 1))
-    fi
-  fi
-
-  cursor_detected=0
-  if command -v cursor >/dev/null 2>&1 || command -v cursor-agent >/dev/null 2>&1 ||
-     [ -d "$HOME/.cursor" ] || [ -d "$HOME/Library/Application Support/Cursor" ]; then
-    cursor_detected=1
-  fi
-  if [ "$cursor_detected" -eq 1 ]; then
-    detected=$((detected + 1))
-    if ! install_portable_agent_plugin "$HOME/.cursor/plugins/local/simplicio" "Cursor"; then
-      failures=$((failures + 1))
-    fi
-  fi
-
-  kiro_detected=0
-  if command -v kiro >/dev/null 2>&1 || command -v kiro-cli >/dev/null 2>&1 ||
-     [ -d "$HOME/.kiro" ] || [ -d "/Applications/Kiro.app" ]; then
-    kiro_detected=1
-  fi
-  if [ "$kiro_detected" -eq 1 ]; then
-    detected=$((detected + 1))
-    if ! install_portable_agent_plugin "$HOME/.kiro/powers/simplicio" "Kiro"; then
-      failures=$((failures + 1))
-    fi
-  fi
-
-  if [ "$detected" -eq 0 ]; then
-    info "nenhum host com pacote de plugin compatível detectado; o registro MCP cobre os demais clientes"
-  fi
-  [ "$failures" -eq 0 ]
 }
 
 # ─── --doctor: idempotent, read-only health check ──────────────────────────
@@ -497,9 +877,9 @@ run_doctor() {
     fi
 
     if verify_active_login; then
-      ok "sessão Google ativa e entitlement válido"
+      ok "sessão Google verificada de forma fresh e entitlement válido"
     else
-      warn "sessão Google ausente, expirada, revogada ou sem entitlement ativo"
+      warn "sessão Google não verificada de forma fresh (ausente, cacheada, expirada, revogada ou sem entitlement)"
       status=1
     fi
   fi
@@ -507,7 +887,7 @@ run_doctor() {
   if [ "$status" -eq 0 ]; then
     ok "simplicio está saudável"
   else
-    err "simplicio tem problemas — rode o instalador novamente"
+    warn "simplicio tem problemas — rode o instalador novamente"
   fi
   exit "$status"
 }
@@ -546,7 +926,7 @@ run_uninstall() {
 }
 
 case "${1:-}" in
-  --doctor) detect_platform; run_doctor ;;
+  --doctor) run_doctor ;;
   --uninstall)
     case "${2:-}" in
       ""|--keep-data) UNINSTALL_MODE="keep-data" ;;
@@ -567,12 +947,14 @@ printf '%b' "${NC}"
 echo ""
 
 # ─── 1. Detect platform ──────────────────────────────────────────────────────
+INSTALL_STAGE="platform_detection"
 detect_platform
 info "Plataforma detectada: $OS-$ARCH"
 
 # ─── 2. Instalar simplicio binary (staged download + SHA256 + atomic swap) ──
+INSTALL_STAGE="runtime_install"
 info "Instalando Simplicio Runtime..."
-mkdir -p "$BIN_DIR"
+mkdir -p "$BIN_DIR" || err "não foi possível criar o diretório do Runtime: $BIN_DIR"
 
 # A plain re-run means "update to latest". Only skip the download when the
 # caller explicitly pins the version already installed; otherwise an older
@@ -620,7 +1002,7 @@ if [ "$SKIP_EXISTING" != "true" ]; then
   SIGNATURE=""
   SIGNING_PUBKEY=""
   SIGNATURE_REQUIRED="false"
-  MANIFEST_TMP="$(mktemp)"
+  MANIFEST_TMP="$(mktemp)" || err "não foi possível criar o arquivo temporário do manifest de release"
   trap 'rm -f "$MANIFEST_TMP"' EXIT
   if fetch "$MANIFEST_URL" "$MANIFEST_TMP" 2>/dev/null; then
     if ! command -v python3 >/dev/null 2>&1; then
@@ -720,7 +1102,7 @@ except Exception:
   fi
 
   if [ "$SIGNED" = "true" ]; then
-    SIGNATURE_HELPER_TMP="$(mktemp)"
+    SIGNATURE_HELPER_TMP="$(mktemp)" || err "não foi possível criar o arquivo temporário do verificador Ed25519"
     if [ "$SIGNING_PUBKEY" != "$ED25519_PUBLIC_KEY" ] || ! verify_ed25519_signature "$STAGING_PATH" "$SIGNATURE" "$ED25519_PUBLIC_KEY" "$EXPECTED_SHA256" "$SIGNATURE_HELPER_TMP"; then
       rm -f "$STAGING_PATH" "$SIGNATURE_HELPER_TMP"
       err "assinatura Ed25519 inválida ou não verificável; instalação recusada"
@@ -729,7 +1111,7 @@ except Exception:
     ok "assinatura Ed25519 verificada sobre o digest SHA256"
   fi
 
-  chmod +x "$STAGING_PATH"
+  chmod +x "$STAGING_PATH" || { rm -f "$STAGING_PATH"; err "não foi possível tornar o Runtime baixado executável"; }
   # Validate the staged executable before the atomic swap. A release that lacks
   # embedded sources, Google login activation, or the signed-update key must
   # not replace a working installation and then fail its post-install checks.
@@ -752,39 +1134,48 @@ except Exception:
     rm -f "$STAGING_PATH" "$PREVIOUS_PATH"
     err "não foi possível ativar o Runtime verificado"
   fi
+  INSTALL_EFFECT_STARTED="true"
+  RUNTIME_INSTALLED="true"
   INSTALL_TRANSACTION_ACTIVE="false"
-  rm -f "$PREVIOUS_PATH"
+  if ! rm -f "$PREVIOUS_PATH"; then
+    err "o Runtime foi ativado, mas o backup temporário não pôde ser removido: $PREVIOUS_PATH"
+  fi
   ok "Simplicio Runtime instalado em $DEST_PATH"
 fi
 
 # ─── 2.1 Verificar o contrato de release antes de anunciar sucesso ──────────
+INSTALL_STAGE="runtime_contract"
 if ! verify_runtime_contract "$DEST_PATH"; then
   report_runtime_contract "$DEST_PATH"
   err "este Runtime não atende ao contrato de distribuição (fontes embutidas, login Google e chave pública de updates); instalação interrompida"
 fi
+RUNTIME_INSTALLED="true"
 ok "contrato de release do Runtime verificado"
 
 # ─── 2.2 Register MCP and native hooks for every detected client ───────────
-if verify_mcp_tools "$DEST_PATH"; then
-  ok "MCP e hooks registrados automaticamente para os clientes detectados"
-else
-  err "o Runtime foi instalado, mas o registro automático de MCP/hooks falhou: $DEST_PATH mcp register --binary $DEST_PATH --json"
-fi
+INSTALL_STAGE="mcp_registration"
+# Registration may update several client configs before returning a failure.
+# From this point an error is conservatively recorded as a partial effect.
+INSTALL_EFFECT_STARTED="true"
+  if verify_mcp_tools "$DEST_PATH"; then
+    MCP_REGISTERED="true"
+    ok "MCP e hooks registrados automaticamente para os clientes detectados"
+  else
+    fail_install "${MCP_FAILURE_CODE:-mcp_registration_failed}" "${MCP_FAILURE_REASON:-Runtime MCP registration failed without a diagnostic}"
+  fi
+INSTALL_STAGE="hook_registration"
 if reconcile_public_route_overlay; then
-  ok "hook público v11 verificado e reconciliado após o registro do Runtime"
+  HOOK_INSTALLED="true"
+  ok "hook público v12 verificado e reconciliado após o registro do Runtime"
 else
-  err "o Runtime registrou o MCP, mas o hook público v11 não pôde ser verificado e ativado"
+  fail_install "${HOOK_FAILURE_CODE:-hook_registration_failed}" "${HOOK_FAILURE_REASON:-Public hook registration failed without a diagnostic}"
 fi
 
-# Host packages add skills, commands and host-specific lifecycle behavior on
-# top of Runtime MCP registration. Every detected host with a documented
-# package surface is installed automatically; MCP remains the compatibility
-# path for clients without a package API.
-if install_detected_host_plugins; then
-  ok "plugins nativos reconciliados para os hosts detectados"
-else
-  err "Runtime/MCP estão prontos, mas a instalação automática de um ou mais plugins detectados falhou; consulte PLUGIN.md"
-fi
+# Host-specific plugin changes require a second, explicit consent transaction.
+# This installer never invokes host CLIs and never downloads a mutable plugin
+# archive. The Runtime owns planning, application, receipts and reconciliation.
+probe_host_plugins_capability || true
+report_host_plugin_consent
 report_login_state
 ok "MCP direto: $DEST_PATH serve --mcp --stdio; SIMPLICIO_MCP_URL=${SIMPLICIO_MCP_URL}"
 
@@ -797,15 +1188,25 @@ case ":$PATH:" in
 esac
 
 # ─── 3. Registrar e anunciar o contrato do Runtime ──────────────────────────
+INSTALL_STAGE="runtime_report"
 BUNDLE_DIR="${SIMPLICIO_BUNDLE_DIR:-$HOME/.simplicio}"
 RUNTIME_REPORT="$BUNDLE_DIR/runtime-release.json"
-mkdir -p "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR" || err "não foi possível criar o diretório do relatório do Runtime: $BUNDLE_DIR"
 if "$DEST_PATH" version --json >"$RUNTIME_REPORT" 2>/dev/null; then
   ok "contrato de release registrado em $RUNTIME_REPORT"
 else
-  rm -f "$RUNTIME_REPORT"
+  if ! rm -f "$RUNTIME_REPORT"; then
+    err "o Runtime falhou ao gerar o relatório e o arquivo parcial não pôde ser removido: $RUNTIME_REPORT"
+  fi
   err "não foi possível persistir o contrato de release; instalação interrompida"
 fi
+
+INSTALL_STAGE="complete"
+if ! persist_install_receipt "succeeded" 0 "" ""; then
+  INSTALL_STAGE="receipt_persistence"
+  err "Runtime/MCP/hook foram instalados, mas o recibo estruturado da instalação não pôde ser persistido"
+fi
+ok "recibo estruturado da instalação registrado em $INSTALL_RECEIPT"
 
 # ─── 4. Mensagem final ───────────────────────────────────────────────────────
 echo ""
@@ -815,8 +1216,17 @@ printf '%b\n' "${GREEN}║   Simplicio Runtime instalado com sucesso!           
 printf '%b\n' "${GREEN}║                                                          ║${NC}"
 printf '%b\n' "${GREEN}║   ✓ Contrato de release verificado                       ║${NC}"
 printf '%b\n' "${GREEN}║   ✓ Sem pip ou clones durante a instalação               ║${NC}"
-printf '%b\n' "${GREEN}║   ✓ Login Google verificável após auth login             ║${NC}"
+if verify_active_login; then
+  printf '%b\n' "${GREEN}║   ✓ Sessão Google fresh verificada                       ║${NC}"
+else
+  printf '%b\n' "${YELLOW}║   ⚠ Login Google pendente: execute auth login            ║${NC}"
+fi
 printf '%b\n' "${GREEN}║   ✓ MCP direto para o binário gerenciado                 ║${NC}"
+if [ "$HOST_PLUGINS_STATE" = "pending_consent" ]; then
+  printf '%b\n' "${GREEN}║   ⏳ Plugins aguardam consentimento separado             ║${NC}"
+else
+  printf '%b\n' "${YELLOW}║   ⚠ Plugins indisponíveis neste Runtime                  ║${NC}"
+fi
 printf '%b\n' "${GREEN}║   🩺 Doctor: sh install.sh --doctor                     ║${NC}"
 printf '%b\n' "${GREEN}║                                                          ║${NC}"
 printf '%b\n' "${GREEN}╚══════════════════════════════════════════════════════════╝${NC}"

--- a/tests/test_codex_install_contract.py
+++ b/tests/test_codex_install_contract.py
@@ -3,9 +3,8 @@
 import hashlib
 import json
 import os
-from pathlib import Path
 import subprocess
-
+from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
 
@@ -35,7 +34,10 @@ def test_installers_configure_direct_stdio_and_hooks():
         text = (ROOT / name).read_text(encoding="utf-8")
         assert "SIMPLICIO_MCP_URL" in text
         assert "serve" in text and "--mcp" in text and "--stdio" in text
-        assert "mcp register" in text
+        if name == "install.sh":
+            assert "mcp register" in text
+        else:
+            assert '@("mcp", "register", "--binary", $BinaryPath, "--json")' in text
         assert "--binary" in text
         assert "--json" in text
 
@@ -51,15 +53,16 @@ def test_plain_install_registers_all_detected_hosts_without_codex_opt_in():
     assert "SIMPLICIO_INSTALL_CODEX" not in powershell
     assert "SIMPLICIO_CODEX_HOOK_REF" not in powershell
     assert "if (Require-ActiveLogin)" not in powershell
-    assert "mcp register --binary $BinaryPath --json" in powershell
+    assert '@("mcp", "register", "--binary", $BinaryPath, "--json")' in powershell
 
 
 def test_installers_preserve_existing_codex_state():
     shell = (ROOT / "install.sh").read_text(encoding="utf-8")
     powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
     assert "mcp register" in shell
-    assert "mcp register" in powershell
-    assert "automatic MCP/hooks registration failed" in powershell
+    assert '@("mcp", "register", "--binary", $BinaryPath, "--json")' in powershell
+    assert "Resolve-RuntimeFailure" in powershell
+    assert "$script:McpFailureReason" in powershell
 
 
 def test_installers_preserve_stable_login_state_during_upgrades():
@@ -76,8 +79,8 @@ def test_windows_installer_reconciles_the_pinned_public_hook_after_runtime_regis
     hook_digest = hashlib.sha256((ROOT / "codex" / "mcp-route.ps1").read_bytes()).hexdigest()
     assert "Install-CodexRouteHook" not in powershell
     assert "SIMPLICIO_CODEX_HOOK_REF" not in powershell
-    assert "mcp register --binary $BinaryPath --json" in powershell
-    assert '$PublicRouteRef = "cc9950025baf823cdecc657228ff1e89d7701e7e"' in powershell
+    assert '@("mcp", "register", "--binary", $BinaryPath, "--json")' in powershell
+    assert '$PublicRouteRef = "68b4c7f7ac27d07624ffa4ddf0673a43e180c3e5"' in powershell
     assert f'$PublicRouteSha256 = "{hook_digest}"' in powershell
     assert "Sync-PublicRouteOverlay" in powershell
     assert powershell.index("Test-McpToolSurface $DestPath") < powershell.index("if (Sync-PublicRouteOverlay)")
@@ -90,7 +93,7 @@ def test_unix_installer_reconciles_the_pinned_public_hook_after_runtime_registra
     assert "install_codex_route_hook" not in shell
     assert "SIMPLICIO_CODEX_HOOK_REF" not in shell
     assert 'mcp register --binary "$binary_path" --json' in shell
-    assert 'PUBLIC_ROUTE_REF="cc9950025baf823cdecc657228ff1e89d7701e7e"' in shell
+    assert 'PUBLIC_ROUTE_REF="68b4c7f7ac27d07624ffa4ddf0673a43e180c3e5"' in shell
     assert f'PUBLIC_ROUTE_SHA256="{hook_digest}"' in shell
     assert "reconcile_public_route_overlay" in shell
     assert shell.index('if verify_mcp_tools "$DEST_PATH"') < shell.index("if reconcile_public_route_overlay")
@@ -115,8 +118,8 @@ def test_codex_hooks_have_all_required_lifecycle_events():
     assert "permissionDecision = 'deny'" in powershell_hook
     assert "hookEventName" in shell_hook
     assert "hookEventName" in powershell_hook
-    assert "simplicio-hook-version: 3240-v11" in shell_hook
-    assert "simplicio-hook-version: 3240-v11" in powershell_hook
+    assert "simplicio-hook-version: 3240-v12" in shell_hook
+    assert "simplicio-hook-version: 3240-v12" in powershell_hook
     assert "Empty stdout is the portable allow-unchanged contract" in shell_hook
     assert "No decision means allow unchanged" in powershell_hook
     assert "Allow-Unchanged" in powershell_hook
@@ -126,7 +129,9 @@ def test_codex_hooks_have_all_required_lifecycle_events():
         assert event in shell_hook
         assert event in powershell_hook
     assert "mcp register" in (ROOT / "install.sh").read_text(encoding="utf-8")
-    assert "mcp register" in (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert '@("mcp", "register", "--binary", $BinaryPath, "--json")' in (
+        ROOT / "install.ps1"
+    ).read_text(encoding="utf-8")
     assert "result=subprocess.run([binary,'map','--repo'" in shell_hook
     assert "simplicio_context" in shell_hook
     assert 'SIMPLICIO_BIN="${SIMPLICIO_BIN:-${SIMPLICIO_BIN_DIR:-${HOME}/.simplicio/bin}/simplicio}"' in shell_hook

--- a/tests/test_installer_host_plugins_contract.py
+++ b/tests/test_installer_host_plugins_contract.py
@@ -1,75 +1,941 @@
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
 from pathlib import Path
 
+import pytest
 
 ROOT = Path(__file__).parents[1]
+RELEASE_VERSION = "3.8.40"
+SHELL_HOOK_SHA256 = "d91200cae4816c79fe0c903fc6eedc01835a557827e8d3d0480304f3bdce5118"
+FAKE_MCP_FAILURE_CODE = "runtime_mcp_registration_denied"
+FAKE_MCP_FAILURE_REASON = "Runtime refused MCP registration\nhost config policy\tdenied"
+FRESH_AUTH = {
+    "identity": {
+        "enabled": True,
+        "login_enabled": True,
+        "status": "active",
+        "email": "qa@example.test",
+    },
+    "entitlement": {"updates_allowed": True},
+    "session_verification": {"verified": True, "cached": False},
+}
+CACHED_AUTH = {
+    **FRESH_AUTH,
+    "session_verification": {"verified": True, "cached": True},
+}
+MISSING_AUTH_FIELDS = {
+    "identity": {"enabled": True, "login_enabled": True, "email": "qa@example.test"},
+}
 
 
-def test_shell_installs_documented_native_plugins_after_runtime_registration() -> None:
-    text = (ROOT / "install.sh").read_text(encoding="utf-8")
-    registration = 'verify_mcp_tools "$DEST_PATH"'
-    plugin_install = "install_detected_host_plugins"
-
-    assert 'command -v codex' in text
-    assert 'codex plugin marketplace add "$REPO" --ref master \\' in text
-    assert "--sparse .agents/plugins --sparse plugins/simplicio" in text
-    assert "codex plugin add simplicio@simplicio-codex" in text
-    assert 'command -v claude' in text
-    assert 'claude plugin marketplace add "$REPO"' in text
-    assert 'MARKETPLACE_PLUGINS="simplicio simplicio-loop simplicio-prompt simplicio-sprint simplicio-hermes"' in text
-    assert 'claude plugin install "$plugin_name@simplicio" --scope user' in text
-    assert 'command -v gemini' in text
-    assert 'gemini extensions install "$plugin_dir" --consent' in text
-    assert 'command -v copilot' in text
-    assert 'copilot plugin install "$plugin_name@simplicio"' in text
-    assert 'command -v qwen' in text
-    assert 'qwen extensions install "$REPO:$plugin_name"' in text
-    assert 'command -v hermes' in text
-    assert 'hermes plugins install "$REPO/plugins/simplicio-hermes" --force --enable' in text
-    assert 'hermes plugins doctor simplicio-hermes --ci' in text
-    assert '"$HOME/.cursor/plugins/local/simplicio"' in text
-    assert '"$HOME/.kiro/powers/simplicio"' in text
-    assert 'err "Runtime/MCP estão prontos, mas a instalação automática' in text
-    assert text.index(registration) < text.index(plugin_install, text.index(registration))
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
-def test_powershell_installs_documented_native_plugins_after_runtime_registration() -> None:
-    text = (ROOT / "install.ps1").read_text(encoding="utf-8")
-    registration = "Test-McpToolSurface $DestPath"
-    plugin_install = "Install-DetectedHostPlugins"
+def _fake_runtime(path: Path) -> None:
+    _write_executable(
+        path,
+        """#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$FAKE_RUNTIME_LOG"
+case "${1:-}:${2:-}" in
+  --version:)
+    printf '%s\n' 'simplicio 3.8.40'
+    ;;
+  version:--json)
+    cat <<'JSON'
+{
+  "version": "3.8.40",
+  "auto_update": {"distribution": {"source_code_distributed": true}},
+  "identity": {"enabled": true, "login_enabled": true},
+  "security": {"signature_required": true, "public_key_configured": true}
+}
+JSON
+    ;;
+  version:)
+    printf '%s\n' 'simplicio 3.8.40'
+    ;;
+    mcp:register)
+    if [ "${FAKE_MCP_EXIT:-0}" -ne 0 ]; then
+      cat <<'JSON'
+{"failure":{"code":"runtime_mcp_registration_denied","reason":"Runtime refused MCP registration\\nhost config policy\\tdenied"}}
+JSON
+      printf '%s\n' 'fallback diagnostic must not replace the structured Runtime reason' >&2
+      if [ "${FAKE_MCP_BURST:-0}" = "1" ]; then
+        awk 'BEGIN { for (i = 0; i < 262144; i++) printf "o"; print "" }'
+        awk 'BEGIN { for (i = 0; i < 262144; i++) printf "e"; print "" }' >&2
+      fi
+    fi
+    exit "${FAKE_MCP_EXIT:-0}"
+    ;;
+    auth:status)
+    if [ -n "${FAKE_AUTH_JSON:-}" ]; then
+      printf '%s\n' "$FAKE_AUTH_JSON"
+      exit 0
+    fi
+    cat <<'JSON'
+{
+  "identity": {
+    "enabled": true,
+    "login_enabled": true,
+    "status": "active",
+    "email": "qa@example.test"
+  },
+    "entitlement": {"updates_allowed": true},
+    "session_verification": {"verified": true, "cached": false}
+}
+JSON
+    ;;
+  host-plugins:--help)
+    if [ "${FAKE_HOST_PLUGINS_EXIT:-2}" -eq 0 ]; then
+      case "${FAKE_HOST_PLUGINS_HELP_MODE:-contract}" in
+        contract)
+          cat <<'HELP'
+simplicio.host-plugins/cli-v1
+simplicio host-plugins plan (--all | --host HOST)
+simplicio host-plugins apply (--all | --host HOST) --plan-digest sha256:HEX --yes
+simplicio host-plugins verify (--all | --host HOST)
+simplicio host-plugins status
+simplicio host-plugins pending
+simplicio host-plugins snapshot --receipt-id sha256:HEX
+simplicio host-plugins reconcile --receipt-id sha256:HEX
+HELP
+          ;;
+        wrong) printf '%s\n' 'Usage: simplicio shell --repo PATH -- COMMAND' ;;
+        empty) : ;;
+      esac
+      exit 0
+    fi
+    printf '%s\n' '{"code":"host_plugins_unavailable","message":"host-plugins is unavailable in Runtime 3.8.40"}'
+    exit "${FAKE_HOST_PLUGINS_EXIT:-2}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+""",
+    )
 
-    assert "Get-Command codex -CommandType Application" in text
-    assert '"plugin", "marketplace", "add", $Repo, "--ref", "master",' in text
-    assert '"--sparse", ".agents/plugins", "--sparse", "plugins/simplicio"' in text
-    assert '@("plugin", "add", "simplicio@simplicio-codex")' in text
-    assert "Get-Command claude -CommandType Application" in text
-    assert '@("plugin", "marketplace", "add", $Repo)' in text
-    assert '$MarketplacePlugins = @("simplicio", "simplicio-loop", "simplicio-prompt", "simplicio-sprint", "simplicio-hermes")' in text
-    assert '@("plugin", "install", "$pluginName@simplicio", "--scope", "user")' in text
-    assert "Get-Command gemini -CommandType Application" in text
-    assert '@("extensions", "install", $manifest.DirectoryName, "--consent")' in text
-    assert "Get-Command copilot -CommandType Application" in text
-    assert '@("plugin", "install", "$pluginName@simplicio")' in text
-    assert "Get-Command qwen -CommandType Application" in text
-    assert '@("extensions", "install", "${Repo}:$pluginName")' in text
-    assert "Get-Command hermes -CommandType Application" in text
-    assert '@("plugins", "install", "$Repo/plugins/simplicio-hermes", "--force", "--enable")' in text
-    assert '@("plugins", "doctor", "simplicio-hermes", "--ci")' in text
-    assert '".cursor\\plugins\\local\\simplicio"' in text
-    assert '".kiro\\powers\\simplicio"' in text
-    assert 'Write-Error "Runtime/MCP are ready, but automatic installation' in text
-    assert text.index(registration) < text.index(plugin_install, text.index(registration))
+
+def _shell_fixture(
+    tmp_path: Path,
+    mcp_exit: int,
+    *,
+    host_plugins_exit: int = 2,
+    host_plugins_help_mode: str = "contract",
+    mcp_burst: bool = False,
+) -> tuple[dict[str, str], Path, Path]:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    runtime = install_bin / "simplicio"
+    runtime_log = tmp_path / "runtime.log"
+    host_log = tmp_path / "host.log"
+    fake_bin = tmp_path / "fake-bin"
+
+    _fake_runtime(runtime)
+    hook = bundle / "hooks" / "mcp-route.sh"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("# test hook; hash is supplied by the fake checksum tool\n", encoding="utf-8")
+    _write_executable(
+        fake_bin / "sha256sum",
+        f"""#!/bin/sh
+if [ "${{FAKE_BAD_HOOK_HASH:-0}}" = "1" ]; then
+  printf '%064d  %s\n' 0 "$1"
+else
+  printf '%s  %s\n' '{SHELL_HOOK_SHA256}' "$1"
+fi
+""",
+    )
+    for host in ("codex", "claude", "gemini", "copilot", "qwen", "hermes", "cursor", "kiro"):
+        _write_executable(
+            fake_bin / host,
+            "#!/bin/sh\nprintf '%s\\n' \"$0 $*\" >>\"$FAKE_HOST_LOG\"\nexit 97\n",
+        )
+    _write_executable(
+        fake_bin / "curl",
+        """#!/bin/sh
+printf '%s\n' '{"failure":{"code":"hook_fetch_denied","reason":"public hook download denied by fixture"}}'
+printf '%s\n' 'fallback hook diagnostic' >&2
+exit "${FAKE_HOOK_DOWNLOAD_EXIT:-22}"
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "SIMPLICIO_VERSION": RELEASE_VERSION,
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_HOST_LOG": str(host_log),
+            "FAKE_MCP_EXIT": str(mcp_exit),
+            "FAKE_MCP_BURST": "1" if mcp_burst else "0",
+            "FAKE_HOST_PLUGINS_EXIT": str(host_plugins_exit),
+            "FAKE_HOST_PLUGINS_HELP_MODE": host_plugins_help_mode,
+            "PATH": os.pathsep.join((str(fake_bin), os.environ["PATH"])),
+        }
+    )
+    return env, bundle, host_log
 
 
-def test_host_plugin_bootstrap_is_idempotent_and_uses_documented_surfaces() -> None:
-    shell = (ROOT / "install.sh").read_text(encoding="utf-8")
-    powershell = (ROOT / "install.ps1").read_text(encoding="utf-8")
-    bootstrap = (
-        ROOT / "plugins/simplicio/bin/simplicio-mcp-bootstrap.js"
-    ).read_text(encoding="utf-8")
+def _run_shell_installer(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", str(ROOT / "install.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
 
-    for text in (shell, powershell):
-        assert "SIMPLICIO_INSTALL_HOST_PLUGINS" in text
-        for unsupported in ("cursor plugin install", "code plugin install", "kiro plugin install"):
-            assert unsupported not in text.lower()
 
-    assert 'SIMPLICIO_INSTALL_HOST_PLUGINS: "0"' in bootstrap
+def test_shell_code_1_preserves_exact_partial_receipt(tmp_path: Path) -> None:
+    env, bundle, host_log = _shell_fixture(tmp_path, mcp_exit=1)
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 1
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["schema"] == "simplicio-install-receipt/v1"
+    assert receipt["status"] == "partial"
+    assert receipt["exit_code"] == 1
+    assert receipt["stage"] == "mcp_registration"
+    assert receipt["failure"] == {
+        "code": FAKE_MCP_FAILURE_CODE,
+        "reason": FAKE_MCP_FAILURE_REASON,
+    }
+    assert FAKE_MCP_FAILURE_REASON in result.stderr
+    assert "fallback diagnostic must not replace" not in receipt["failure"]["reason"]
+    assert receipt["runtime"] == {"installed": True}
+    assert receipt["mcp"] == {"registered": False}
+    assert receipt["hook"] == {"installed": False}
+    assert receipt["host_plugins"]["state"] == "unavailable"
+    assert receipt["host_plugins"]["mutated"] is False
+    assert (bundle / "install-receipt.json").stat().st_size < 16_384
+    assert not host_log.exists()
+
+
+def test_shell_drains_oversized_runtime_output_without_expanding_receipt(tmp_path: Path) -> None:
+    env, bundle, _ = _shell_fixture(tmp_path, mcp_exit=1, mcp_burst=True)
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 1
+    receipt_path = bundle / "install-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["failure"] == {
+        "code": FAKE_MCP_FAILURE_CODE,
+        "reason": FAKE_MCP_FAILURE_REASON,
+    }
+    assert receipt_path.stat().st_size < 16_384
+
+
+def test_shell_pre_python_failure_receipt_escapes_control_bytes(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    fake_bin = tmp_path / "fake-bin"
+    blocked_bin = tmp_path / "blocked\nruntime\tbin"
+    blocked_bin.write_text("not a directory", encoding="utf-8")
+    _write_executable(fake_bin / "python3", "#!/bin/sh\nexit 127\n")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(blocked_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "SIMPLICIO_VERSION": RELEASE_VERSION,
+            "PATH": os.pathsep.join((str(fake_bin), "/bin", "/usr/bin")),
+        }
+    )
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 1
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "failed"
+    assert receipt["failure"] == {
+        "code": "runtime_install_failed",
+        "reason": f"não foi possível criar o diretório do Runtime: {blocked_bin}",
+    }
+
+
+def test_shell_doctor_failure_never_mutates_existing_partial_receipt(tmp_path: Path) -> None:
+    env, bundle, _ = _shell_fixture(tmp_path, mcp_exit=0)
+    runtime = Path(env["SIMPLICIO_BIN_DIR"]) / "simplicio"
+    runtime.unlink()
+    receipt_path = bundle / "install-receipt.json"
+    original = (
+        b'{"schema":"simplicio-install-receipt/v1","status":"partial",'
+        b'"failure":{"code":"preserve_me","reason":"original bytes"}}\n'
+    )
+    receipt_path.write_bytes(original)
+    os.utime(receipt_path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+    before = receipt_path.stat()
+    before_digest = hashlib.sha256(original).hexdigest()
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "install.sh"), "--doctor"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert receipt_path.read_bytes() == original
+    assert hashlib.sha256(receipt_path.read_bytes()).hexdigest() == before_digest
+    after = receipt_path.stat()
+    assert after.st_mtime_ns == before.st_mtime_ns
+
+
+def test_shell_doctor_unsupported_platform_never_mutates_receipt(tmp_path: Path) -> None:
+    env, bundle, _ = _shell_fixture(tmp_path, mcp_exit=0)
+    runtime = Path(env["SIMPLICIO_BIN_DIR"]) / "simplicio"
+    runtime.unlink()
+    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
+    uname_log = tmp_path / "uname-called.log"
+    _write_executable(
+        fake_bin / "uname",
+        f"""#!/bin/sh
+printf '%s\n' "$1" >>'{uname_log}'
+case "$1" in
+  -s) printf '%s\n' 'Plan9' ;;
+  -m) printf '%s\n' 'riscv128' ;;
+esac
+""",
+    )
+    receipt_path = bundle / "install-receipt.json"
+    original = (
+        b'{"schema":"simplicio-install-receipt/v1","status":"partial",'
+        b'"failure":{"code":"unsupported_preserve","reason":"original bytes"}}\n'
+    )
+    receipt_path.write_bytes(original)
+    os.utime(receipt_path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+    before = receipt_path.stat()
+    before_digest = hashlib.sha256(original).hexdigest()
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "install.sh"), "--doctor"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert not uname_log.exists(), "--doctor must not execute platform detection"
+    assert receipt_path.read_bytes() == original
+    assert hashlib.sha256(receipt_path.read_bytes()).hexdigest() == before_digest
+    after = receipt_path.stat()
+    assert after.st_mtime_ns == before.st_mtime_ns
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_code", "fresh_verified"),
+    [
+        (FRESH_AUTH, 0, True),
+        (CACHED_AUTH, 1, False),
+        (MISSING_AUTH_FIELDS, 1, False),
+    ],
+)
+def test_shell_doctor_requires_fresh_complete_login_evidence(
+    tmp_path: Path,
+    payload: dict[str, object],
+    expected_code: int,
+    fresh_verified: bool,
+) -> None:
+    env, _, _ = _shell_fixture(tmp_path, mcp_exit=0)
+    env["FAKE_AUTH_JSON"] = json.dumps(payload)
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "install.sh"), "--doctor"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == expected_code
+    assert ("sessão Google verificada de forma fresh" in result.stdout) is fresh_verified
+
+
+def test_shell_repeat_is_idempotent_and_reports_plugins_unavailable(tmp_path: Path) -> None:
+    env, bundle, host_log = _shell_fixture(tmp_path, mcp_exit=0)
+
+    first = _run_shell_installer(env)
+    second = _run_shell_installer(env)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert "capacidade host-plugins indisponível" in first.stdout
+    assert "capacidade host-plugins indisponível" in second.stdout
+    receipt_path = bundle / "install-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "succeeded"
+    assert receipt["exit_code"] == 0
+    assert receipt["runtime"] == {"installed": True}
+    assert receipt["mcp"] == {"registered": True}
+    assert receipt["hook"] == {"installed": True}
+    assert receipt["host_plugins"]["state"] == "unavailable"
+    assert receipt["host_plugins"]["command"] is None
+    assert "host-plugins capability unavailable" in receipt["host_plugins"]["reason"]
+    assert receipt["host_plugins"]["mutated"] is False
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o600
+    assert not list(bundle.glob("install-receipt.json.tmp.*"))
+    assert not host_log.exists()
+
+
+def test_shell_marks_plugins_pending_only_when_runtime_capability_exists(tmp_path: Path) -> None:
+    env, bundle, host_log = _shell_fixture(
+        tmp_path,
+        mcp_exit=0,
+        host_plugins_exit=0,
+    )
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 0, result.stderr
+    runtime_calls = Path(env["FAKE_RUNTIME_LOG"]).read_text(encoding="utf-8")
+    assert "host-plugins --help" in runtime_calls
+    assert "host-plugins plan --all" not in runtime_calls
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["host_plugins"] == {
+        "state": "pending_consent",
+        "owner": "simplicio-runtime",
+        "command": "simplicio host-plugins plan --all",
+        "mutated": False,
+        "reason": "Host plugins require separate explicit user consent.",
+    }
+    assert "nenhum plugin de host foi alterado" in result.stdout
+    assert not host_log.exists()
+
+
+@pytest.mark.parametrize("help_mode", ["wrong", "empty"])
+def test_shell_exit_zero_without_host_plugin_contract_is_unavailable(
+    tmp_path: Path,
+    help_mode: str,
+) -> None:
+    env, bundle, host_log = _shell_fixture(
+        tmp_path,
+        mcp_exit=0,
+        host_plugins_exit=0,
+        host_plugins_help_mode=help_mode,
+    )
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 0, result.stderr
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["host_plugins"]["state"] == "unavailable"
+    assert receipt["host_plugins"]["command"] is None
+    assert "simplicio.host-plugins/cli-v1" in receipt["host_plugins"]["reason"]
+    assert receipt["host_plugins"]["mutated"] is False
+    runtime_calls = Path(env["FAKE_RUNTIME_LOG"]).read_text(encoding="utf-8")
+    assert "host-plugins --help" in runtime_calls
+    assert "host-plugins plan --all" not in runtime_calls
+    assert not host_log.exists()
+
+
+def test_shell_hook_failure_preserves_structured_code_and_reason(tmp_path: Path) -> None:
+    env, bundle, _ = _shell_fixture(tmp_path, mcp_exit=0)
+    env["FAKE_BAD_HOOK_HASH"] = "1"
+
+    result = _run_shell_installer(env)
+
+    assert result.returncode == 1
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "partial"
+    assert receipt["stage"] == "hook_registration"
+    assert receipt["failure"] == {
+        "code": "hook_fetch_denied",
+        "reason": "public hook download denied by fixture",
+    }
+    assert receipt["mcp"] == {"registered": True}
+    assert receipt["hook"] == {"installed": False}
+
+
+def test_installers_delegate_plugins_only_to_runtime_after_consent() -> None:
+    installers = [
+        (ROOT / "install.sh").read_text(encoding="utf-8"),
+        (ROOT / "install.ps1").read_text(encoding="utf-8"),
+    ]
+    forbidden = (
+        "archive/refs/heads/master.zip",
+        "codex plugin marketplace add",
+        "claude plugin marketplace add",
+        "gemini extensions install",
+        "copilot plugin marketplace add",
+        "qwen extensions install",
+        "hermes plugins install",
+        ".cursor/plugins/local/simplicio",
+        ".kiro/powers/simplicio",
+    )
+    for text in installers:
+        assert "simplicio-install-receipt/v1" in text
+        assert "pending_consent" in text
+        assert "host-plugins" in text
+        assert "--help" in text
+        assert "simplicio host-plugins plan --all" in text
+        assert all(token not in text for token in forbidden)
+    assert "Login Google verificável após auth login" not in installers[0]
+    assert "active Google login is verified after auth login" not in installers[1]
+    assert "if verify_active_login; then" in installers[0]
+    assert "if (Test-ActiveLogin)" in installers[1]
+    assert "não alterou nenhum host" not in installers[0]
+    assert "changed no host" not in installers[1]
+    assert "SetAccessRuleProtection" in installers[1]
+    assert "FileSystemAccessRule" in installers[1]
+    assert "Set-Acl -Path $Path" in installers[1]
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is not installed")
+@pytest.mark.parametrize("mcp_burst", [False, True])
+def test_powershell_code_1_preserves_partial_receipt(
+    tmp_path: Path,
+    mcp_burst: bool,
+) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    source_runtime = tmp_path / "simplicio-runtime"
+    runtime_log = tmp_path / "runtime-pwsh.log"
+    _fake_runtime(source_runtime)
+    digest = hashlib.sha256(source_runtime.read_bytes()).hexdigest()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "FAKE_RUNTIME_SOURCE": str(source_runtime),
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_MCP_EXIT": "1",
+            "FAKE_MCP_BURST": "1" if mcp_burst else "0",
+            "FAKE_RUNTIME_SHA256": digest,
+            "INSTALLER_PATH": str(ROOT / "install.ps1"),
+        }
+    )
+    harness = r"""
+function Invoke-RestMethod {
+  param([string]$Uri, [object]$ErrorAction)
+  return [pscustomobject]@{
+    artifacts = @([pscustomobject]@{
+      target = "windows-x64"
+      sha256 = $env:FAKE_RUNTIME_SHA256
+      signed = $false
+      signature = ""
+    })
+    signing_pubkey = ""
+    security = [pscustomobject]@{ signature_required = $false }
+  }
+}
+function Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile, [switch]$UseBasicParsing, [object]$ErrorAction)
+  Copy-Item -Force -Path $env:FAKE_RUNTIME_SOURCE -Destination $OutFile
+}
+& $env:INSTALLER_PATH -Version "3.8.40"
+"""
+
+    result = subprocess.run(
+        [shutil.which("pwsh"), "-NoProfile", "-NonInteractive", "-Command", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "partial"
+    assert receipt["exit_code"] == 1
+    assert receipt["stage"] == "mcp_registration"
+    assert receipt["failure"] == {
+        "code": FAKE_MCP_FAILURE_CODE,
+        "reason": FAKE_MCP_FAILURE_REASON,
+    }
+    assert FAKE_MCP_FAILURE_REASON in result.stderr
+    assert "fallback diagnostic must not replace" not in receipt["failure"]["reason"]
+    assert receipt["runtime"] == {"installed": True}
+    assert receipt["mcp"] == {"registered": False}
+    assert receipt["host_plugins"]["state"] == "unavailable"
+    assert receipt["host_plugins"]["mutated"] is False
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is not installed")
+def test_powershell_hook_failure_preserves_concrete_code_and_reason(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    source_runtime = tmp_path / "simplicio-runtime"
+    runtime_log = tmp_path / "runtime-pwsh-hook.log"
+    _fake_runtime(source_runtime)
+    digest = hashlib.sha256(source_runtime.read_bytes()).hexdigest()
+    hook = bundle / "hooks" / "mcp-route.ps1"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("# deliberately invalid hook\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "FAKE_RUNTIME_SOURCE": str(source_runtime),
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_MCP_EXIT": "0",
+            "FAKE_RUNTIME_SHA256": digest,
+            "INSTALLER_PATH": str(ROOT / "install.ps1"),
+        }
+    )
+    harness = r"""
+function Invoke-RestMethod {
+  param([string]$Uri, [object]$ErrorAction)
+  return [pscustomobject]@{
+    artifacts = @([pscustomobject]@{
+      target = "windows-x64"
+      sha256 = $env:FAKE_RUNTIME_SHA256
+      signed = $false
+      signature = ""
+    })
+    signing_pubkey = ""
+    security = [pscustomobject]@{ signature_required = $false }
+  }
+}
+function Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile, [switch]$UseBasicParsing, [object]$ErrorAction)
+  if ($Uri -like "*mcp-route.ps1") {
+    throw "public hook download denied by fixture"
+  }
+  Copy-Item -Force -Path $env:FAKE_RUNTIME_SOURCE -Destination $OutFile
+}
+& $env:INSTALLER_PATH -Version "3.8.40"
+"""
+
+    result = subprocess.run(
+        [shutil.which("pwsh"), "-NoProfile", "-NonInteractive", "-Command", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "partial"
+    assert receipt["stage"] == "hook_registration"
+    assert receipt["failure"] == {
+        "code": "hook_download_failed",
+        "reason": "public hook download denied by fixture",
+    }
+    assert receipt["mcp"] == {"registered": True}
+    assert receipt["hook"] == {"installed": False}
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is not installed")
+@pytest.mark.parametrize(
+    ("host_plugins_exit", "host_plugins_help_mode", "expected_state"),
+    [
+        (2, "contract", "unavailable"),
+        (0, "contract", "pending_consent"),
+        (0, "wrong", "unavailable"),
+        (0, "empty", "unavailable"),
+    ],
+)
+def test_powershell_repeat_is_idempotent_and_gates_host_plugins(
+    tmp_path: Path,
+    host_plugins_exit: int,
+    host_plugins_help_mode: str,
+    expected_state: str,
+) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    source_runtime = tmp_path / "simplicio-runtime"
+    runtime_log = tmp_path / "runtime-pwsh-success.log"
+    _fake_runtime(source_runtime)
+    digest = hashlib.sha256(source_runtime.read_bytes()).hexdigest()
+    hook = bundle / "hooks" / "mcp-route.ps1"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ROOT / "codex" / "mcp-route.ps1", hook)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "FAKE_RUNTIME_SOURCE": str(source_runtime),
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_MCP_EXIT": "0",
+            "FAKE_HOST_PLUGINS_EXIT": str(host_plugins_exit),
+            "FAKE_HOST_PLUGINS_HELP_MODE": host_plugins_help_mode,
+            "FAKE_RUNTIME_SHA256": digest,
+            "INSTALLER_PATH": str(ROOT / "install.ps1"),
+        }
+    )
+    harness = r"""
+function Invoke-RestMethod {
+  param([string]$Uri, [object]$ErrorAction)
+  return [pscustomobject]@{
+    artifacts = @([pscustomobject]@{
+      target = "windows-x64"
+      sha256 = $env:FAKE_RUNTIME_SHA256
+      signed = $false
+      signature = ""
+    })
+    signing_pubkey = ""
+    security = [pscustomobject]@{ signature_required = $false }
+  }
+}
+function Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile, [switch]$UseBasicParsing, [object]$ErrorAction)
+  Copy-Item -Force -Path $env:FAKE_RUNTIME_SOURCE -Destination $OutFile
+}
+& $env:INSTALLER_PATH -Version "3.8.40"
+"""
+
+    first = subprocess.run(
+        [shutil.which("pwsh"), "-NoProfile", "-NonInteractive", "-Command", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    second = subprocess.run(
+        [shutil.which("pwsh"), "-NoProfile", "-NonInteractive", "-Command", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    runtime_calls = runtime_log.read_text(encoding="utf-8")
+    assert "host-plugins --help" in runtime_calls
+    assert "host-plugins plan --all" not in runtime_calls
+    if expected_state == "pending_consent":
+        assert "host plugins are pending separate consent" in first.stdout
+        assert "host plugins are pending separate consent" in second.stdout
+    else:
+        assert "host-plugins capability is unavailable" in first.stdout + first.stderr
+        assert "host-plugins capability is unavailable" in second.stdout + second.stderr
+    receipt = json.loads((bundle / "install-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "succeeded"
+    assert receipt["exit_code"] == 0
+    assert receipt["runtime"] == {"installed": True}
+    assert receipt["mcp"] == {"registered": True}
+    assert receipt["hook"] == {"installed": True}
+    assert receipt["host_plugins"]["state"] == expected_state
+    expected_command = (
+        "simplicio host-plugins plan --all" if expected_state == "pending_consent" else None
+    )
+    assert receipt["host_plugins"]["command"] == expected_command
+    assert receipt["host_plugins"]["mutated"] is False
+    assert stat.S_IMODE((bundle / "install-receipt.json").stat().st_mode) == 0o600
+    assert not list(bundle.glob("install-receipt.json.tmp.*"))
+    assert not list(bundle.glob("install-receipt.json.backup.*"))
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is not installed")
+def test_powershell_acl_failure_restores_previous_receipt(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    source_runtime = tmp_path / "simplicio-runtime"
+    runtime_log = tmp_path / "runtime-pwsh-acl.log"
+    _fake_runtime(source_runtime)
+    digest = hashlib.sha256(source_runtime.read_bytes()).hexdigest()
+    hook = bundle / "hooks" / "mcp-route.ps1"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ROOT / "codex" / "mcp-route.ps1", hook)
+    receipt_path = bundle / "install-receipt.json"
+    original = (
+        b'{"schema":"simplicio-install-receipt/v1","status":"partial",'
+        b'"failure":{"code":"acl_preserve","reason":"original secure receipt"}}\n'
+    )
+    receipt_path.write_bytes(original)
+    os.chmod(receipt_path, 0o640)
+    os.utime(receipt_path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+    before_stat = receipt_path.stat()
+
+    def permission_snapshot(path: Path) -> str:
+        if os.name != "nt":
+            return oct(stat.S_IMODE(path.stat().st_mode))
+        completed = subprocess.run(
+            [
+                shutil.which("pwsh"),
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "(Get-Acl -LiteralPath $args[0]).Sddl",
+                str(path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        return completed.stdout.strip()
+
+    before_permission = permission_snapshot(receipt_path)
+    fake_bin = tmp_path / "fake-acl-bin"
+    fake_bin.mkdir(parents=True)
+    chmod_counter = tmp_path / "chmod-counter"
+    _write_executable(
+        fake_bin / "chmod",
+        """#!/bin/sh
+count=0
+if [ -f "$FAKE_CHMOD_COUNTER" ]; then count=$(cat "$FAKE_CHMOD_COUNTER"); fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FAKE_CHMOD_COUNTER"
+if [ "$count" -ge 2 ]; then
+  printf '%s\n' 'fixture chmod ACL failure' >&2
+  exit 1
+fi
+exec /bin/chmod "$@"
+""",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "FAKE_RUNTIME_SOURCE": str(source_runtime),
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_MCP_EXIT": "0",
+            "FAKE_HOST_PLUGINS_EXIT": "0",
+            "FAKE_HOST_PLUGINS_HELP_MODE": "contract",
+            "FAKE_RUNTIME_SHA256": digest,
+            "FAKE_CHMOD_COUNTER": str(chmod_counter),
+            "INSTALLER_PATH": str(ROOT / "install.ps1"),
+            "PATH": os.pathsep.join((str(fake_bin), os.environ["PATH"])),
+        }
+    )
+    harness = r"""
+function Invoke-RestMethod {
+  param([string]$Uri, [object]$ErrorAction)
+  return [pscustomobject]@{
+    artifacts = @([pscustomobject]@{
+      target = "windows-x64"
+      sha256 = $env:FAKE_RUNTIME_SHA256
+      signed = $false
+      signature = ""
+    })
+    signing_pubkey = ""
+    security = [pscustomobject]@{ signature_required = $false }
+  }
+}
+function Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile, [switch]$UseBasicParsing, [object]$ErrorAction)
+  Copy-Item -Force -Path $env:FAKE_RUNTIME_SOURCE -Destination $OutFile
+}
+$script:ReceiptAclCalls = 0
+function global:Set-Acl {
+  param([string]$Path, [object]$AclObject)
+  $script:ReceiptAclCalls += 1
+  if ($script:ReceiptAclCalls -ge 2) { throw "fixture Set-Acl failure" }
+  Microsoft.PowerShell.Security\Set-Acl -Path $Path -AclObject $AclObject
+}
+& $env:INSTALLER_PATH -Version "3.8.40"
+"""
+
+    result = subprocess.run(
+        [shutil.which("pwsh"), "-NoProfile", "-NonInteractive", "-Command", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert receipt_path.read_bytes() == original
+    assert receipt_path.stat().st_mtime_ns == before_stat.st_mtime_ns
+    assert permission_snapshot(receipt_path) == before_permission
+    assert not list(bundle.glob("install-receipt.json.tmp.*"))
+    assert not list(bundle.glob("install-receipt.json.backup.*"))
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is not installed")
+@pytest.mark.parametrize(
+    ("payload", "expected_code", "fresh_verified"),
+    [
+        (FRESH_AUTH, 0, True),
+        (CACHED_AUTH, 1, False),
+        (MISSING_AUTH_FIELDS, 1, False),
+    ],
+)
+def test_powershell_doctor_requires_fresh_complete_login_evidence(
+    tmp_path: Path,
+    payload: dict[str, object],
+    expected_code: int,
+    fresh_verified: bool,
+) -> None:
+    home = tmp_path / "home"
+    bundle = home / ".simplicio"
+    install_bin = bundle / "bin"
+    runtime = install_bin / "simplicio.exe"
+    runtime_log = tmp_path / "runtime-pwsh-doctor.log"
+    _fake_runtime(runtime)
+    receipt_path = bundle / "install-receipt.json"
+    original_receipt = (
+        b'{"schema":"simplicio-install-receipt/v1","status":"partial",'
+        b'"failure":{"code":"pwsh_doctor_preserve","reason":"original bytes"}}\n'
+    )
+    receipt_path.write_bytes(original_receipt)
+    os.utime(receipt_path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+    receipt_before = receipt_path.stat()
+    receipt_digest = hashlib.sha256(original_receipt).hexdigest()
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "SIMPLICIO_BIN_DIR": str(install_bin),
+            "SIMPLICIO_BUNDLE_DIR": str(bundle),
+            "FAKE_RUNTIME_LOG": str(runtime_log),
+            "FAKE_AUTH_JSON": json.dumps(payload),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            shutil.which("pwsh"),
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            str(ROOT / "install.ps1"),
+            "-Doctor",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == expected_code
+    assert ("fresh Google session and entitlement verified" in result.stdout) is fresh_verified
+    assert receipt_path.read_bytes() == original_receipt
+    assert hashlib.sha256(receipt_path.read_bytes()).hexdigest() == receipt_digest
+    assert receipt_path.stat().st_mtime_ns == receipt_before.st_mtime_ns


### PR DESCRIPTION
## Resumo

- preserva causa estruturada e limitada de falhas MCP/hook no recibo
- torna `--doctor` estritamente somente leitura, inclusive em plataforma não suportada
- exige autenticação Google realmente fresh antes de declarar sessão verificada
- registra plugins como `pending_consent` somente quando o Runtime anuncia o contrato versionado
- mantém instalação do Runtime separada de qualquer mutação de plugins
- protege e restaura o recibo no PowerShell se a aplicação de ACL falhar

## Validação

- 309 testes passaram, 1 skip justificado e 39 subtests
- focal final: 35 testes passaram
- `sh -n install.sh`
- `shellcheck -s sh install.sh`
- Ruff
- `git diff --check`

## Contrato

O instalador não executa `host-plugins plan` nem `apply`. Ele apenas reconhece o marker `simplicio.host-plugins/cli-v1` e deixa a ação explícita para o Desktop.
