### PR TITLE
feat(desktop): consume validated Runtime lifecycle receipts

### DIFF
--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -31,6 +31,7 @@ import {
   type RuntimeInstallReconciliation,
   type RuntimeInstallStatus,
 } from "./runtime_install";
+import { parseRuntimeLifecycleReceipt, type RuntimeLifecycleReceipt } from "./runtime_lifecycle";
 
 const readSnapshot = createReadonlyRequest<DesktopSnapshot>(30_000, "desktop_snapshot_timeout");
 const readContext = createContextReader((repoPath) => invoke<unknown>("desktop_context_report", { repoPath: repoPath || null }));
@@ -170,6 +171,19 @@ export async function loadDesktopRuntimeInstallStatus(): Promise<RuntimeInstallS
     return { schema: "simplicio.desktop-install-status/v1", status: "clear", redacted: true };
   }
   return parseRuntimeInstallStatus(await invoke<unknown>("desktop_runtime_install_status"));
+}
+
+/**
+ * Read an optional full lifecycle receipt. Unsupported native builds fail
+ * closed rather than downgrading an install/rollback claim to a version string.
+ */
+export async function loadDesktopRuntimeLifecycle(): Promise<RuntimeLifecycleReceipt> {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  return parseRuntimeLifecycleReceipt(await withTimeout(
+    invoke<unknown>("desktop_runtime_lifecycle"),
+    30_000,
+    "runtime_lifecycle_timeout",
+  ));
 }
 
 export async function beginDesktopLogin(): Promise<DesktopSnapshot> {


### PR DESCRIPTION
## Summary

- expose the existing redacted Runtime lifecycle receipt parser through the Desktop bridge
- validate version/digest identity, fsync/atomic/durable/healthy flags, plugin non-mutation, and rollback invariants before React consumes the receipt
- keep unsupported native lifecycle commands fail-closed
- retain regression coverage for install, upgrade, repair, rollback, and sensitive diagnostics

## Verification

- `vitest run apps/desktop/src/runtime_lifecycle.test.ts` — 4 passed
- TypeScript compiler passed for `runtime_lifecycle.ts`

## Delivery

This is the Desktop contract portion of #288. The current public Runtime v3.8.40 still exposes only the older install/reconcile commands; native upgrade/repair/rollback command wiring and installed cross-platform evidence remain unresolved, so the issue stays open.