### PR TITLE
fix(release): harden Desktop artifact evidence gate

### DIFF
--- a/scripts/verify_desktop_release_evidence.py
+++ b/scripts/verify_desktop_release_evidence.py
@@ -26,10 +26,23 @@ REASON_CODES = {
     "artifact_not_built",
     "environment_blocked",
 }
+UNSAFE_KEY = re.compile(r"(?:path|cwd|home|argv|secret|password|credential|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|raw[_-]?(?:output|payload))", re.I)
 
 
 def _error(code: str, message: str) -> dict[str, str]:
     return {"code": code, "message": message}
+
+
+def _contains_unsafe_key(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(
+            not isinstance(key, str) or UNSAFE_KEY.search(key) is not None
+            or _contains_unsafe_key(child)
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_unsafe_key(child) for child in value)
+    return False
 
 
 def _safe_path(root: Path, value: Any) -> Path | None:
@@ -58,6 +71,8 @@ def verify_evidence(document: Any, staging_root: Path) -> dict[str, Any]:
     errors: list[dict[str, str]] = []
     if not isinstance(document, dict):
         return {"schema": SCHEMA, "ready": False, "errors": [_error("document_invalid", "evidence must be a JSON object")], "verified_platforms": []}
+    if _contains_unsafe_key(document):
+        return {"schema": SCHEMA, "ready": False, "errors": [_error("sensitive_field", "evidence contains a forbidden sensitive field")], "verified_platforms": []}
     if document.get("schema") != SCHEMA:
         errors.append(_error("schema_invalid", f"schema must be {SCHEMA}"))
     tag = document.get("release_tag")

--- a/tests/test_desktop_release_evidence.py
+++ b/tests/test_desktop_release_evidence.py
@@ -63,3 +63,11 @@ def test_digest_and_path_fail_closed(tmp_path: Path) -> None:
     codes = {item["code"] for item in report["errors"]}
     assert "artifact_digest_mismatch" in codes
     assert "artifact_path_invalid" in codes
+
+
+def test_sensitive_evidence_fields_are_rejected(tmp_path: Path) -> None:
+    document = valid_document(tmp_path)
+    document["platforms"][0]["raw_output"] = "secret"
+    report = verify_evidence(document, tmp_path)
+    assert report["ready"] is False
+    assert report["errors"][0]["code"] == "sensitive_field"


### PR DESCRIPTION
## Summary

- harden the existing manual Desktop release evidence validator used by #282
- reject nested sensitive fields (raw output, credentials, tokens, paths, and similar) before any platform gate is evaluated
- add regression coverage for the redaction fail-closed rule

## Verification

- `python3 -m py_compile scripts/verify_desktop_release_evidence.py tests/test_desktop_release_evidence.py` — passed
- direct full-matrix, served-byte digest, and sensitive-field checks — passed
- pytest-style suite is present but `pytest` is unavailable in this execution image

## Delivery

The validator still blocks the release unless all four native platforms, signatures, SBOM/provenance, clean install, Runtime health, smoke, and re-download checks are positive. This PR does not fabricate platform evidence; #282 remains open until the manual native release is actually produced and verified.