### PR TITLE
fix(release): gate all drained usage and UX issues

### DIFF
--- a/scripts/test_verify_release_gate.py
+++ b/scripts/test_verify_release_gate.py
@@ -50,7 +50,7 @@ def valid_document():
                 "evidence_ids": [f"{issue}:receipt"],
                 "redacted": True,
             }
-            for issue in ("#282", "#283", "#286", "#287", "#288", "#289")
+            for issue in ("#282", "#283", "#286", "#287", "#288", "#289", "#301", "#302", "#303")
         },
     }
 
@@ -92,6 +92,14 @@ def test_zero_usage_requires_proof_and_sensitive_or_preview_data_is_rejected():
             *valid_document()["tracks"][:-1],
             {**valid_document()["tracks"][-1], "path": "/private/evidence"},
         ]})
+
+
+def test_new_usage_and_ux_issues_are_required_dependencies():
+    document = valid_document()
+    del document["dependencies"]["#303"]
+    result = module.verify_gate(document)
+    assert result["status"] == "blocked"
+    assert "dependencies=exact_required_issues" in result["blocking_reasons"]
 
 
 def test_required_issue_set_cannot_be_skipped():

--- a/scripts/verify_release_gate.py
+++ b/scripts/verify_release_gate.py
@@ -11,7 +11,7 @@ from typing import Any, Mapping
 
 SCHEMA = "simplicio.desktop.release-gate/v1"
 REQUIRED_TRACKS = ("install", "oauth", "e2e", "usage", "cost", "privacy", "release")
-REQUIRED_DEPENDENCIES = ("#282", "#283", "#286", "#287", "#288", "#289")
+REQUIRED_DEPENDENCIES = ("#282", "#283", "#286", "#287", "#288", "#289", "#301", "#302", "#303")
 STATUSES = ("verified", "unavailable", "blocked")
 SOURCES = ("installed", "runtime")
 SAFE_ID = re.compile(r"^[A-Za-z0-9#][A-Za-z0-9_.:#-]{0,127}$")


### PR DESCRIPTION
## Summary

- extend the existing release gate dependency set from six prerequisites to all nine drained issues: #282, #283, #286, #287, #288, #289, #301, #302, and #303
- add regression coverage proving a missing #303 dependency blocks readiness
- preserve fail-closed installed-source, redaction, usage, cost, privacy, and zero-proof rules

## Verification

- `python3 -m py_compile scripts/verify_release_gate.py scripts/test_verify_release_gate.py` — passed
- direct ready/blocked checks with all nine dependencies — passed
- pytest-style suite is present; pytest is unavailable in this execution image

## Delivery

The gate still reports blocked until every track and dependency has installed, redacted evidence. No release or issue closure is claimed by this PR; #290 remains open until that evidence is real.