### PR TITLE
release(desktop): prepare v3.8.41 native preflight

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -17,12 +17,16 @@ The Rust Runtime source lives in the private [`simplicio-runtime`](https://githu
 - **Runtime targets:** macOS ARM64, macOS x64, Linux x64, and Windows x64.
   The canonical target table and release manifest define the asset, checksum,
   Ed25519 signature, SBOM, and provenance for each Runtime platform.
-- **Desktop status:** Desktop remains at v3.8.39. Its
-  `Simplicio-3.8.39-arm64.dmg` and `.zip` assets were published with v3.8.39,
-  built from public commit
+- **Desktop status:** Desktop source is v3.8.41. A macOS ARM64
+  preflight was built locally with the verified Runtime v3.8.40 sidecar; the
+  artifacts are not published and do not represent a completed Desktop release.
+  The previously published `Simplicio-3.8.39-arm64.dmg` and `.zip` assets
+  remain the only public Desktop installers, built from public commit
   `dd7dd0665630fcdd6c9a76d07956d840f80fc0a9`. Exact filenames, SHA-256,
   sizes, verification evidence, and signing status are recorded in
   [the release runbook](docs/RELEASE_RUNBOOK.md#published-desktop-v3839).
+  The current preflight and its unavailable release gates are recorded in
+  [the v3.8.41 preflight](docs/desktop/RELEASE-3.8.41-PREFLIGHT.md).
   Desktop is not part of the v3.8.40 release artifacts.
 - **Release status:** GitHub Release v3.8.40 and `simplicio-installer 3.8.40`
   on PyPI are published manually, without GitHub Actions. Installers and the

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.39",
+  "version": "3.8.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@simplicio/desktop",
-      "version": "3.8.39",
+      "version": "3.8.41",
       "dependencies": {
         "@tauri-apps/api": "2.11.1",
         "@tauri-apps/plugin-dialog": "2.7.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.39",
+  "version": "3.8.41",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simplicio-desktop"
-version = "3.8.39"
+version = "3.8.41"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicio-desktop"
-version = "3.8.39"
+version = "3.8.41"
 description = "Public desktop shell for the Simplicio Runtime"
 authors = ["SimpleTI"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Simplicio",
-  "version": "3.8.39",
+  "version": "3.8.41",
   "identifier": "br.com.simpleti.simplicio",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/desktop/RELEASE-3.8.41-PREFLIGHT.md
+++ b/docs/desktop/RELEASE-3.8.41-PREFLIGHT.md
@@ -1,0 +1,39 @@
+# Desktop v3.8.41 native release preflight
+
+Date: 2026-09-01  
+Status: **blocked; local preflight only; no public release**
+
+This record captures the evidence produced on the Apple Silicon host. It is not a release declaration and does not close issues #282 or #283.
+
+## Inputs
+
+- Desktop source baseline: `origin/master` at `96c7447dc3877d40846729b105b13b1d6a62835e`
+- Desktop candidate: `3.8.41`
+- Runtime sidecar: public Runtime `v3.8.40`, macOS ARM64
+- Runtime sidecar SHA-256: `f8404218d89bb6599d2f83335d3419f86fe9f81730a53b9690639c0f9fee9a8e`
+- Target: `aarch64-apple-darwin`
+
+## Local evidence
+
+- `npm --prefix apps/desktop test`: 50 test files, 337 tests passed.
+- `npm --prefix apps/desktop run build`: passed.
+- Packaged sidecar smoke: 1 passed, 0 failed.
+- Tauri CLI: `2.11.4`.
+- Tauri bundle: `Simplicio.app`, `Simplicio-3.8.41-arm64.dmg`, and `Simplicio-3.8.41-arm64.zip`.
+- SHA-256 of local ZIP: `5ff980aba7d62868fffa62d08b88dc76d24e4fa8d4b4be0cbf0d1eb72ea47d47`.
+- SHA-256 of local DMG: `ae58107de0e361da45b0b7762e15de1db52093d85a4d1e30e9f05d7039be6fcc`.
+- The sidecar inside the app, ZIP extraction, and mounted DMG all match the Runtime digest above.
+- `codesign --verify --deep --strict`: passed after local ad-hoc signing.
+
+## Blocking gates
+
+- `security find-identity -v -p codesigning`: 0 valid identities. The package is ad-hoc signed, with no Developer ID identity.
+- `spctl --assess --type execute`: rejected. Apple notarization/Gatekeeper acceptance is not proven.
+- This host has Command Line Tools but no full Xcode; the required multi-platform native build/sign sequence was not completed.
+- Windows x64, Linux x64, and macOS Intel installers were not built or smoke-tested.
+- No clean native installation with a real Google OAuth grant, callback, logout, or redacted screenshots was performed. The UI control executable required for that manual evidence was unavailable in this session.
+- Desktop ZIP/DMG Ed25519 signatures, SBOM, and provenance were not generated. The Runtime sidecar's own signed manifest does not substitute for signatures/provenance of the Desktop containers.
+
+## Release decision
+
+Do not tag, publish, or close #282/#283 from this preflight. The next release attempt must add the missing platform builds, platform signing/notarization, Desktop-container attestations, served-byte re-download checks, and the manual clean-HOME Google OAuth evidence.


### PR DESCRIPTION
## Summary

- bump the first-party Desktop manifests to `3.8.41`;
- record the reproducible macOS ARM64 preflight;
- verify the exact public Runtime v3.8.40 sidecar remains embedded in the app, ZIP, and DMG.

## Verification

- Desktop unit tests: 50 files / 337 tests passed;
- TypeScript/Vite build passed;
- packaged release sidecar smoke passed;
- `codesign --verify --deep --strict` passed after local ad-hoc signing;
- ZIP and DMG extraction/mount checks preserved Runtime SHA-256 `f8404218d89bb6599d2f83335d3419f86fe9f81730a53b9690639c0f9fee9a8e`.

## Explicitly blocked

This is intentionally a draft. It must not be merged or published as a completed release yet:

- no Developer ID identity or notarization; `spctl` rejects the ad-hoc app;
- Windows x64, Linux x64, and macOS Intel native build/install smoke are unavailable on this host;
- real clean-HOME Google OAuth/callback/logout evidence and screenshots were not captured;
- Desktop-container Ed25519 signatures, SBOM, and provenance were not generated;
- global repository validation still reports a checksum mismatch in the pre-existing ignored `simplicio-linux-x64` artifact.

Refs #282, #283.