### PR TITLE
feat(desktop): add fail-closed usage changefeed consumer

### DIFF
--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -18,6 +18,7 @@ import { parseLocalProject, type LocalProject } from "./workbench";
 import { createReadonlyRequest } from "./readonly_request";
 import { createContextReader } from "./context_report";
 import { parseUsageProjects } from "./project_usage";
+import { applyUsageChangefeedEvent, createUsageChangefeedState, type UsageChangefeedState } from "./usage_changefeed";
 import { createConsolidatedReader, type ConsolidatedQuery, type ConsolidatedReport } from "./consolidated_tokens";
 import {
   createPreviewRuntimeInstallResult,
@@ -105,6 +106,22 @@ export async function loadDesktopSnapshot(): Promise<DesktopSnapshot> {
   }
 
   return readSnapshot(() => invoke<DesktopSnapshot>("desktop_snapshot"));
+}
+
+/**
+ * Pull one Runtime-owned usage event. The current public Runtime may not
+ * expose this command yet; callers keep the last state and surface the
+ * capability error instead of showing a false zero.
+ */
+export async function pullDesktopUsageChangefeed(
+  cursor: UsageChangefeedState = createUsageChangefeedState(),
+): Promise<UsageChangefeedState> {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  const event = await withTimeout(invoke<unknown>("desktop_usage_changefeed", {
+    afterSequence: cursor.cursor.sequence,
+    afterRevision: cursor.cursor.revision,
+  }), 30_000, "usage_changefeed_timeout");
+  return applyUsageChangefeedEvent(cursor, event);
 }
 
 export async function installDesktopRuntime(): Promise<RuntimeInstallResult> {

--- a/apps/desktop/src/usage_changefeed.test.ts
+++ b/apps/desktop/src/usage_changefeed.test.ts
@@ -25,7 +25,7 @@ const projection: UnifiedUsageProjection = {
     source: "runtime", generated_by: "runtime_usage_ledger", generated_at_epoch: 1700000100,
     report_digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     pricing_version: null, pricing_sources: [],
-    coverage: { status: "no_data", missing_usage_events: 0, unpriced_events: 0, providers: [], reason: null },
+    coverage: { status: "partial", missing_usage_events: 0, unpriced_events: 0, providers: [], reason: null },
     redacted: true,
   },
 };

--- a/apps/desktop/src/usage_changefeed.test.ts
+++ b/apps/desktop/src/usage_changefeed.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyUsageChangefeedEvent,
+  createUsageChangefeedState,
+  markUsageChangefeedOffline,
+} from "./usage_changefeed";
+import type { UnifiedUsageProjection } from "./unified_usage";
+
+const projection: UnifiedUsageProjection = {
+  schema: "simplicio.desktop-unified-usage/v1",
+  generated_at_epoch: 1700000100,
+  query: {},
+  rows: [{
+    provider: "openai", model: "gpt-5", host: "codex",
+    project_id: null, session_id: "session-1", execution: "remote",
+    input_tokens: 10, cache_read_tokens: 2, cache_write_tokens: 1,
+    output_tokens: 4, reasoning_tokens: 1, total_tokens: 15, cost_usd: null,
+    provenance: "unavailable", event_count: 1,
+  }],
+  totals: {
+    event_count: 1, input_tokens: 10, cache_read_tokens: 2, cache_write_tokens: 1,
+    output_tokens: 4, reasoning_tokens: 1, total_tokens: 15, cost_usd: null,
+  },
+  metadata: {
+    source: "runtime", generated_by: "runtime_usage_ledger", generated_at_epoch: 1700000100,
+    report_digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    pricing_version: null, pricing_sources: [],
+    coverage: { status: "no_data", missing_usage_events: 0, unpriced_events: 0, providers: [], reason: null },
+    redacted: true,
+  },
+};
+
+function event(sequence: number, revision = sequence, eventId = `event-${sequence}`) {
+  return {
+    schema: "simplicio.desktop-usage-changefeed/v1",
+    event_id: eventId, sequence, revision, kind: sequence === 1 ? "snapshot" : "delta",
+    generated_at_epoch: 1700000100 + sequence, projection,
+  };
+}
+
+describe("Runtime usage changefeed", () => {
+  it("applies a snapshot and an in-order delta while advancing the cursor", () => {
+    let state = applyUsageChangefeedEvent(createUsageChangefeedState(), event(1));
+    state = applyUsageChangefeedEvent(state, event(2));
+    expect(state.connection).toBe("live");
+    expect(state.cursor).toEqual({ sequence: 2, revision: 2, event_ids: ["event-1", "event-2"] });
+    expect(state.projection?.totals.total_tokens).toBe(15);
+  });
+
+  it("deduplicates replayed event IDs without changing the projection", () => {
+    const first = applyUsageChangefeedEvent(createUsageChangefeedState(), event(1));
+    const replay = applyUsageChangefeedEvent(first, event(1, 1, "event-1"));
+    expect(replay.reason_code).toBe("usage_changefeed_duplicate_ignored");
+    expect(replay.cursor.sequence).toBe(1);
+  });
+
+  it("preserves the last projection and asks for replay when a sequence gap appears", () => {
+    const first = applyUsageChangefeedEvent(createUsageChangefeedState(), event(1));
+    const gap = applyUsageChangefeedEvent(first, event(3));
+    expect(gap.connection).toBe("reconnecting");
+    expect(gap.projection).toBe(first.projection);
+    expect(gap.cursor.sequence).toBe(1);
+  });
+
+  it("keeps last known data when transport goes offline", () => {
+    const first = applyUsageChangefeedEvent(createUsageChangefeedState(), event(1));
+    const offline = markUsageChangefeedOffline(first);
+    expect(offline.connection).toBe("offline");
+    expect(offline.projection).toBe(first.projection);
+  });
+
+  it("rejects untrusted projection data before it reaches the renderer state", () => {
+    expect(() => applyUsageChangefeedEvent(createUsageChangefeedState(), {
+      ...event(1), projection: { ...projection, metadata: { ...projection.metadata, redacted: false } },
+    })).toThrow("usage_projection_untrusted_source");
+  });
+});

--- a/apps/desktop/src/usage_changefeed.ts
+++ b/apps/desktop/src/usage_changefeed.ts
@@ -1,0 +1,123 @@
+import { parseUnifiedUsageProjection, type UnifiedUsageProjection } from "./unified_usage";
+
+export const USAGE_CHANGEFEED_SCHEMA = "simplicio.desktop-usage-changefeed/v1";
+export const MAX_CHANGEFEED_EVENT_IDS = 128;
+
+export type UsageChangefeedConnection = "live" | "reconnecting" | "stale" | "offline";
+export type UsageChangefeedKind = "snapshot" | "delta";
+
+export interface UsageChangefeedEvent {
+  schema: typeof USAGE_CHANGEFEED_SCHEMA;
+  event_id: string;
+  sequence: number;
+  revision: number;
+  kind: UsageChangefeedKind;
+  generated_at_epoch: number;
+  projection: unknown;
+}
+
+export interface UsageChangefeedCursor {
+  sequence: number;
+  revision: number;
+  event_ids: string[];
+}
+
+export interface UsageChangefeedState {
+  connection: UsageChangefeedConnection;
+  cursor: UsageChangefeedCursor;
+  projection: UnifiedUsageProjection | null;
+  last_event_at_epoch: number | null;
+  reason_code: string;
+}
+
+const KINDS: UsageChangefeedKind[] = ["snapshot", "delta"];
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("usage_changefeed_invalid");
+  }
+  return value as Record<string, unknown>;
+}
+
+function text(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 256
+    || /[\\/\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error("usage_changefeed_invalid");
+  }
+  return value;
+}
+
+function integer(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error("usage_changefeed_invalid");
+  }
+  return value;
+}
+
+function parseEvent(value: unknown): UsageChangefeedEvent {
+  const raw = record(value);
+  const kind = text(raw.kind);
+  if (!KINDS.includes(kind as UsageChangefeedKind)) throw new Error("usage_changefeed_invalid");
+  return {
+    schema: raw.schema === USAGE_CHANGEFEED_SCHEMA ? USAGE_CHANGEFEED_SCHEMA : (() => {
+      throw new Error("usage_changefeed_invalid");
+    })(),
+    event_id: text(raw.event_id),
+    sequence: integer(raw.sequence),
+    revision: integer(raw.revision),
+    kind: kind as UsageChangefeedKind,
+    generated_at_epoch: integer(raw.generated_at_epoch),
+    projection: raw.projection,
+  };
+}
+
+export function createUsageChangefeedState(): UsageChangefeedState {
+  return {
+    connection: "offline",
+    cursor: { sequence: 0, revision: 0, event_ids: [] },
+    projection: null,
+    last_event_at_epoch: null,
+    reason_code: "usage_changefeed_unavailable",
+  };
+}
+
+function remember(cursor: UsageChangefeedCursor, eventId: string): UsageChangefeedCursor {
+  return {
+    sequence: cursor.sequence,
+    revision: cursor.revision,
+    event_ids: [...cursor.event_ids, eventId].slice(-MAX_CHANGEFEED_EVENT_IDS),
+  };
+}
+
+export function applyUsageChangefeedEvent(
+  state: UsageChangefeedState,
+  value: unknown,
+): UsageChangefeedState {
+  const event = parseEvent(value);
+  if (state.cursor.event_ids.includes(event.event_id)) {
+    return { ...state, connection: "live", reason_code: "usage_changefeed_duplicate_ignored" };
+  }
+  if (event.sequence <= state.cursor.sequence || event.revision <= state.cursor.revision) {
+    return { ...state, connection: "stale", reason_code: "usage_changefeed_stale_ignored" };
+  }
+  if (state.cursor.sequence > 0 && event.sequence !== state.cursor.sequence + 1) {
+    return { ...state, connection: "reconnecting", reason_code: "usage_changefeed_gap" };
+  }
+
+  const projection = parseUnifiedUsageProjection(event.projection);
+  const cursor = remember({ ...state.cursor, sequence: event.sequence, revision: event.revision }, event.event_id);
+  return {
+    connection: "live",
+    cursor,
+    projection,
+    last_event_at_epoch: event.generated_at_epoch,
+    reason_code: event.kind === "delta" ? "usage_changefeed_delta_applied" : "usage_changefeed_snapshot_applied",
+  };
+}
+
+export function markUsageChangefeedOffline(
+  state: UsageChangefeedState,
+  reasonCode = "usage_changefeed_offline",
+): UsageChangefeedState {
+  return { ...state, connection: "offline", reason_code: reasonCode };
+}


### PR DESCRIPTION
## Summary

- add a bounded, versioned Runtime usage changefeed state machine
- advance sequence/revision cursors only for validated in-order events
- deduplicate event IDs, preserve the last good projection across gaps/offline, and fail closed on untrusted payloads
- expose a bridge pull that sends the cursor without renderer-side usage math

## Verification

- `vitest run apps/desktop/src/usage_changefeed.test.ts` — 5 passed

## Delivery

This is the public Desktop consumer boundary for #302. The current public Runtime v3.8.40 does not expose `desktop_usage_changefeed`; the native command and installed changefeed proof remain unresolved, so the issue stays open.