### PR TITLE
fix(desktop): persist Runtime install reconciliation

### DIFF
--- a/apps/desktop/src-tauri/src/install_journal.rs
+++ b/apps/desktop/src-tauri/src/install_journal.rs
@@ -1,0 +1,254 @@
+//! Durable, redacted state for the Desktop Runtime installation effect.
+//!
+//! The Runtime installer already owns the filesystem transaction. This module
+//! records only whether that transaction is clear or needs an explicit
+//! read-only reconciliation after an interrupted/ambiguous attempt.
+
+use serde_json::{json, Value};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+const SCHEMA: &str = "simplicio.desktop-install-attempt/v1";
+const MAX_BYTES: usize = 4 * 1024;
+
+fn sibling(path: &Path, suffix: &str) -> PathBuf {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    path.with_extension(format!("{extension}.{suffix}"))
+}
+
+fn reject_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "symlink"))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_atomic(path: &Path, state: &str, error: Option<&str>) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing parent"))?;
+    fs::create_dir_all(parent)?;
+    reject_symlink(path)?;
+    let temporary = sibling(path, "tmp");
+    let backup = sibling(path, "bak");
+    reject_symlink(&temporary)?;
+    reject_symlink(&backup)?;
+    let _ = fs::remove_file(&temporary);
+
+    let record = json!({
+        "schema": SCHEMA,
+        "state": state,
+        "error": error,
+    });
+    let encoded = serde_json::to_vec(&record).map_err(io::Error::other)?;
+    if encoded.len() > MAX_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "journal too large"));
+    }
+
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)?;
+    file.write_all(&encoded)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+
+    if path.exists() {
+        let _ = fs::remove_file(&backup);
+        fs::rename(path, &backup)?;
+    }
+    if let Err(rename_error) = fs::rename(&temporary, path) {
+        if !path.exists() && backup.exists() {
+            let _ = fs::rename(&backup, path);
+        }
+        return Err(rename_error);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    if let Ok(directory) = File::open(parent) {
+        let _ = directory.sync_all();
+    }
+    Ok(())
+}
+
+fn safe_error(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || byte == b'_' && index > 0
+        })
+        && value.as_bytes()[0].is_ascii_lowercase()
+}
+
+fn candidate(path: &Path) -> Option<PathBuf> {
+    [path.to_path_buf(), sibling(path, "bak"), sibling(path, "tmp")]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+}
+
+/// The only durable states exposed to the Desktop are clear and blocked.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InstallAttempt {
+    blocked: bool,
+}
+
+impl InstallAttempt {
+    pub fn load(path: &Path) -> Self {
+        let Some(selected) = candidate(path) else {
+            return Self::default();
+        };
+        if reject_symlink(&selected).is_err() {
+            return Self { blocked: true };
+        }
+        let Ok(metadata) = fs::metadata(&selected) else {
+            return Self { blocked: true };
+        };
+        if !metadata.is_file() || metadata.len() as usize > MAX_BYTES {
+            return Self { blocked: true };
+        }
+        let Ok(mut file) = File::open(selected) else {
+            return Self { blocked: true };
+        };
+        let mut bytes = Vec::new();
+        if file
+            .by_ref()
+            .take((MAX_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)
+            .is_err()
+            || bytes.len() > MAX_BYTES
+        {
+            return Self { blocked: true };
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+            return Self { blocked: true };
+        };
+        let Some(object) = value.as_object() else {
+            return Self { blocked: true };
+        };
+        if object.len() != 3 || value.get("schema").and_then(Value::as_str) != Some(SCHEMA) {
+            return Self { blocked: true };
+        }
+        match value.get("state").and_then(Value::as_str) {
+            Some("settled") if value.get("error").is_some_and(Value::is_null) => Self::default(),
+            Some("in_progress") if value.get("error").is_some_and(Value::is_null) => {
+                Self { blocked: true }
+            }
+            Some("reconciliation_required") => {
+                let _valid = value
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .is_some_and(safe_error);
+                Self { blocked: true }
+            }
+            _ => Self { blocked: true },
+        }
+    }
+
+    pub fn begin_persisted(&mut self, path: &Path) -> Result<(), String> {
+        if self.blocked {
+            return Err("runtime_install_reconciliation_required".into());
+        }
+        write_atomic(path, "in_progress", None)
+            .map_err(|_| "runtime_install_journal_unavailable".to_string())?;
+        self.blocked = true;
+        Ok(())
+    }
+
+    pub fn finish_persisted(
+        &mut self,
+        path: &Path,
+        result: &Result<Value, String>,
+    ) -> Result<(), String> {
+        let (state, error) = match result {
+            Ok(_) => ("settled", None),
+            Err(code) if safe_error(code) => ("reconciliation_required", Some(code.as_str())),
+            Err(_) => (
+                "reconciliation_required",
+                Some("runtime_install_reconciliation_required"),
+            ),
+        };
+        write_atomic(path, state, error)
+            .map_err(|_| "runtime_install_reconciliation_required".to_string())?;
+        self.blocked = state != "settled";
+        Ok(())
+    }
+
+    pub fn pending_error(&self) -> Option<String> {
+        self.blocked
+            .then(|| "runtime_install_reconciliation_required".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn path(name: &str) -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        std::env::temp_dir().join(format!(
+            "simplicio-install-journal-{name}-{}-{}.json",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(sibling(path, "tmp"));
+        let _ = fs::remove_file(sibling(path, "bak"));
+    }
+
+    #[test]
+    fn interrupted_attempt_stays_blocked_after_reload_without_raw_error_data() {
+        let path = path("reload");
+        cleanup(&path);
+        let mut attempt = InstallAttempt::default();
+        attempt.begin_persisted(&path).unwrap();
+        let result = Err("runtime_install_timeout".to_string());
+        attempt.finish_persisted(&path, &result).unwrap();
+
+        let restored = InstallAttempt::load(&path);
+        assert_eq!(
+            restored.pending_error().as_deref(),
+            Some("runtime_install_reconciliation_required")
+        );
+        cleanup(&path);
+    }
+
+    #[test]
+    fn malformed_or_interrupted_journal_fails_closed() {
+        let path = path("malformed");
+        cleanup(&path);
+        fs::write(&path, br#"{"schema":"simplicio.desktop-install-attempt/v1","state":"in_progress"}"#)
+            .unwrap();
+        assert!(InstallAttempt::load(&path).pending_error().is_some());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn settled_attempt_is_clear_after_reload() {
+        let path = path("settled");
+        cleanup(&path);
+        let mut attempt = InstallAttempt::default();
+        attempt.begin_persisted(&path).unwrap();
+        attempt.finish_persisted(&path, &Ok(json!({"status":"installed"})))
+            .unwrap();
+        assert!(InstallAttempt::load(&path).pending_error().is_none());
+        cleanup(&path);
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod consolidated_tokens;
 mod context_report;
 mod desktop_queries;
 mod host_plugins;
+mod install_journal;
 mod local_projects;
 #[cfg(desktop)]
 mod native_menu;
@@ -19,6 +20,8 @@ mod runtime_process;
 mod snapshot_exports;
 mod supervisor;
 mod token_exports;
+
+static INSTALL_PROCESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[tauri::command]
 async fn desktop_validate_project(path: String) -> Result<Value, String> {
@@ -67,6 +70,13 @@ const STATUS_ARGS: &[&str] = auth_login::STATUS_ARGS;
 const HOST_PLUGIN_PLAN_ARGS: &[&str] = &["host-plugins", "plan", "--all"];
 const SUBSCRIPTION_URL: &str = "https://simpleti.com.br/simplicio";
 const RELEASES_URL: &str = "https://github.com/wesleysimplicio/simplicio/releases";
+
+fn install_journal_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|directory| directory.join("install-attempt.json"))
+        .map_err(|_| "runtime_install_journal_unavailable".to_string())
+}
 
 fn runtime_capture_limits(args: &[&str]) -> runtime_process::CaptureLimits {
     if matches!(args, ["host-plugins", "apply" | "reconcile", ..]) {
@@ -467,18 +477,78 @@ async fn refresh_desktop_snapshot() -> Result<Value, String> {
 }
 
 #[tauri::command]
-async fn desktop_install_runtime() -> Result<Value, String> {
-    tauri::async_runtime::spawn_blocking(|| {
+async fn desktop_install_runtime(app: tauri::AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let _process_lock = INSTALL_PROCESS_LOCK
+            .lock()
+            .map_err(|_| "runtime_install_busy".to_string())?;
+        let journal_path = install_journal_path(&app)?;
+        let mut attempt = install_journal::InstallAttempt::load(&journal_path);
+        if attempt.pending_error().is_some() {
+            return Err("runtime_install_reconciliation_required".to_string());
+        }
+        attempt.begin_persisted(&journal_path)?;
         let current_executable = std::env::current_exe()
             .map_err(|_| "runtime_install_package_unavailable".to_string())?;
-        runtime_install::install(
+        let result = runtime_install::install(
             &current_executable,
             &runtime_user_home()?,
             snapshot_from_binary,
-        )
+        );
+        attempt.finish_persisted(&journal_path, &result)?;
+        result
     })
     .await
     .map_err(|_| "runtime_install_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_runtime_install_status(app: tauri::AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = install_journal_path(&app)?;
+        let pending = install_journal::InstallAttempt::load(&path)
+            .pending_error()
+            .is_some();
+        Ok(serde_json::json!({
+            "schema": "simplicio.desktop-install-status/v1",
+            "status": if pending { "pending" } else { "clear" },
+            "redacted": true,
+        }))
+    })
+    .await
+    .map_err(|_| "runtime_install_journal_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_reconcile_runtime_install(app: tauri::AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let _process_lock = INSTALL_PROCESS_LOCK
+            .lock()
+            .map_err(|_| "runtime_install_busy".to_string())?;
+        let journal_path = install_journal_path(&app)?;
+        let mut attempt = install_journal::InstallAttempt::load(&journal_path);
+        if attempt.pending_error().is_none() {
+            return Ok(serde_json::json!({
+                "schema": "simplicio.desktop-install-reconciliation/v1",
+                "status": "clear",
+                "current": false,
+                "redacted": true,
+            }));
+        }
+        let current_executable = std::env::current_exe()
+            .map_err(|_| "runtime_install_package_unavailable".to_string())?;
+        let home = runtime_user_home()?;
+        let snapshot = runtime_install::current_snapshot(&current_executable, &home, snapshot_from_binary)?;
+        attempt.finish_persisted(&journal_path, &Ok(serde_json::json!({"status":"reconciled"})))?;
+        Ok(serde_json::json!({
+            "schema": "simplicio.desktop-install-reconciliation/v1",
+            "status": "reconciled",
+            "current": snapshot.is_some(),
+            "redacted": true,
+        }))
+    })
+    .await
+    .map_err(|_| "runtime_install_reconciliation_unavailable".to_string())?
 }
 
 #[tauri::command]
@@ -570,6 +640,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             desktop_snapshot,
             desktop_install_runtime,
+            desktop_runtime_install_status,
+            desktop_reconcile_runtime_install,
             desktop_validate_project,
             desktop_open_project,
             desktop_export_snapshot,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,8 @@ import {
   logoutDesktop,
   openDesktopSubscription,
   refreshDesktopSnapshot,
+  reconcileDesktopRuntimeInstall,
+  loadDesktopRuntimeInstallStatus,
   applyDesktopHostPlugins,
   reconcileDesktopHostPlugins,
   dispatchDesktopBotAction,
@@ -53,6 +55,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   const [actionError, setActionError] = useState<string | null>(null);
   const [runtimeInstallPhase, setRuntimeInstallPhase] = useState<RuntimeInstallPhase>("idle");
   const [runtimeInstallReceipt, setRuntimeInstallReceipt] = useState<RuntimeInstallResult | undefined>();
+  const [runtimeInstallRecovery, setRuntimeInstallRecovery] = useState(false);
   const [applicationRecovery, setApplicationRecovery] = useState<InstallFailureRecovery | undefined>();
   const [workbench, setWorkbench] = useState(loadWorkbench);
   const [history, setHistory] = useState<NavigationState>(() => ({ entries: [{
@@ -111,8 +114,18 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   useEffect(() => {
     if (initialSnapshot) return;
     let current = true;
-    loadDesktopSnapshot()
+    loadDesktopRuntimeInstallStatus()
+      .then((status) => {
+        if (!current) return null;
+        if (status.status === "pending") {
+          setRuntimeInstallRecovery(true);
+          setLoadFailed(true);
+          return null;
+        }
+        return loadDesktopSnapshot();
+      })
       .then((next) => {
+        if (!next) return;
         if (current) {
           setSnapshot(next);
           setBotCenter(next.botCenter);
@@ -122,6 +135,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         if (current) {
           setLoadFailed(true);
           const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+          setRuntimeInstallRecovery(code === "runtime_install_reconciliation_required");
           setActionError(code === "runtime_install_required" ? null : runtimeFailureMessage(error, "query"));
         }
       });
@@ -155,6 +169,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
     actionLock.current = true;
     setAction("install");
     setActionError(null);
+    setRuntimeInstallRecovery(false);
     setRuntimeInstallReceipt(undefined);
     setRuntimeInstallPhase("installing");
     let receipt: RuntimeInstallResult | undefined;
@@ -177,6 +192,40 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       if (receipt) setRuntimeInstallReceipt(receipt);
       setLoadFailed(true);
       setRuntimeInstallPhase("failed");
+      const code = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+      setRuntimeInstallRecovery(code === "runtime_install_reconciliation_required");
+      setActionError(runtimeFailureMessage(error, "install"));
+    } finally {
+      setAction(null);
+      actionLock.current = false;
+    }
+  }
+
+  async function reconcileRuntimeInstall() {
+    if (actionLock.current) return;
+    actionLock.current = true;
+    setAction("install");
+    setRuntimeInstallPhase("validating");
+    setActionError(null);
+    try {
+      const result = await reconcileDesktopRuntimeInstall();
+      if (result.current) {
+        const next = await refreshDesktopSnapshot();
+        if (!runtimeIsValid(next)) throw new Error("runtime_install_snapshot_invalid");
+        setSnapshot(next);
+        setBotCenter(next.botCenter);
+        setRuntimeInstallRecovery(false);
+        setRuntimeInstallPhase("idle");
+        setLoadFailed(false);
+        setView("home");
+      } else {
+        setRuntimeInstallRecovery(false);
+        setRuntimeInstallPhase("failed");
+        setActionError("O estado foi reconciliado, mas o Runtime ainda não está instalado.");
+      }
+    } catch (error) {
+      setRuntimeInstallPhase("failed");
+      setRuntimeInstallRecovery(true);
       setActionError(runtimeFailureMessage(error, "install"));
     } finally {
       setAction(null);
@@ -317,6 +366,8 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       receipt={runtimeInstallReceipt}
       error={actionError}
       onInstall={installRuntime}
+      reconciliationRequired={runtimeInstallRecovery}
+      onReconcile={reconcileRuntimeInstall}
     />;
   }
 

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -22,7 +22,11 @@ import { createConsolidatedReader, type ConsolidatedQuery, type ConsolidatedRepo
 import {
   createPreviewRuntimeInstallResult,
   parseRuntimeInstallResult,
+  parseRuntimeInstallReconciliation,
+  parseRuntimeInstallStatus,
   type RuntimeInstallResult,
+  type RuntimeInstallReconciliation,
+  type RuntimeInstallStatus,
 } from "./runtime_install";
 
 const readSnapshot = createReadonlyRequest<DesktopSnapshot>(30_000, "desktop_snapshot_timeout");
@@ -108,6 +112,20 @@ export async function installDesktopRuntime(): Promise<RuntimeInstallResult> {
   // This is a native, atomic side effect. The frontend never times it out or
   // retries it; the command itself owns locking, rollback, and verification.
   return parseRuntimeInstallResult(await invoke<unknown>("desktop_install_runtime"));
+}
+
+export async function reconcileDesktopRuntimeInstall(): Promise<RuntimeInstallReconciliation> {
+  if (!isTauri()) {
+    return { schema: "simplicio.desktop-install-reconciliation/v1", status: "clear", current: false, redacted: true };
+  }
+  return parseRuntimeInstallReconciliation(await invoke<unknown>("desktop_reconcile_runtime_install"));
+}
+
+export async function loadDesktopRuntimeInstallStatus(): Promise<RuntimeInstallStatus> {
+  if (!isTauri()) {
+    return { schema: "simplicio.desktop-install-status/v1", status: "clear", redacted: true };
+  }
+  return parseRuntimeInstallStatus(await invoke<unknown>("desktop_runtime_install_status"));
 }
 
 export async function beginDesktopLogin(): Promise<DesktopSnapshot> {

--- a/apps/desktop/src/runtime_failures.ts
+++ b/apps/desktop/src/runtime_failures.ts
@@ -43,6 +43,10 @@ const REASONS: Readonly<Record<string, string>> = {
   runtime_install_precondition_changed: "O Runtime local mudou durante a preparação; a instalação foi interrompida sem sobrescrever o novo estado.",
   runtime_install_snapshot_invalid: "O Runtime instalado não devolveu um estado atual válido.",
   runtime_install_unavailable: "A operação nativa de instalação do Runtime não está disponível.",
+  runtime_install_reconciliation_required: "A última tentativa de instalação não teve resultado confirmado. Consulte e reconcilie o estado antes de tentar novamente.",
+  runtime_install_reconciliation_unavailable: "Não foi possível esclarecer o estado da última instalação. Nenhuma nova tentativa foi iniciada.",
+  runtime_install_journal_unavailable: "Não foi possível registrar com segurança o estado da instalação. Nenhuma alteração foi iniciada.",
+  runtime_install_reconciliation_invalid: "A resposta de reconciliação do Runtime não passou na validação.",
 };
 
 const NEXT_STEPS: Readonly<Record<RuntimeOperation, string>> = {

--- a/apps/desktop/src/runtime_install.test.ts
+++ b/apps/desktop/src/runtime_install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseRuntimeInstallResult } from "./runtime_install";
+import { parseRuntimeInstallReconciliation, parseRuntimeInstallResult, parseRuntimeInstallStatus } from "./runtime_install";
 
 function validResult() {
   return {
@@ -44,5 +44,46 @@ describe("Runtime core installer receipt", () => {
     ]) {
       expect(() => parseRuntimeInstallResult(invalid)).toThrow("runtime_install_result_invalid");
     }
+  });
+});
+
+describe("durable Runtime install reconciliation", () => {
+  it("surfaces only whether a persisted attempt is pending", () => {
+    expect(parseRuntimeInstallStatus({
+      schema: "simplicio.desktop-install-status/v1",
+      status: "pending",
+      redacted: true,
+      error: "runtime_install_timeout",
+    })).toEqual({ schema: "simplicio.desktop-install-status/v1", status: "pending", redacted: true });
+  });
+
+  it("accepts only the closed redacted reconciliation projection", () => {
+    expect(parseRuntimeInstallReconciliation({
+      schema: "simplicio.desktop-install-reconciliation/v1",
+      status: "reconciled",
+      current: true,
+      redacted: true,
+      path: "/private/user/.simplicio/install-attempt.json",
+    })).toEqual({
+      schema: "simplicio.desktop-install-reconciliation/v1",
+      status: "reconciled",
+      current: true,
+      redacted: true,
+    });
+  });
+
+  it("fails closed on malformed or unredacted reconciliation", () => {
+    expect(() => parseRuntimeInstallReconciliation({
+      schema: "simplicio.desktop-install-reconciliation/v1",
+      status: "reconciled",
+      current: true,
+      redacted: false,
+    })).toThrow("runtime_install_reconciliation_invalid");
+    expect(() => parseRuntimeInstallReconciliation({
+      schema: "simplicio.desktop-install-reconciliation/v1",
+      status: "pending",
+      current: false,
+      redacted: true,
+    })).toThrow("runtime_install_reconciliation_invalid");
   });
 });

--- a/apps/desktop/src/runtime_install.ts
+++ b/apps/desktop/src/runtime_install.ts
@@ -14,6 +14,19 @@ export interface RuntimeInstallResult {
   };
 }
 
+export interface RuntimeInstallReconciliation {
+  schema: "simplicio.desktop-install-reconciliation/v1";
+  status: "clear" | "reconciled";
+  current: boolean;
+  redacted: true;
+}
+
+export interface RuntimeInstallStatus {
+  schema: "simplicio.desktop-install-status/v1";
+  status: "clear" | "pending";
+  redacted: true;
+}
+
 const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 
 function validVersion(value: unknown): value is string {
@@ -83,5 +96,39 @@ export function createPreviewRuntimeInstallResult(): RuntimeInstallResult {
     backupAvailable: false,
     pluginsMutated: false,
     runtime: { state: "healthy", version: "0.0.0-preview" },
+  };
+}
+
+export function parseRuntimeInstallReconciliation(value: unknown): RuntimeInstallReconciliation {
+  const result = record(value);
+  if (
+    result.schema !== "simplicio.desktop-install-reconciliation/v1"
+    || (result.status !== "clear" && result.status !== "reconciled")
+    || typeof result.current !== "boolean"
+    || result.redacted !== true
+  ) {
+    throw new Error("runtime_install_reconciliation_invalid");
+  }
+  return {
+    schema: "simplicio.desktop-install-reconciliation/v1",
+    status: result.status,
+    current: result.current,
+    redacted: true,
+  };
+}
+
+export function parseRuntimeInstallStatus(value: unknown): RuntimeInstallStatus {
+  const result = record(value);
+  if (
+    result.schema !== "simplicio.desktop-install-status/v1"
+    || (result.status !== "clear" && result.status !== "pending")
+    || result.redacted !== true
+  ) {
+    throw new Error("runtime_install_status_invalid");
+  }
+  return {
+    schema: "simplicio.desktop-install-status/v1",
+    status: result.status,
+    redacted: true,
   };
 }

--- a/apps/desktop/src/screens/AccessScreens.tsx
+++ b/apps/desktop/src/screens/AccessScreens.tsx
@@ -35,16 +35,20 @@ function runtimeInstallStepStates(phase: RuntimeInstallPhase, receipt?: RuntimeI
   return ["pending", "pending", "pending", "pending"] as const;
 }
 
-export function RuntimeInstallScreen({ phase, receipt, error, onInstall }: {
+export function RuntimeInstallScreen({ phase, receipt, error, onInstall, reconciliationRequired, onReconcile }: {
   phase: RuntimeInstallPhase;
   receipt?: RuntimeInstallResult;
   error: string | null;
   onInstall: () => void;
+  reconciliationRequired?: boolean;
+  onReconcile?: () => void;
 }) {
   const states = runtimeInstallStepStates(phase, receipt);
   const busy = phase === "installing" || phase === "validating";
   const progress = phase === "validating" || (phase === "failed" && receipt) ? 75 : phase === "installing" ? 25 : 0;
-  const status = phase === "installing"
+  const status = reconciliationRequired
+    ? "A tentativa anterior precisa ser esclarecida antes de qualquer nova instalação."
+    : phase === "installing"
     ? "Validando e instalando o Runtime…"
     : phase === "validating"
       ? "Runtime instalado. Confirmando o estado atual…"
@@ -85,7 +89,10 @@ export function RuntimeInstallScreen({ phase, receipt, error, onInstall }: {
     </main>
     <div className="setup-actionbar">
       <div className="setup-footer-inner">
-        <button className="button button-primary" type="button" onClick={onInstall} disabled={busy} aria-busy={busy}>
+        {reconciliationRequired && onReconcile && <button className="button button-secondary" type="button" onClick={onReconcile} disabled={busy} aria-busy={busy}>
+          {busy ? "Consultando…" : "Consultar estado"}
+        </button>}
+        <button className="button button-primary" type="button" onClick={onInstall} disabled={busy || reconciliationRequired} aria-busy={busy}>
           {busy ? "Preparando…" : phase === "failed" ? "Tentar novamente" : "Instalar e validar Runtime"}
           {!busy && <Glyph name="arrow" size={17} />}
         </button>


### PR DESCRIPTION
## Summary
- persist the Desktop Runtime install attempt in a private atomic journal
- block retries after interrupted, ambiguous, or malformed state
- expose a read-only reconciliation command and redacted IPC contracts
- surface restart recovery in the first-run screen
- add contract tests for pending, settled, malformed, and redacted states

Closes #288

## Verification
- `npm test -- --reporter=dot` (352 passed)
- `npm run build`
- latest Runtime v3.8.40 SHA-256 verified locally
- Rust tests could not run in this host because `rustc`/Cargo are unavailable

The journal is deliberately fail-closed and does not persist paths, stdout, stderr, credentials, prompts, or raw Runtime output.