### PR TITLE
feat(desktop): add Runtime install lifecycle evidence

### DIFF
--- a/apps/desktop/src/runtime_lifecycle.test.ts
+++ b/apps/desktop/src/runtime_lifecycle.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseRuntimeLifecycleReceipt,
+  runtimeLifecycleState,
+  type RuntimeLifecycleReceipt,
+} from './runtime_lifecycle';
+
+const digestA = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const digestB = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function validReceipt(): RuntimeLifecycleReceipt {
+  return {
+    schema: 'simplicio.desktop-runtime-lifecycle/v1',
+    action: 'upgrade',
+    status: 'installed',
+    candidate_version: '3.8.40',
+    candidate_digest: digestA,
+    active_version: '3.8.40',
+    active_digest: digestA,
+    previous_version: '3.8.39',
+    previous_digest: digestB,
+    validated: true,
+    atomic_swap: true,
+    directory_fsynced: true,
+    receipt_durable: true,
+    runtime_healthy: true,
+    backup_available: true,
+    plugins_mutated: false,
+    rollback_proven: false,
+  };
+}
+
+describe('Runtime lifecycle receipt contract', () => {
+  it('accepts an atomic validated upgrade and exposes only safe fields', () => {
+    const parsed = parseRuntimeLifecycleReceipt({
+      ...validReceipt(),
+      targetPath: '/private/user/.simplicio/bin/simplicio',
+      rawOutput: 'secret-token',
+    });
+    expect(parsed).toEqual(validReceipt());
+    expect(runtimeLifecycleState(parsed)).toBe('current');
+    expect(JSON.stringify(parsed)).not.toMatch(/private|rawOutput|secret-token/);
+  });
+
+  it('accepts idempotent install and explicit repair receipts', () => {
+    const current = {
+      ...validReceipt(),
+      action: 'install' as const,
+      status: 'already_current' as const,
+      previous_version: null,
+      previous_digest: null,
+      backup_available: false,
+    };
+    const repaired = {
+      ...validReceipt(),
+      action: 'repair' as const,
+      status: 'repaired' as const,
+      previous_version: null,
+      previous_digest: null,
+    };
+    expect(parseRuntimeLifecycleReceipt(current).status).toBe('already_current');
+    expect(parseRuntimeLifecycleReceipt(repaired).status).toBe('repaired');
+  });
+
+  it('accepts rollback only when the prior verified target is active', () => {
+    const rolledBack = {
+      ...validReceipt(),
+      action: 'rollback' as const,
+      status: 'rolled_back' as const,
+      active_version: '3.8.39',
+      active_digest: digestB,
+      rollback_proven: true,
+    };
+    expect(parseRuntimeLifecycleReceipt(rolledBack).status).toBe('rolled_back');
+  });
+
+  it('fails closed for unverified, non-atomic, plugin-mutating, and inconsistent receipts', () => {
+    const invalid = [
+      { ...validReceipt(), validated: false },
+      { ...validReceipt(), atomic_swap: false },
+      { ...validReceipt(), directory_fsynced: false },
+      { ...validReceipt(), receipt_durable: false },
+      { ...validReceipt(), runtime_healthy: false },
+      { ...validReceipt(), plugins_mutated: true },
+      { ...validReceipt(), active_digest: digestB },
+      { ...validReceipt(), action: 'rollback' as const },
+      { ...validReceipt(), path: '/private/user/.simplicio/bin/simplicio' },
+    ];
+    for (const receipt of invalid) {
+      expect(() => parseRuntimeLifecycleReceipt(receipt)).toThrow();
+    }
+  });
+});

--- a/apps/desktop/src/runtime_lifecycle.ts
+++ b/apps/desktop/src/runtime_lifecycle.ts
@@ -68,7 +68,7 @@ function nullableDigest(value: unknown): string | null {
   return value === null ? null : digest(value);
 }
 
-function boolean(value: unknown, expected: boolean): boolean {
+function boolean<T extends boolean>(value: unknown, expected: T): T {
   if (value !== expected) throw new Error('runtime_lifecycle_invalid');
   return expected;
 }

--- a/apps/desktop/src/runtime_lifecycle.ts
+++ b/apps/desktop/src/runtime_lifecycle.ts
@@ -1,0 +1,153 @@
+/** Versioned, redacted lifecycle evidence for the Runtime core installer. */
+export const RUNTIME_LIFECYCLE_SCHEMA = 'simplicio.desktop-runtime-lifecycle/v1';
+
+export type RuntimeLifecycleAction = 'install' | 'upgrade' | 'repair' | 'rollback';
+export type RuntimeLifecycleStatus = 'installed' | 'already_current' | 'repaired' | 'rolled_back';
+export type RuntimeLifecycleState = 'missing' | 'installing' | 'current' | 'upgrading' | 'repairing' | 'rolling_back' | 'blocked';
+
+export interface RuntimeLifecycleReceipt {
+  schema: typeof RUNTIME_LIFECYCLE_SCHEMA;
+  action: RuntimeLifecycleAction;
+  status: RuntimeLifecycleStatus;
+  candidate_version: string;
+  candidate_digest: string;
+  active_version: string;
+  active_digest: string;
+  previous_version: string | null;
+  previous_digest: string | null;
+  validated: true;
+  atomic_swap: true;
+  directory_fsynced: true;
+  receipt_durable: true;
+  runtime_healthy: true;
+  backup_available: boolean;
+  plugins_mutated: false;
+  rollback_proven: boolean;
+}
+
+const ACTIONS: RuntimeLifecycleAction[] = ['install', 'upgrade', 'repair', 'rollback'];
+const STATUSES: RuntimeLifecycleStatus[] = ['installed', 'already_current', 'repaired', 'rolled_back'];
+const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const DIGEST = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY = /(^|_)(path|cwd|home|argv|prompt|secret|password|credential|authorization|api_key|access_token|refresh_token|raw_payload|raw_output)(_|$)/i;
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('runtime_lifecycle_invalid');
+  return value as Record<string, unknown>;
+}
+
+function rejectSensitiveKeys(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(rejectSensitiveKeys);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEY.test(key)) throw new Error('runtime_lifecycle_sensitive_field');
+    rejectSensitiveKeys(child);
+  }
+}
+
+function version(value: unknown): string {
+  if (typeof value !== 'string' || value.length > 64 || !SEMVER.test(value)) {
+    throw new Error('runtime_lifecycle_invalid');
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  if (typeof value !== 'string' || !DIGEST.test(value)) throw new Error('runtime_lifecycle_invalid');
+  return value;
+}
+
+function nullableVersion(value: unknown): string | null {
+  return value === null ? null : version(value);
+}
+
+function nullableDigest(value: unknown): string | null {
+  return value === null ? null : digest(value);
+}
+
+function boolean(value: unknown, expected: boolean): boolean {
+  if (value !== expected) throw new Error('runtime_lifecycle_invalid');
+  return expected;
+}
+
+function enumValue<T extends string>(value: unknown, values: T[]): T {
+  if (typeof value !== 'string' || !values.includes(value as T)) throw new Error('runtime_lifecycle_invalid');
+  return value as T;
+}
+
+function samePair(leftVersion: string | null, leftDigest: string | null, rightVersion: string, rightDigest: string): boolean {
+  return leftVersion === rightVersion && leftDigest === rightDigest;
+}
+
+/**
+ * Accept only a successful native lifecycle receipt. Unknown fields are discarded
+ * so paths, command output, credentials, and backup locations never reach React.
+ */
+export function parseRuntimeLifecycleReceipt(value: unknown): RuntimeLifecycleReceipt {
+  rejectSensitiveKeys(value);
+  const raw = record(value);
+  const action = enumValue(raw.action, ACTIONS);
+  const status = enumValue(raw.status, STATUSES);
+  const candidateVersion = version(raw.candidate_version);
+  const candidateDigest = digest(raw.candidate_digest);
+  const activeVersion = version(raw.active_version);
+  const activeDigest = digest(raw.active_digest);
+  const previousVersion = nullableVersion(raw.previous_version);
+  const previousDigest = nullableDigest(raw.previous_digest);
+  if ((previousVersion === null) !== (previousDigest === null)) throw new Error('runtime_lifecycle_invalid');
+
+  const receipt: RuntimeLifecycleReceipt = {
+    schema: RUNTIME_LIFECYCLE_SCHEMA,
+    action,
+    status,
+    candidate_version: candidateVersion,
+    candidate_digest: candidateDigest,
+    active_version: activeVersion,
+    active_digest: activeDigest,
+    previous_version: previousVersion,
+    previous_digest: previousDigest,
+    validated: boolean(raw.validated, true),
+    atomic_swap: boolean(raw.atomic_swap, true),
+    directory_fsynced: boolean(raw.directory_fsynced, true),
+    receipt_durable: boolean(raw.receipt_durable, true),
+    runtime_healthy: boolean(raw.runtime_healthy, true),
+    backup_available: typeof raw.backup_available === 'boolean' ? raw.backup_available : (() => {
+      throw new Error('runtime_lifecycle_invalid');
+    })(),
+    plugins_mutated: boolean(raw.plugins_mutated, false) as false,
+    rollback_proven: typeof raw.rollback_proven === 'boolean' ? raw.rollback_proven : (() => {
+      throw new Error('runtime_lifecycle_invalid');
+    })(),
+  };
+
+  if (status === 'rolled_back') {
+    if (action !== 'rollback' || previousVersion === null || previousDigest === null
+      || !samePair(activeVersion, activeDigest, previousVersion, previousDigest)
+      || receipt.backup_available !== true || receipt.rollback_proven !== true) {
+      throw new Error('runtime_lifecycle_invalid');
+    }
+  } else {
+    if (action === 'rollback' || !samePair(activeVersion, activeDigest, candidateVersion, candidateDigest)
+      || receipt.rollback_proven !== false) {
+      throw new Error('runtime_lifecycle_invalid');
+    }
+    if (status === 'installed' && action !== 'install' && action !== 'upgrade') {
+      throw new Error('runtime_lifecycle_invalid');
+    }
+    if (status === 'already_current' && action !== 'install' && action !== 'upgrade') {
+      throw new Error('runtime_lifecycle_invalid');
+    }
+    if (status === 'repaired' && action !== 'repair') throw new Error('runtime_lifecycle_invalid');
+  }
+  if (action === 'install' && status === 'repaired') throw new Error('runtime_lifecycle_invalid');
+  return receipt;
+}
+
+/** A successfully committed or restored receipt leaves the active Runtime current and healthy. */
+export function runtimeLifecycleState(value: unknown): RuntimeLifecycleState {
+  parseRuntimeLifecycleReceipt(value);
+  return 'current';
+}


### PR DESCRIPTION
## Summary
- add a versioned, redacted Runtime lifecycle receipt contract
- model install, upgrade, repair, idempotent current, and rollback outcomes
- require validated atomic swap, directory fsync, durable receipt, healthy Runtime, and no plugin mutation
- discard paths, command output, credentials, and unknown fields before UI use

## Verification
- TypeScript type-check passes for the contract and tests.
- Vitest: 4 tests passed.
- Native filesystem behavior remains implemented and tested in the Rust installer; this PR makes its lifecycle evidence consumable without exposing private paths.

Refs #288