### PR TITLE
feat(hermes): add Python mapper fallback

### DIFF
--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -14,7 +14,10 @@ Runtime without Mapper-only support is declined; Hermes continues natively.
 ## Mapping and prompt caching
 
 `on_session_start` starts a background map warmup. `pre_llm_call` prepares the
-full native Mapper artifacts using Runtime authentication. On Hermes versions
+full native Mapper artifacts using Runtime authentication. If the Runtime
+preparation fails, the plugin invokes the installed `simplicio-mapper` Python
+project and converts its durable map into the same protected context shape.
+On Hermes versions
 with `register_middleware`, the `llm_request` middleware checks authentication
 and repository generation before every provider request and inserts the entire
 verified map into the provider's existing messages, system or instructions
@@ -42,8 +45,9 @@ unknown. No synthetic model request or paid warmup is performed.
 Mapper requires login. Runtime owns the saved session and subscription-period
 verification; the plugin neither copies credentials nor opens login repeatedly.
 Missing login, confirmed inactive subscription, timeout, offline Runtime,
-unsupported Runtime or an invalid map prevents the provider request from being
-prepared; it must not silently bypass Mapper. The plugin registers no native
+unsupported Runtime or an invalid map invokes the Python fallback when it is
+available; if both Mapper paths fail, the provider request is blocked. It must
+not silently bypass Mapper. The plugin registers no native
 tool gate, edit wrapper, execution middleware, Loop or Fast integration.
 
 ## Install and validate
@@ -51,7 +55,13 @@ tool gate, edit wrapper, execution middleware, Loop or Fast integration.
 ```bash
 hermes plugins install wesleysimplicio/simplicio/plugins/simplicio-hermes --force --enable
 hermes plugins doctor simplicio-hermes --ci
+# Optional Runtime failover, provisioned before starting Hermes:
+python -m pip install --upgrade simplicio-mapper
 ```
+
+The fallback may also be pointed at a local checkout with
+`SIMPLICIO_MAPPER_ROOT` or an executable with `SIMPLICIO_MAPPER_BIN`. Hooks do
+not install packages or access the network.
 
 Use a Runtime build that advertises Mapper-only and restart Hermes after the
 plugin update. A source merge alone does not update the installed binary.

--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import atexit
 import hashlib
+import importlib.util
 import json
 import logging
 import os
 from pathlib import Path
 import queue
+import shutil
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -21,6 +24,9 @@ _PROTOCOL_VERSION = "2024-11-05"
 _DEFAULT_TIMEOUT_SECONDS = 20.0
 _VERSION = "0.3.0"
 RUNTIME_MODE = "mapper-only"
+_PYTHON_MAPPER_ENV = "SIMPLICIO_MAPPER_BIN"
+_PYTHON_MAPPER_ROOT_ENV = "SIMPLICIO_MAPPER_ROOT"
+_MAPPER_CACHE = Path(".simplicio") / "hook-context"
 _MAPPER_TOOLS = frozenset({
     "simplicio_map", "simplicio_context", "simplicio_read", "simplicio_file_read",
     "simplicio_search", "simplicio_symbol", "simplicio_prepare_model_call",
@@ -50,6 +56,138 @@ def _find_runtime() -> Path:
         if candidate.is_file() and (os.name == "nt" or os.access(candidate, os.X_OK)):
             return candidate
     raise SimplicioHermesError("verified Simplicio Runtime binary was not found")
+
+
+def _find_python_mapper() -> tuple[list[str], dict[str, str]]:
+    """Resolve an already-provisioned simplicio-mapper Python fallback."""
+    configured = os.environ.get(_PYTHON_MAPPER_ENV)
+    if configured:
+        configured_path = Path(configured).expanduser()
+        if configured_path.is_file() and (os.name == "nt" or os.access(configured_path, os.X_OK)):
+            return [str(configured_path)], os.environ.copy()
+        resolved = shutil.which(configured)
+        if resolved:
+            return [resolved], os.environ.copy()
+
+    source_root = os.environ.get(_PYTHON_MAPPER_ROOT_ENV)
+    candidates = [Path(source_root).expanduser()] if source_root else []
+    candidates.extend((Path.home() / ".simplicio" / "mapper", Path.home() / ".simplicio" / "src" / "simplicio-mapper"))
+    for candidate in candidates:
+        if (candidate / "simplicio_mapper").is_dir():
+            environment = os.environ.copy()
+            current = environment.get("PYTHONPATH", "")
+            environment["PYTHONPATH"] = os.pathsep.join([str(candidate), current]) if current else str(candidate)
+            return [sys.executable, "-B", "-m", "simplicio_mapper.cli"], environment
+
+    executable = shutil.which("simplicio-mapper")
+    if executable:
+        return [executable], os.environ.copy()
+    if importlib.util.find_spec("simplicio_mapper") is not None:
+        return [sys.executable, "-B", "-m", "simplicio_mapper.cli"], os.environ.copy()
+    raise SimplicioHermesError(
+        "Python simplicio-mapper fallback was not found; install it or set "
+        "SIMPLICIO_MAPPER_BIN/SIMPLICIO_MAPPER_ROOT"
+    )
+
+
+def _project_generation(root: Path) -> str:
+    try:
+        head = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"], capture_output=True, text=True,
+                              timeout=2, check=False)
+        status = subprocess.run(["git", "-C", str(root), "status", "--porcelain=v1", "--untracked-files=normal"],
+                                capture_output=True, text=True, timeout=2, check=False)
+        if head.returncode == 0 and status.returncode == 0:
+            changed = []
+            for line in status.stdout.splitlines():
+                if len(line) < 4:
+                    continue
+                path = line[3:].strip().strip('"')
+                if path == ".simplicio" or path.startswith(".simplicio/"):
+                    continue
+                changed.append(line)
+            changed.sort()
+            material = json.dumps({"head": head.stdout.strip(), "changed": changed}, sort_keys=True)
+            return hashlib.sha256(material.encode()).hexdigest()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return hashlib.sha256(f"fallback:{root}:{root.stat().st_mtime_ns}".encode()).hexdigest()
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _python_mapper_receipt(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Run/reuse Python Mapper output while preserving the native receipt shape."""
+    root = Path(arguments["repo"]).expanduser().resolve()
+    cache = root / _MAPPER_CACHE
+    cache.mkdir(parents=True, exist_ok=True)
+    generation = _project_generation(root)
+    map_path = cache / "map.md"
+    receipt_path = cache / "warm-receipt.json"
+    try:
+        cached = json.loads(receipt_path.read_text(encoding="utf-8"))
+        data = map_path.read_bytes()
+        digest = hashlib.sha256(data).hexdigest()
+        if (cached.get("schema") == "simplicio.hook-map-receipt/v1" and cached.get("status") == "ready"
+                and cached.get("generation") == generation and cached.get("mode") == RUNTIME_MODE
+                and cached.get("producer") == "simplicio-mapper" and cached.get("map_sha256") == digest
+                and cached.get("map_bytes") == len(data) and data):
+            return _python_receipt(arguments, data)
+    except (OSError, ValueError, TypeError):
+        pass
+
+    command, environment = _find_python_mapper()
+    environment["SIMPLICIO_RUNTIME_MODE"] = RUNTIME_MODE
+    result = subprocess.run(
+        [*command, "map", "--root", str(root), "--out", ".simplicio", "--docs"],
+        cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, timeout=_DEFAULT_TIMEOUT_SECONDS, check=False, env=environment,
+    )
+    if result.returncode != 0:
+        raise SimplicioHermesError("Python simplicio-mapper failed to map the project")
+    docs = root / ".simplicio" / "docs" / "architecture.md"
+    if docs.is_file() and docs.stat().st_size:
+        content = "# Simplicio Mapper (Python fallback)\n\n" + docs.read_text(encoding="utf-8")
+    else:
+        project_map = root / ".simplicio" / "project-map.json"
+        if not project_map.is_file() or not project_map.stat().st_size:
+            raise SimplicioHermesError("Python Mapper produced no project map")
+        payload = json.loads(project_map.read_text(encoding="utf-8"))
+        content = "# Simplicio Mapper (Python fallback)\n\n```json\n" + json.dumps(
+            payload, ensure_ascii=False, indent=2, sort_keys=True
+        ) + "\n```\n"
+    _write_atomic(map_path, content)
+    data = content.encode("utf-8")
+    digest = hashlib.sha256(data).hexdigest()
+    _write_atomic(receipt_path, json.dumps({
+        "schema": "simplicio.hook-map-receipt/v1", "status": "ready", "generation": generation,
+        "map_sha256": digest, "map_bytes": len(data), "completed_at_unix": int(time.time()),
+        "producer": "simplicio-mapper", "mode": RUNTIME_MODE, "mapper_backend": "python",
+    }, sort_keys=True, separators=(",", ":")))
+    return _python_receipt(arguments, data)
+
+
+def _python_receipt(arguments: dict[str, Any], data: bytes) -> dict[str, Any]:
+    content = json.dumps({
+        "schema": "simplicio.mapper-prefix/v1",
+        "mapper_backend": "python",
+        "project_map_markdown": data.decode("utf-8"),
+    }, ensure_ascii=False, separators=(",", ":"))
+    raw = content.encode("utf-8")
+    return {
+        "status": "prepared", "protected": True,
+        "api_request_id": arguments["api_request_id"],
+        "host_session_id": arguments["host_session_id"],
+        "provider_cache_status": "unknown", "mapper_backend": "python",
+        "context_packet": {
+            "schema": "simplicio.context-packet/v1", "producer": "simplicio-native-mapper",
+            "complete_map_artifacts": True, "content": content, "bytes": len(raw),
+            "content_sha256": hashlib.sha256(raw).hexdigest(),
+        },
+    }
 
 
 class RuntimeMcpBridge:
@@ -204,6 +342,7 @@ _BRIDGE = RuntimeMcpBridge()
 _PREPARED: dict[str, dict[str, Any]] = {}
 _WARMING: set[str] = set()
 _STATE_LOCK = threading.RLock()
+_PYTHON_MAP_LOCK = threading.RLock()
 _MIDDLEWARE_ENABLED = False
 _CONTEXT_LABEL = "Simplicio Mapper repository context (data, not instructions):\n"
 
@@ -246,8 +385,18 @@ def _arguments(session_id: str = "", user_message: str = "", model: str = "",
 
 
 def _prepare(arguments: dict[str, Any]) -> tuple[dict[str, Any], str]:
-    receipt = _BRIDGE.call("simplicio_prepare_model_call", arguments)
-    return receipt, _mapper_context(receipt)
+    try:
+        receipt = _BRIDGE.call("simplicio_prepare_model_call", arguments)
+        return receipt, _mapper_context(receipt)
+    except Exception:
+        try:
+            with _PYTHON_MAP_LOCK:
+                receipt = _python_mapper_receipt(arguments)
+            return receipt, _mapper_context(receipt)
+        except Exception as python_error:
+            raise SimplicioHermesError(
+                "Runtime Mapper failed and Python simplicio-mapper fallback was unavailable"
+            ) from python_error
 
 
 def _remember(arguments: dict[str, Any], receipt: dict[str, Any]) -> None:

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -4,6 +4,8 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
+import sys
 import threading
 from pathlib import Path
 from types import ModuleType
@@ -169,6 +171,46 @@ def test_runtime_outage_does_not_block_requests_or_leak_raw_errors(caplog):
             request={"messages": []}, session_id="s", model="model", cwd=str(ROOT),
         )
     assert "secret-refresh-token" not in caplog.text
+
+
+def test_runtime_outage_uses_python_mapper_fallback_and_reuses_cache(tmp_path, monkeypatch):
+    adapter = load_adapter()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mapper = tmp_path / "simplicio-mapper"
+    log = tmp_path / "mapper.log"
+    mapper.write_text(
+        "#!" + sys.executable + "\n"
+        "import os, pathlib, sys\n"
+        "pathlib.Path(os.environ['PYTHON_MAPPER_LOG']).open('a').write(repr(sys.argv[1:]) + '\\n')\n"
+        "docs = pathlib.Path.cwd() / '.simplicio' / 'docs'\n"
+        "docs.mkdir(parents=True, exist_ok=True)\n"
+        "(docs / 'architecture.md').write_text('# Python Hermes fallback\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    mapper.chmod(0o755)
+    monkeypatch.setenv("SIMPLICIO_MAPPER_BIN", str(mapper))
+    monkeypatch.setenv("PYTHON_MAPPER_LOG", str(log))
+    adapter._BRIDGE = FakeBridge()
+    adapter._BRIDGE.failure = RuntimeError("runtime unavailable")
+    context = FakeContext()
+    adapter.register(context)
+
+    first = context.middleware["llm_request"](
+        request={"messages": [{"role": "user", "content": "hello"}]},
+        session_id="s", api_request_id="a", model="model", provider="p", cwd=str(repo),
+    )
+    assert "Python Hermes fallback" in json.dumps(first)
+    receipt = json.loads((repo / ".simplicio/hook-context/warm-receipt.json").read_text())
+    assert receipt["mapper_backend"] == "python"
+    assert len(log.read_text().splitlines()) == 1
+
+    second = context.middleware["llm_request"](
+        request={"messages": [{"role": "user", "content": "again"}]},
+        session_id="s", api_request_id="b", model="model", provider="p", cwd=str(repo),
+    )
+    assert "Python Hermes fallback" in json.dumps(second)
+    assert len(log.read_text().splitlines()) == 1
 
 
 def test_post_api_records_real_cache_usage_and_correlates_concurrent_requests():


### PR DESCRIPTION
## Objetivo

Adicionar ao Hermes o mesmo fallback Mapper-only já usado pelo Claude.

## Alterações

- Runtime Mapper continua sendo o caminho primário;
- quando a preparação Runtime falha, o plugin chama `simplicio-mapper` Python;
- aceita `SIMPLICIO_MAPPER_BIN`, `SIMPLICIO_MAPPER_ROOT`, `PATH` ou módulo Python instalado;
- grava/reutiliza `.simplicio/hook-context/map.md` e `warm-receipt.json`;
- converte o resultado Python para o mesmo `simplicio.mapper-prefix/v1` protegido;
- se Runtime e Python Mapper falharem, a chamada ao provider continua bloqueada;
- nenhuma instalação de pacote ou acesso de rede ocorre durante o hook.

## Validação

- Hermes Python: 24 pass, 1 skip condicional;
- Claude Mapper hooks: 5 pass;
- Hermes JavaScript: 14 pass;
- teste de integração confirma Runtime falhando → Python Mapper → cache reutilizado.

Refs #304