### PR TITLE
feat(desktop): consume Runtime cost and savings evidence

### DIFF
--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -20,6 +20,7 @@ import { createContextReader } from "./context_report";
 import { parseUsageProjects } from "./project_usage";
 import { applyUsageChangefeedEvent, createUsageChangefeedState, type UsageChangefeedState } from "./usage_changefeed";
 import { exportUnifiedUsageProjection, parseUnifiedUsageProjection, type UnifiedUsageProjection, type UsageQuery } from "./unified_usage";
+import { parseCostProjection, type CostProjection, type CostQuery } from "./cost_projection";
 import { createConsolidatedReader, type ConsolidatedQuery, type ConsolidatedReport } from "./consolidated_tokens";
 import {
   createPreviewRuntimeInstallResult,
@@ -61,6 +62,15 @@ export function exportDesktopUnifiedUsage(
   format: "json" | "csv",
 ): string {
   return exportUnifiedUsageProjection(projection, format);
+}
+
+export async function loadDesktopCostProjection(query: CostQuery = {}): Promise<CostProjection> {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  return parseCostProjection(await withTimeout(
+    invoke<unknown>("desktop_cost_projection", { query }),
+    60_000,
+    "cost_projection_timeout",
+  ));
 }
 
 export function loadDesktopContextReport(repoPath: string) {

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -5,7 +5,8 @@ import { TokenProjects } from "../components/TokenProjects";
 import { ConsolidatedTokens } from "../components/ConsolidatedTokens";
 import type { UsageProjects } from "../project_usage";
 import type { UnifiedUsageProjection } from "../unified_usage";
-import { exportDesktopTokenReport, loadDesktopTokenReport, loadDesktopUnifiedUsage } from "../bridge";
+import type { CostProjection } from "../cost_projection";
+import { exportDesktopTokenReport, loadDesktopTokenReport, loadDesktopUnifiedUsage, loadDesktopCostProjection } from "../bridge";
 import { TOKEN_PERIODS, tokenErrorMessage, tokenExportErrorMessage, type TokenPeriod, type TokenQuery, type TokenUsageReport } from "../token_usage";
 
 export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { initialRepoPath?: string; projectPaths?: string[] }) {
@@ -23,6 +24,9 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { init
   const [unifiedProjection, setUnifiedProjection] = useState<UnifiedUsageProjection | null>(null);
   const [unifiedBusy, setUnifiedBusy] = useState(false);
   const [unifiedError, setUnifiedError] = useState<string | null>(null);
+  const [costProjection, setCostProjection] = useState<CostProjection | null>(null);
+  const [costBusy, setCostBusy] = useState(false);
+  const [costError, setCostError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
@@ -95,6 +99,21 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { init
       setUnifiedError(cause instanceof Error ? cause.message : "unified_usage_unavailable");
     } finally {
       setUnifiedBusy(false);
+    }
+  }
+
+  async function loadCostProjection() {
+    if (costBusy) return;
+    setCostBusy(true);
+    setCostProjection(null);
+    setCostError(null);
+    try {
+      const query = sessionId.trim() ? { session_id: sessionId.trim() } : {};
+      setCostProjection(await loadDesktopCostProjection(query));
+    } catch (cause) {
+      setCostError(cause instanceof Error ? cause.message : "cost_projection_unavailable");
+    } finally {
+      setCostBusy(false);
     }
   }
 
@@ -172,6 +191,19 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { init
           <p>Tokens registrados: {unifiedProjection.totals.total_tokens.toLocaleString("pt-BR")}; custo: {unifiedProjection.totals.cost_usd === null ? "indisponível" : `US$ ${unifiedProjection.totals.cost_usd.toFixed(6)}`}</p>
           <ul>{unifiedProjection.rows.slice(0, 10).map((row) => <li key={`${row.provider}:${row.model}:${row.host}:${row.session_id ?? "none"}`}>{row.provider} · {row.model} · {row.host} · {row.total_tokens.toLocaleString("pt-BR")} tokens · {row.provenance}</li>)}</ul>
           <code>{unifiedProjection.metadata.report_digest}</code>
+        </div>}
+      </section>
+      <section className="panel token-evidence" aria-label="Custo e economia">
+        <h2>Custo, economia e confiança</h2>
+        <p>Valores só são exibidos quando o Runtime fornece períodos, pricing e proveniência reconciliados.</p>
+        <button className="button button-secondary" type="button" disabled={costBusy || exporting} onClick={() => void loadCostProjection()}>
+          {costBusy ? "Consultando custo…" : "Consultar custo e economia"}
+        </button>
+        {costError && <p role="status">Relatório indisponível: <code>{costError}</code>. Nenhuma economia foi estimada no renderer.</p>}
+        {costProjection && <div className="token-cost-result">
+          <p>{costProjection.periods.length} período(s) · {costProjection.breakdown.length} agrupamento(s) · pricing: {costProjection.metadata.pricing.status} · cobertura: {costProjection.metadata.coverage.status}</p>
+          <p>Tokens reais: {costProjection.totals.actual_tokens === null ? "indisponível" : costProjection.totals.actual_tokens.toLocaleString("pt-BR")}; economia: {costProjection.totals.saved_tokens === null ? "indisponível" : costProjection.totals.saved_tokens.toLocaleString("pt-BR")}; custo economizado: {costProjection.totals.saved_cost_usd === null ? "indisponível" : `US$ ${costProjection.totals.saved_cost_usd.toFixed(6)}`}</p>
+          <p>Proveniência: {costProjection.breakdown.map((row) => row.provenance).filter((value, index, values) => values.indexOf(value) === index).join(", ") || "indisponível"} · digest <code>{costProjection.metadata.report_digest}</code></p>
         </div>}
       </section>
       <ContextSavings repoPath={repoPath} autoLoad={autoContext} />


### PR DESCRIPTION
## Summary

- add a typed bridge reader for `simplicio.desktop-cost-economy/v1`
- render Runtime-owned periods, actual/saved tokens, saved cost, pricing status, coverage, provenance, and digest
- keep unknown pricing/cost visible as unavailable and avoid renderer-side savings calculations
- scope the public query to the session identifier; project paths remain native/Runtime-owned

## Verification

- `vitest run apps/desktop/src/cost_projection.test.ts` — 4 passed
- TypeScript compiler passed for `cost_projection.ts`

## Delivery

This is the Desktop presentation portion of #289. The public Runtime v3.8.40 does not expose `desktop_cost_projection`, so the UI fails closed and the issue remains open pending the Runtime projection and installed evidence.