### PR TITLE
feat(hermes): capture reasoning and cache-write usage

### DIFF
--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -474,34 +474,53 @@ def _llm_request(request: dict[str, Any], session_id: str = "", model: str = "",
         raise SimplicioHermesError("Mapper preparation is mandatory") from error
 
 
+def _metric_value(source: dict[str, Any], path: str) -> int | None:
+    value: Any = source
+    for part in path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
 def _token_usage(event: dict[str, Any]) -> dict[str, int]:
     usage = event.get("usage")
     if not isinstance(usage, dict):
         usage = {}
-    result = {}
+    result: dict[str, int] = {}
     aliases = {
         "input_tokens": ("prompt_tokens", "input_tokens"),
         "output_tokens": ("output_tokens", "completion_tokens"),
-        "cache_read_input_tokens": ("cache_read_input_tokens", "cache_read_tokens"),
+        "cache_read_input_tokens": (
+            "cache_read_input_tokens", "cache_read_tokens", "cached_input_tokens",
+            "input_tokens_details.cached_tokens", "prompt_tokens_details.cached_tokens",
+        ),
+        "cache_write_tokens": (
+            "cache_write_tokens", "cache_write_input_tokens", "cache_creation_input_tokens",
+            "cache_creation_tokens", "input_tokens_details.cache_write_tokens",
+            "input_tokens_details.cache_creation_input_tokens",
+            "prompt_tokens_details.cache_write_tokens",
+            "prompt_tokens_details.cache_creation_input_tokens",
+        ),
+        "reasoning_tokens": (
+            "reasoning_tokens", "reasoning",
+            "completion_tokens_details.reasoning_tokens",
+            "output_tokens_details.reasoning_tokens",
+            "reasoning_details.reasoning_tokens",
+        ),
     }
     for target, names in aliases.items():
         for source in (event, usage):
             for name in names:
-                value = source.get(name)
-                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                value = _metric_value(source, name)
+                if value is not None:
                     result[target] = value
                     break
             if target in result:
                 break
-    if "cache_read_input_tokens" not in result:
-        for key in ("input_tokens_details", "prompt_tokens_details"):
-            details = usage.get(key)
-            cached = details.get("cached_tokens") if isinstance(details, dict) else None
-            if isinstance(cached, int) and not isinstance(cached, bool) and cached >= 0:
-                result["cache_read_input_tokens"] = cached
-                break
     return result
-
 
 def _record(session_id: str = "", status: str = "completed", **kwargs: Any) -> None:
     with _STATE_LOCK:

--- a/plugins/simplicio-hermes/index.mjs
+++ b/plugins/simplicio-hermes/index.mjs
@@ -65,23 +65,40 @@ function injectContext(request, content) {
   throw new HermesProtectionError("unsupported_request_shape");
 }
 
+function metricValue(source, path) {
+  let value = source;
+  for (const part of path.split(".")) value = value?.[part];
+  return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 function tokenUsage(event) {
   const usage = event.usage ?? event.response?.usage ?? event.result?.usage ?? {};
   const aliases = {
     input_tokens: ["prompt_tokens", "input_tokens"],
     output_tokens: ["output_tokens", "completion_tokens"],
-    cache_read_input_tokens: ["cache_read_input_tokens", "cache_read_tokens"],
+    cache_read_input_tokens: [
+      "cache_read_input_tokens", "cache_read_tokens", "cached_input_tokens",
+      "input_tokens_details.cached_tokens", "prompt_tokens_details.cached_tokens",
+    ],
+    cache_write_tokens: [
+      "cache_write_tokens", "cache_write_input_tokens", "cache_creation_input_tokens",
+      "cache_creation_tokens", "input_tokens_details.cache_write_tokens",
+      "input_tokens_details.cache_creation_input_tokens",
+      "prompt_tokens_details.cache_write_tokens", "prompt_tokens_details.cache_creation_input_tokens",
+    ],
+    reasoning_tokens: [
+      "reasoning_tokens", "reasoning",
+      "completion_tokens_details.reasoning_tokens",
+      "output_tokens_details.reasoning_tokens",
+      "reasoning_details.reasoning_tokens",
+    ],
   };
   const result = {};
   for (const [target, names] of Object.entries(aliases)) {
     for (const source of [event, usage]) {
-      const value = names.map((name) => source?.[name]).find((item) => Number.isSafeInteger(item) && item >= 0);
+      const value = names.map((name) => metricValue(source, name)).find((item) => item !== undefined);
       if (value !== undefined) { result[target] = value; break; }
     }
-  }
-  if (result.cache_read_input_tokens === undefined) {
-    const value = usage.input_tokens_details?.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens;
-    if (Number.isSafeInteger(value) && value >= 0) result.cache_read_input_tokens = value;
   }
   return result;
 }

--- a/plugins/simplicio-hermes/test.mjs
+++ b/plugins/simplicio-hermes/test.mjs
@@ -131,12 +131,18 @@ test("records actual cache telemetry with matching request and no source bodies"
   });
   await plugin.record_model_result({
     session_id: "s", api_request_id: "a", response: { id: "provider-a" },
-    usage: { input_tokens: 20, prompt_tokens: 100, output_tokens: 4, cache_read_tokens: 80 },
+    usage: {
+      input_tokens: 20, prompt_tokens: 100, output_tokens: 4, cache_read_tokens: 80,
+      cache_creation_input_tokens: 7,
+      completion_tokens_details: { reasoning_tokens: 3 },
+    },
   });
   const record = runtime.calls.record[0];
   assert.equal(record.api_request_id, "a");
   assert.equal(record.provider_request_id, "provider-a");
   assert.equal(record.cache_read_input_tokens, 80);
+  assert.equal(record.cache_write_tokens, 7);
+  assert.equal(record.reasoning_tokens, 3);
   assert.equal(record.input_tokens, 100);
   assert.doesNotMatch(JSON.stringify(record), /complete_map_tail/);
   assert.equal(plugin.status().provider_cache_status, "reported");

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -223,13 +223,19 @@ def test_post_api_records_real_cache_usage_and_correlates_concurrent_requests():
     context.hooks["post_api_request"](
         session_id="s", turn_id="t", api_request_id="a", model="model", provider="p",
         response={"body": {"id": "provider-a"}},
-        usage={"input_tokens": 100, "output_tokens": 5, "cache_read_tokens": 80},
+        usage={
+            "input_tokens": 100, "output_tokens": 5, "cache_read_tokens": 80,
+            "cache_creation_input_tokens": 7,
+            "completion_tokens_details": {"reasoning_tokens": 3},
+        },
     )
     tool, args = bridge.calls[-1]
     assert tool == "simplicio_record_model_result"
     assert args["api_request_id"] == "a"
     assert args["provider_request_id"] == "provider-a"
     assert args["cache_read_input_tokens"] == 80
+    assert args["cache_write_tokens"] == 7
+    assert args["reasoning_tokens"] == 3
     assert args["input_tokens"] == 100 and args["output_tokens"] == 5
     assert "complete_map_tail" not in json.dumps(args)
     assert len(adapter._PREPARED) == 1
@@ -352,8 +358,12 @@ def test_canonical_hermes_usage_keeps_total_prompt_and_cache_buckets():
     adapter = load_adapter()
     assert adapter._token_usage({"usage": {
         "input_tokens": 20, "prompt_tokens": 100, "output_tokens": 4,
-        "cache_read_tokens": 80,
-    }}) == {"input_tokens": 100, "output_tokens": 4, "cache_read_input_tokens": 80}
+        "cache_read_tokens": 80, "cache_creation_input_tokens": 7,
+        "completion_tokens_details": {"reasoning_tokens": 3},
+    }}) == {
+        "input_tokens": 100, "output_tokens": 4, "cache_read_input_tokens": 80,
+        "cache_write_tokens": 7, "reasoning_tokens": 3,
+    }
     assert adapter._token_usage({"usage": {"input_tokens_details": {"cached_tokens": 0}}}) == {
         "cache_read_input_tokens": 0,
     }


### PR DESCRIPTION
## Summary

- normalize Hermes provider usage aliases for canonical Runtime `cache_write_tokens` and `reasoning_tokens`
- preserve absent metrics as absent (never synthesize zero values)
- cover JavaScript and native Python adapters with focused fixtures

## Verification

- `node --test plugins/simplicio-hermes/test.mjs` — 14 passed
- `python3 -m py_compile plugins/simplicio-hermes/hermes_plugin.py` — passed
- direct Python metric checks — passed
- `pytest` was unavailable in the execution image (`No module named pytest`)

## Delivery

This PR is the implementation/test portion of #301. A real Hermes→Runtime v2 receipt and installed end-to-end proof still require the private Runtime release and a real Hermes provider response; the issue remains open until that evidence exists.