### PR TITLE
feat(hermes): harden request identity and Mapper fallback (#318)

### DIFF
--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -1,55 +1,34 @@
 # Simplicio Hermes Mapper-only adapter
 
-The Hermes plugin uses Simplicio only for authenticated repository mapping and
-provider usage receipts. Mapper preparation is mandatory before a provider
-request; native Hermes tools, terminal, edits, tests, approvals, model
-selection and execution remain owned by Hermes and each project.
+Version 0.4.0 keeps the adapter thin: Hermes owns provider execution and
+Simplicio owns authenticated Mapper context plus redacted usage receipts.
 
-The Python adapter starts its own stdio Runtime with
-`SIMPLICIO_RUNTIME_MODE=mapper-only`. It verifies that initialization and the
-MCP tool catalogue confirm Mapper-only before calling a tool. Global settings,
-project settings, Codex and any shared HTTP Runtime remain unchanged. An older
-Runtime without Mapper-only support is declined; Hermes continues natively.
+## Request identity and receipts
 
-## Mapping and prompt caching
+Hermes 0.20.4+ request, session, turn, logical-request and attempt IDs are
+forwarded byte-for-byte when the host supplies them. Missing values are marked
+`synthetic`; synthetic identities never prove provider-path coverage. Warmup is
+tagged separately and never enters the provider-result candidate set.
 
-`on_session_start` starts a background map warmup. `pre_llm_call` prepares the
-full native Mapper artifacts using Runtime authentication. If the Runtime
-preparation fails, the plugin invokes the bundled Mapper fallback already
-maintained inside the Simplicio-managed `.simplicio` state and converts its
-durable map into the same protected context shape.
-On Hermes versions
-with `register_middleware`, the `llm_request` middleware checks authentication
-and repository generation before every provider request and inserts the entire
-verified map into the provider's existing messages, system or instructions
-shape. This uses Hermes' supported middleware rather than changing its global
-hook output-spill limits.
+Zero candidates, ambiguous candidates, duplicate hooks and duplicate provider
+IDs produce bounded `simplicio.hermes-correlation-receipt/v1` diagnostics rather
+than silent returns. Those receipts contain identifiers and reason codes only;
+prompt, response bodies and secrets are never copied.
 
-The map bytes are stable across session, turn and request IDs. They contain no
-per-request timestamps or local cache-hit flags. The adapter does not silently
-truncate the map or replace it with a receipt handle. Runtime's normal source
-selection limits and ignores still apply. Provider/model/tools, streaming,
-sampling and existing cache settings are preserved.
+## Python fallback contract
 
-Older Hermes versions retain the context-only pre-hook fallback. Their own hook
-output limits may spill large maps; use a Hermes version with request middleware
-for complete provider delivery. The plugin never disables host safeguards to
-work around an older host.
+The Python fallback is resolved only from `SIMPLICIO_MAPPER_BIN`,
+`SIMPLICIO_MAPPER_ROOT`, or an installer-managed Mapper manifest. Before a map
+is used, the adapter executes `version --json` and validates producer, version,
+protocol, schema, capabilities, digest and an explicit minimum/maximum
+compatibility range. An incompatible or unverifiable Mapper fails closed; the
+hook never installs, downloads, or invokes a model.
 
-A stable prefix makes provider prompt caching possible; a local Mapper cache
-hit does not prove an LLM cache hit. `post_api_request` records actual host
-usage/cache counters against the matching API request. Missing counters remain
-unknown. No synthetic model request or paid warmup is performed.
-
-## Login and availability
-
-Mapper requires login. Runtime owns the saved session and subscription-period
-verification; the plugin neither copies credentials nor opens login repeatedly.
-Missing login, confirmed inactive subscription, timeout, offline Runtime,
-unsupported Runtime or an invalid map invokes the bundled Mapper fallback when
-it is available; if both Mapper paths fail, the provider request is blocked. It
-must not silently bypass Mapper. The plugin registers no native
-tool gate, edit wrapper, execution middleware, Loop or Fast integration.
+Fallback receipts use `producer=simplicio-mapper` and `backend=python`, include
+version/digest/resolution source, and never claim native provenance. The map
+cache generation hashes effective project file bytes (excluding `.git` and
+`.simplicio`), so changing content while preserving `git status` invalidates a
+stale map.
 
 ## Install and validate
 
@@ -58,20 +37,7 @@ hermes plugins install wesleysimplicio/simplicio/plugins/simplicio-hermes --forc
 hermes plugins doctor simplicio-hermes --ci
 ```
 
-The fallback is maintained by the Simplicio installation. Hooks do not install
-packages or access the network.
-
-Use a Runtime build that advertises Mapper-only and restart Hermes after the
-plugin update. A source merge alone does not update the installed binary.
-
-The JavaScript embedder adapter in `index.mjs` follows the same Mapper-only
-policy. Its supplied bridge must expose `runtime_mode: "mapper-only"` from a
-verified Runtime handshake and implement the prepare/record methods. A failed
-Mapper preparation raises a typed error and cannot silently send an un-mapped
-provider request.
-Legacy `best_effort` and `enforce` constructor options migrate to Mapper-only;
-they do not retain provider blocking. An explicit `maxContextBytes` budget may
-omit an oversized map, but never truncate it or block native work.
-
-Run `python3 -m pytest tests/test_hermes_native_plugin.py` at the repository root
-and `npm test --prefix plugins/simplicio-hermes` for the two adapters.
+Run `python3 -m pytest tests/test_hermes_native_plugin.py` and
+`npm test --prefix plugins/simplicio-hermes`. A source merge does not update an
+already installed plugin or Runtime. Official Hermes checkout and clean-profile
+tests remain required release evidence when the host checkout is available.

--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+from collections import deque
 import hashlib
 import importlib.util
 import json
@@ -10,6 +11,7 @@ import logging
 import os
 from pathlib import Path
 import queue
+import re
 import shutil
 import subprocess
 import sys
@@ -22,11 +24,16 @@ from typing import Any
 LOGGER = logging.getLogger(__name__)
 _PROTOCOL_VERSION = "2024-11-05"
 _DEFAULT_TIMEOUT_SECONDS = 20.0
-_VERSION = "0.3.1"
+_VERSION = "0.4.0"
 RUNTIME_MODE = "mapper-only"
 _PYTHON_MAPPER_ENV = "SIMPLICIO_MAPPER_BIN"
 _PYTHON_MAPPER_ROOT_ENV = "SIMPLICIO_MAPPER_ROOT"
+_PYTHON_MAPPER_MANIFEST_ENV = "SIMPLICIO_MAPPER_MANIFEST"
 _MAPPER_CACHE = Path(".simplicio") / "hook-context"
+_MAPPER_SCHEMA = "simplicio.mapper-prefix/v1"
+_MAPPER_PROTOCOL = "simplicio.mapper/v1"
+_MAX_CORRELATION_RECEIPTS = 128
+_MAX_TRACKED_RESULTS = 128
 _MAPPER_TOOLS = frozenset({
     "simplicio_map", "simplicio_context", "simplicio_read", "simplicio_file_read",
     "simplicio_search", "simplicio_symbol", "simplicio_prepare_model_call",
@@ -40,6 +47,55 @@ _BRIDGE_TOOLS = frozenset({
 
 class SimplicioHermesError(RuntimeError):
     """Raised when the Runtime preparation path cannot produce a receipt."""
+
+
+class MapperResolution:
+    def __init__(self, command: tuple[str, ...], environment: dict[str, str], version: str,
+                 protocol: str, schema: str, capabilities: tuple[str, ...], digest: str,
+                 compatibility: dict[str, str], resolution_source: str):
+        self.command = command
+        self.environment = environment
+        self.version = version
+        self.protocol = protocol
+        self.schema = schema
+        self.capabilities = capabilities
+        self.digest = digest
+        self.compatibility = compatibility
+        self.resolution_source = resolution_source
+
+
+_SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    match = _SEMVER.match(value)
+    if not match:
+        raise SimplicioHermesError("mapper_version_invalid")
+    return tuple(int(part) for part in match.groups())
+
+
+def _first_string(*values: Any) -> str | None:
+    return next((value for value in values if isinstance(value, str) and value), None)
+
+
+def _minimal_environment(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Keep subprocesses away from tokens, cookies and unrelated host state."""
+    allowed = {
+        "HOME", "USERPROFILE", "PATH", "PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV",
+        "SystemRoot", "WINDIR", "PATHEXT",
+        "TEMP", "TMP", "TMPDIR", "LANG", "LC_ALL",
+    }
+    environment = {key: value for key, value in os.environ.items() if key in allowed}
+    environment["SIMPLICIO_RUNTIME_MODE"] = RUNTIME_MODE
+    if extra:
+        environment.update(extra)
+    return environment
+
+
+def _process_group_options() -> dict[str, Any]:
+    if os.name == "nt":
+        return {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+    return {"start_new_session": True}
 
 
 def _runtime_candidates() -> list[Path]:
@@ -58,56 +114,216 @@ def _find_runtime() -> Path:
     raise SimplicioHermesError("verified Simplicio Runtime binary was not found")
 
 
+def _manifest_candidates(candidate: Path) -> list[Path]:
+    if candidate.is_dir():
+        return [
+            candidate / "simplicio-mapper-manifest.json",
+            candidate / "manifest.json",
+            candidate / ".simplicio-mapper" / "manifest.json",
+        ]
+    return [candidate.with_name("simplicio-mapper-manifest.json"), candidate.with_suffix(".manifest.json")]
+
+
+def _load_mapper_manifest(candidate: Path, *, required: bool) -> dict[str, Any]:
+    configured = os.environ.get(_PYTHON_MAPPER_MANIFEST_ENV)
+    paths = [Path(configured).expanduser()] if configured else _manifest_candidates(candidate)
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    if required:
+        raise SimplicioHermesError("mapper_manifest_missing")
+    return {}
+
+
+def _json_field(payload: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        value = payload.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _compatibility_range(payload: dict[str, Any], manifest: dict[str, Any]) -> dict[str, str]:
+    values: dict[str, Any] = {}
+    for source in (manifest.get("compatibility"), payload.get("compatibility"), manifest, payload):
+        if isinstance(source, dict):
+            for key in ("min_version", "minimum", "max_version", "maximum"):
+                if key not in values and isinstance(source.get(key), str):
+                    values[key] = source[key]
+    if "min_version" not in values or "max_version" not in values:
+        raise SimplicioHermesError("mapper_compatibility_range_missing")
+    minimum = _version_tuple(values["min_version"])
+    maximum = _version_tuple(values["max_version"])
+    if minimum > maximum:
+        raise SimplicioHermesError("mapper_compatibility_range_invalid")
+    return {"min_version": values["min_version"], "max_version": values["max_version"]}
+
+
+def _mapper_digest(command: tuple[str, ...], manifest: dict[str, Any], payload: dict[str, Any]) -> str:
+    digest = _first_string(
+        _json_field(payload, "sha256", "digest", "binary_sha256"),
+        _json_field(manifest, "sha256", "digest", "binary_sha256"),
+    )
+    executable = Path(command[0]) if command and command[0] != sys.executable else None
+    actual = None
+    if executable is not None and executable.is_file():
+        hasher = hashlib.sha256()
+        try:
+            with executable.open("rb") as stream:
+                for block in iter(lambda: stream.read(1024 * 1024), b""):
+                    hasher.update(block)
+            actual = hasher.hexdigest()
+        except OSError as error:
+            raise SimplicioHermesError("mapper_digest_unreadable") from error
+    if not digest or not re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+        raise SimplicioHermesError("mapper_digest_missing")
+    digest = digest.lower()
+    if actual and actual != digest:
+        raise SimplicioHermesError("mapper_digest_mismatch")
+    manifest_digest = _first_string(_json_field(manifest, "sha256", "digest", "binary_sha256"))
+    if manifest_digest and manifest_digest.lower() != digest:
+        raise SimplicioHermesError("mapper_manifest_digest_mismatch")
+    return digest
+
+
+def _resolve_python_mapper() -> MapperResolution:
+    """Resolve and attest a Mapper before any map command is allowed."""
+    configured_binary = os.environ.get(_PYTHON_MAPPER_ENV)
+    configured_root = os.environ.get(_PYTHON_MAPPER_ROOT_ENV)
+    source = ""
+    candidate: Path
+    extra: dict[str, str] = {}
+
+    if configured_binary:
+        candidate = Path(configured_binary).expanduser()
+        if not candidate.is_file():
+            resolved = shutil.which(configured_binary)
+            if resolved:
+                candidate = Path(resolved)
+        if not candidate.is_file() or (os.name != "nt" and not os.access(candidate, os.X_OK)):
+            raise SimplicioHermesError("configured_mapper_invalid")
+        command = (str(candidate.resolve()),)
+        source = "env:SIMPLICIO_MAPPER_BIN"
+        manifest = _load_mapper_manifest(candidate, required=False)
+    elif configured_root:
+        candidate = Path(configured_root).expanduser().resolve()
+        if not (candidate / "simplicio_mapper").is_dir():
+            raise SimplicioHermesError("configured_mapper_root_invalid")
+        command = (sys.executable, "-B", "-m", "simplicio_mapper.cli")
+        source = "env:SIMPLICIO_MAPPER_ROOT"
+        current = os.environ.get("PYTHONPATH", "")
+        extra["PYTHONPATH"] = os.pathsep.join([str(candidate), current]) if current else str(candidate)
+        manifest = _load_mapper_manifest(candidate, required=False)
+    else:
+        managed_root = next((path for path in (
+            Path.home() / ".simplicio" / "mapper",
+            Path.home() / ".simplicio" / "src" / "simplicio-mapper",
+        ) if (path / "simplicio_mapper").is_dir()), None)
+        if managed_root:
+            candidate = managed_root
+            command = (sys.executable, "-B", "-m", "simplicio_mapper.cli")
+            source = "installer-managed-manifest"
+            current = os.environ.get("PYTHONPATH", "")
+            extra["PYTHONPATH"] = os.pathsep.join([str(candidate), current]) if current else str(candidate)
+            manifest = _load_mapper_manifest(candidate, required=True)
+        else:
+            executable = shutil.which("simplicio-mapper")
+            if executable:
+                candidate = Path(executable).resolve()
+                command = (str(candidate),)
+                source = "installer-managed-path"
+                manifest = _load_mapper_manifest(candidate, required=True)
+            else:
+                raise SimplicioHermesError("mapper_resolution_missing")
+
+    environment = _minimal_environment(extra)
+    try:
+        result = subprocess.run(
+            [*command, "version", "--json"], cwd=str(candidate if candidate.is_dir() else candidate.parent),
+            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8", timeout=_DEFAULT_TIMEOUT_SECONDS, check=False,
+            env=environment, **_process_group_options(),
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SimplicioHermesError("mapper_version_timeout") from error
+    if result.returncode != 0:
+        raise SimplicioHermesError("mapper_version_failed")
+    try:
+        payload = json.loads(result.stdout)
+    except (ValueError, TypeError) as error:
+        raise SimplicioHermesError("mapper_version_not_json") from error
+    if not isinstance(payload, dict):
+        raise SimplicioHermesError("mapper_version_invalid")
+    nested = payload.get("mapper")
+    if isinstance(nested, dict):
+        payload = {**payload, **nested}
+    version = _first_string(_json_field(payload, "version", "mapper_version"))
+    protocol = _first_string(_json_field(payload, "protocol", "protocol_version"))
+    schema = _first_string(_json_field(payload, "schema", "schema_version", "schema_range"))
+    producer = _first_string(_json_field(payload, "producer", "name"))
+    if not version or not protocol or not schema or producer != "simplicio-mapper":
+        raise SimplicioHermesError("mapper_version_contract_invalid")
+    version_value = _version_tuple(version)
+    compatibility = _compatibility_range(payload, manifest)
+    if not (_version_tuple(compatibility["min_version"]) <= version_value <= _version_tuple(compatibility["max_version"])):
+        raise SimplicioHermesError("mapper_version_out_of_range")
+    if protocol != _MAPPER_PROTOCOL or schema != _MAPPER_SCHEMA:
+        raise SimplicioHermesError("mapper_protocol_or_schema_incompatible")
+    raw_capabilities = _json_field(payload, "capabilities")
+    if isinstance(raw_capabilities, dict):
+        capabilities = tuple(sorted(key for key, value in raw_capabilities.items() if value is True))
+    elif isinstance(raw_capabilities, list):
+        capabilities = tuple(sorted(value for value in raw_capabilities if isinstance(value, str)))
+    else:
+        raise SimplicioHermesError("mapper_capabilities_missing")
+    if "map" not in capabilities:
+        raise SimplicioHermesError("mapper_map_capability_missing")
+    digest = _mapper_digest(command, manifest, payload)
+    return MapperResolution(
+        command=command, environment=environment, version=version, protocol=protocol,
+        schema=schema, capabilities=capabilities, digest=digest,
+        compatibility=compatibility, resolution_source=source,
+    )
+
+
 def _find_python_mapper() -> tuple[list[str], dict[str, str]]:
-    """Resolve the already-maintained bundled Mapper fallback."""
-    configured = os.environ.get(_PYTHON_MAPPER_ENV)
-    if configured:
-        configured_path = Path(configured).expanduser()
-        if configured_path.is_file() and (os.name == "nt" or os.access(configured_path, os.X_OK)):
-            return [str(configured_path)], os.environ.copy()
-        resolved = shutil.which(configured)
-        if resolved:
-            return [resolved], os.environ.copy()
-
-    source_root = os.environ.get(_PYTHON_MAPPER_ROOT_ENV)
-    candidates = [Path(source_root).expanduser()] if source_root else []
-    candidates.extend((Path.home() / ".simplicio" / "mapper", Path.home() / ".simplicio" / "src" / "simplicio-mapper"))
-    for candidate in candidates:
-        if (candidate / "simplicio_mapper").is_dir():
-            environment = os.environ.copy()
-            current = environment.get("PYTHONPATH", "")
-            environment["PYTHONPATH"] = os.pathsep.join([str(candidate), current]) if current else str(candidate)
-            return [sys.executable, "-B", "-m", "simplicio_mapper.cli"], environment
-
-    executable = shutil.which("simplicio-mapper")
-    if executable:
-        return [executable], os.environ.copy()
-    if importlib.util.find_spec("simplicio_mapper") is not None:
-        return [sys.executable, "-B", "-m", "simplicio_mapper.cli"], os.environ.copy()
-    raise SimplicioHermesError("Bundled Mapper fallback was not found")
+    resolution = _resolve_python_mapper()
+    return list(resolution.command), dict(resolution.environment)
 
 
 def _project_generation(root: Path) -> str:
+    """Hash effective project bytes so equal git status cannot hide edits."""
+    root = root.expanduser().resolve()
+    if not root.is_dir():
+        raise SimplicioHermesError("project_root_invalid")
+    digest = hashlib.sha256()
     try:
-        head = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"], capture_output=True, text=True,
-                              timeout=2, check=False)
-        status = subprocess.run(["git", "-C", str(root), "status", "--porcelain=v1", "--untracked-files=normal"],
-                                capture_output=True, text=True, timeout=2, check=False)
-        if head.returncode == 0 and status.returncode == 0:
-            changed = []
-            for line in status.stdout.splitlines():
-                if len(line) < 4:
+        for directory, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+            directory_path = Path(directory)
+            dirnames[:] = sorted(
+                name for name in dirnames
+                if name not in {".git", ".simplicio"} and not (directory_path / name).is_symlink()
+            )
+            for name in sorted(filenames):
+                path = directory_path / name
+                if path.is_symlink() or not path.is_file():
                     continue
-                path = line[3:].strip().strip('"')
-                if path == ".simplicio" or path.startswith(".simplicio/"):
-                    continue
-                changed.append(line)
-            changed.sort()
-            material = json.dumps({"head": head.stdout.strip(), "changed": changed}, sort_keys=True)
-            return hashlib.sha256(material.encode()).hexdigest()
-    except (OSError, subprocess.SubprocessError):
-        pass
-    return hashlib.sha256(f"fallback:{root}:{root.stat().st_mtime_ns}".encode()).hexdigest()
+                resolved = path.resolve(strict=True)
+                if root not in resolved.parents:
+                    raise SimplicioHermesError("project_symlink_escapes_root")
+                relative = path.relative_to(root).as_posix().encode("utf-8")
+                digest.update(len(relative).to_bytes(8, "big"))
+                digest.update(relative)
+                with path.open("rb") as stream:
+                    for block in iter(lambda: stream.read(1024 * 1024), b""):
+                        digest.update(block)
+    except OSError as error:
+        raise SimplicioHermesError("project_generation_unavailable") from error
+    return digest.hexdigest()
 
 
 def _write_atomic(path: Path, content: str) -> None:
@@ -117,11 +333,12 @@ def _write_atomic(path: Path, content: str) -> None:
 
 
 def _python_mapper_receipt(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Run/reuse Python Mapper output while preserving the native receipt shape."""
+    """Run/reuse an attested Python Mapper without installing from a hook."""
     root = Path(arguments["repo"]).expanduser().resolve()
     cache = root / _MAPPER_CACHE
     cache.mkdir(parents=True, exist_ok=True)
     generation = _project_generation(root)
+    resolution = _resolve_python_mapper()
     map_path = cache / "map.md"
     receipt_path = cache / "warm-receipt.json"
     try:
@@ -131,20 +348,25 @@ def _python_mapper_receipt(arguments: dict[str, Any]) -> dict[str, Any]:
         if (cached.get("schema") == "simplicio.hook-map-receipt/v1" and cached.get("status") == "ready"
                 and cached.get("generation") == generation and cached.get("mode") == RUNTIME_MODE
                 and cached.get("producer") == "simplicio-mapper" and cached.get("map_sha256") == digest
-                and cached.get("map_bytes") == len(data) and data):
-            return _python_receipt(arguments, data)
+                and cached.get("map_bytes") == len(data) and data
+                and cached.get("mapper_version") == resolution.version
+                and cached.get("mapper_digest") == resolution.digest
+                and cached.get("resolution_source") == resolution.resolution_source):
+            return _python_receipt(arguments, data, resolution)
     except (OSError, ValueError, TypeError):
         pass
 
-    command, environment = _find_python_mapper()
-    environment["SIMPLICIO_RUNTIME_MODE"] = RUNTIME_MODE
-    result = subprocess.run(
-        [*command, "map", "--root", str(root), "--out", ".simplicio", "--docs"],
-        cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, timeout=_DEFAULT_TIMEOUT_SECONDS, check=False, env=environment,
-    )
+    try:
+        result = subprocess.run(
+            [*resolution.command, "map", "--root", str(root), "--out", ".simplicio", "--docs"],
+            cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=_DEFAULT_TIMEOUT_SECONDS, check=False,
+            env=resolution.environment, **_process_group_options(),
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SimplicioHermesError("mapper_map_timeout") from error
     if result.returncode != 0:
-        raise SimplicioHermesError("Bundled Mapper fallback failed to map the project")
+        raise SimplicioHermesError("mapper_map_failed")
     docs = root / ".simplicio" / "docs" / "architecture.md"
     if docs.is_file() and docs.stat().st_size:
         content = "# Simplicio Mapper fallback\n\n" + docs.read_text(encoding="utf-8")
@@ -163,11 +385,15 @@ def _python_mapper_receipt(arguments: dict[str, Any]) -> dict[str, Any]:
         "schema": "simplicio.hook-map-receipt/v1", "status": "ready", "generation": generation,
         "map_sha256": digest, "map_bytes": len(data), "completed_at_unix": int(time.time()),
         "producer": "simplicio-mapper", "mode": RUNTIME_MODE, "mapper_backend": "python",
+        "mapper_version": resolution.version, "mapper_protocol": resolution.protocol,
+        "mapper_schema": resolution.schema, "mapper_capabilities": list(resolution.capabilities),
+        "mapper_digest": resolution.digest, "resolution_source": resolution.resolution_source,
+        "compatibility": resolution.compatibility,
     }, sort_keys=True, separators=(",", ":")))
-    return _python_receipt(arguments, data)
+    return _python_receipt(arguments, data, resolution)
 
 
-def _python_receipt(arguments: dict[str, Any], data: bytes) -> dict[str, Any]:
+def _python_receipt(arguments: dict[str, Any], data: bytes, resolution: MapperResolution) -> dict[str, Any]:
     content = json.dumps({
         "schema": "simplicio.mapper-prefix/v1",
         "mapper_backend": "python",
@@ -179,8 +405,14 @@ def _python_receipt(arguments: dict[str, Any], data: bytes) -> dict[str, Any]:
         "api_request_id": arguments["api_request_id"],
         "host_session_id": arguments["host_session_id"],
         "provider_cache_status": "unknown", "mapper_backend": "python",
+        "producer": "simplicio-mapper", "mapper_version": resolution.version,
+        "mapper_protocol": resolution.protocol, "mapper_schema": resolution.schema,
+        "mapper_capabilities": list(resolution.capabilities), "mapper_digest": resolution.digest,
+        "resolution_source": resolution.resolution_source, "compatibility": resolution.compatibility,
         "context_packet": {
-            "schema": "simplicio.context-packet/v1", "producer": "simplicio-native-mapper",
+            "schema": "simplicio.context-packet/v1", "producer": "simplicio-mapper",
+            "mapper_backend": "python", "mapper_version": resolution.version,
+            "mapper_digest": resolution.digest, "resolution_source": resolution.resolution_source,
             "complete_map_artifacts": True, "content": content, "bytes": len(raw),
             "content_sha256": hashlib.sha256(raw).hexdigest(),
         },
@@ -257,12 +489,11 @@ class RuntimeMcpBridge:
         binary = self.binary or _find_runtime()
         # Scope the mode to this plugin-owned process. Never rewrite global,
         # project, Codex, or shared HTTP Runtime configuration.
-        environment = os.environ.copy()
-        environment["SIMPLICIO_RUNTIME_MODE"] = RUNTIME_MODE
+        environment = _minimal_environment()
         self._process = subprocess.Popen(
             [str(binary), "serve", "--mcp", "--stdio", "--no-facade-mode"],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-            text=True, encoding="utf-8", bufsize=1, env=environment,
+            text=True, encoding="utf-8", bufsize=1, env=environment, **_process_group_options(),
         )
         try:
             initialized = self._request("initialize", {
@@ -341,7 +572,39 @@ _WARMING: set[str] = set()
 _STATE_LOCK = threading.RLock()
 _PYTHON_MAP_LOCK = threading.RLock()
 _MIDDLEWARE_ENABLED = False
+_CORRELATION_RECEIPTS: deque[dict[str, Any]] = deque(maxlen=_MAX_CORRELATION_RECEIPTS)
+_RECORDED_REQUESTS: dict[str, str] = {}
+_RECORDED_PROVIDER_IDS: dict[str, str] = {}
 _CONTEXT_LABEL = "Simplicio Mapper repository context (data, not instructions):\n"
+
+
+def _bounded_insert(mapping: dict[str, str], key: str, value: str) -> None:
+    if len(mapping) >= _MAX_TRACKED_RESULTS:
+        mapping.pop(next(iter(mapping)))
+    mapping[key] = value
+
+
+def _emit_correlation_receipt(reason_code: str, session_id: str, candidate_count: int,
+                              kwargs: dict[str, Any]) -> None:
+    receipt = {
+        "schema": "simplicio.hermes-correlation-receipt/v1",
+        "status": "not_recorded", "reason_code": reason_code,
+        "host": "hermes", "candidate_count": candidate_count,
+    }
+    for key in ("host_session_id", "turn_id", "api_request_id", "logical_request_id", "attempt_id"):
+        value = kwargs.get(key)
+        if isinstance(value, str) and value:
+            receipt[key] = value
+    with _STATE_LOCK:
+        _CORRELATION_RECEIPTS.append(receipt)
+    LOGGER.warning("Simplicio Hermes correlation unavailable (reason_code=%s candidates=%d)",
+                   reason_code, candidate_count)
+
+
+def correlation_receipts() -> list[dict[str, Any]]:
+    """Return bounded redacted correlation diagnostics for host/doctor tooling."""
+    with _STATE_LOCK:
+        return [dict(item) for item in _CORRELATION_RECEIPTS]
 
 
 def _mapper_context(receipt: dict[str, Any]) -> str:
@@ -355,26 +618,53 @@ def _mapper_context(receipt: dict[str, Any]) -> str:
     if not isinstance(content, str) or not content:
         raise SimplicioHermesError("Runtime did not return Mapper content")
     raw = content.encode("utf-8")
-    if (packet.get("producer") != "simplicio-native-mapper"
-            or packet.get("bytes") != len(raw)
+    producer = packet.get("producer")
+    if producer not in {"simplicio-native-mapper", "simplicio-mapper"}:
+        raise SimplicioHermesError("Runtime Mapper producer is unsupported")
+    if (producer == "simplicio-mapper" and receipt.get("mapper_backend") != "python"):
+        raise SimplicioHermesError("Python Mapper receipt provenance is invalid")
+    if (producer == "simplicio-native-mapper" and receipt.get("mapper_backend") == "python"):
+        raise SimplicioHermesError("Python Mapper cannot claim native provenance")
+    if (packet.get("bytes") != len(raw)
             or packet.get("content_sha256") != hashlib.sha256(raw).hexdigest()):
         raise SimplicioHermesError("Runtime Mapper context integrity check failed")
     parsed = json.loads(content)
-    if not isinstance(parsed, dict) or parsed.get("schema") != "simplicio.mapper-prefix/v1":
+    if not isinstance(parsed, dict) or parsed.get("schema") != _MAPPER_SCHEMA:
         raise SimplicioHermesError("Runtime Mapper context schema is unsupported")
     return _CONTEXT_LABEL + content
 
 
 def _arguments(session_id: str = "", user_message: str = "", model: str = "",
                **kwargs: Any) -> dict[str, Any]:
+    provided = {
+        "host_session_id": _first_string(session_id, kwargs.get("host_session_id")),
+        "turn_id": _identity_value(kwargs, "turn_id", "hermes_turn_id"),
+        "api_request_id": _identity_value(kwargs, "api_request_id", "request_id", "hermes_request_id"),
+        "logical_request_id": _identity_value(kwargs, "logical_request_id", "hermes_logical_request_id", "request_id"),
+        "attempt_id": _identity_value(kwargs, "attempt_id", "hermes_attempt_id"),
+    }
+    synthetic_ids = [key for key in ("host_session_id", "turn_id", "api_request_id", "logical_request_id", "attempt_id")
+                     if not provided[key]]
+    for key in synthetic_ids:
+        provided[key] = str(uuid.uuid4())
+    provider = kwargs.get("provider")
+    if not isinstance(provider, str) or not provider:
+        provider = "unknown"
+    model_value = model if isinstance(model, str) and model else kwargs.get("model")
+    if not isinstance(model_value, str) or not model_value:
+        model_value = "unknown"
+    capabilities = _safe_capabilities(
+        kwargs.get("hermes_capabilities", kwargs.get("capabilities"))
+    )
     return {
         "repo": str(kwargs.get("cwd") or kwargs.get("repo") or os.getenv("TERMINAL_CWD") or os.getcwd()),
         "host": "hermes",
-        "host_session_id": str(session_id or kwargs.get("host_session_id") or uuid.uuid4()),
-        "turn_id": str(kwargs.get("turn_id") or uuid.uuid4()),
-        "api_request_id": str(kwargs.get("api_request_id") or uuid.uuid4()),
-        "provider": str(kwargs.get("provider") or "unknown"),
-        "model": str(model or "unknown"),
+        "host_session_id": provided["host_session_id"], "turn_id": provided["turn_id"],
+        "api_request_id": provided["api_request_id"], "logical_request_id": provided["logical_request_id"],
+        "attempt_id": provided["attempt_id"], "synthetic": bool(synthetic_ids),
+        "synthetic_ids": synthetic_ids, "provider": provider, "model": model_value,
+        "hermes_capabilities": capabilities,
+        "lifecycle": kwargs.get("lifecycle", "provider_request"),
         # Task text is unnecessary for a full-project map and must not enter
         # cache identity or per-request evidence.
         "protection_mode": "best_effort",
@@ -413,6 +703,24 @@ def _warn(stage: str, error: Exception) -> None:
     # Auth/MCP exception strings can contain upstream response bodies.
     LOGGER.warning("Simplicio Mapper %s unavailable (%s); provider request is blocked",
                    stage, type(error).__name__)
+
+
+def _safe_capabilities(value: Any) -> dict[str, Any] | list[str] | None:
+    """Keep only small capability metadata from the installed Hermes host."""
+    if isinstance(value, dict):
+        safe: dict[str, Any] = {}
+        for key, item in value.items():
+            if (isinstance(key, str) and len(key) <= 80
+                    and isinstance(item, (bool, int, float, str))):
+                safe[key] = item
+        return safe
+    if isinstance(value, (list, tuple, set)):
+        return sorted(item for item in value if isinstance(item, str) and len(item) <= 80)
+    return None
+
+
+def _identity_value(kwargs: dict[str, Any], *names: str) -> str | None:
+    return _first_string(*(kwargs.get(name) for name in names))
 
 
 def _pre_llm_call(session_id: str = "", user_message: str = "", model: str = "",
@@ -461,7 +769,12 @@ def _inject_context(request: dict[str, Any], content: str) -> dict[str, Any]:
 
 def _llm_request(request: dict[str, Any], session_id: str = "", model: str = "",
                  **kwargs: Any) -> dict[str, Any] | None:
-    arguments = _arguments(session_id, model=model or request.get("model", ""), **kwargs)
+    request_metadata = dict(kwargs)
+    for key in ("turn_id", "api_request_id", "request_id", "logical_request_id", "attempt_id",
+                "provider", "hermes_capabilities", "capabilities"):
+        if key not in request_metadata and key in request:
+            request_metadata[key] = request[key]
+    arguments = _arguments(session_id, model=model or request.get("model", ""), **request_metadata)
     with _STATE_LOCK:
         _PREPARED.pop(arguments["api_request_id"], None)
     try:
@@ -523,35 +836,63 @@ def _token_usage(event: dict[str, Any]) -> dict[str, int]:
     return result
 
 def _record(session_id: str = "", status: str = "completed", **kwargs: Any) -> None:
-    with _STATE_LOCK:
-        candidates = [
-            key for key, item in _PREPARED.items()
-            if item["arguments"]["host_session_id"] == session_id
-            and (not kwargs.get("api_request_id") or key == kwargs["api_request_id"])
-            and (not kwargs.get("turn_id") or item["arguments"]["turn_id"] == kwargs["turn_id"])
-        ]
-        if len(candidates) != 1:
-            return  # Never attribute ambiguous concurrent requests to each other.
-        prepared = _PREPARED.pop(candidates[0])
-    original = prepared["arguments"]
-    arguments = {
-        key: original[key] for key in (
-            "repo", "host", "host_session_id", "turn_id", "api_request_id", "provider", "model",
-        )
-    }
-    arguments.update(status=status, prepared_receipt=prepared["receipt"])
-    arguments.update(_token_usage(kwargs))
+    observed_session = _first_string(session_id, kwargs.get("host_session_id")) or ""
+    requested_api_id = _first_string(kwargs.get("api_request_id"), kwargs.get("request_id"))
+    requested_turn_id = _first_string(kwargs.get("turn_id"), kwargs.get("hermes_turn_id"))
     response = kwargs.get("response")
     if not isinstance(response, dict):
         response = {}
     body = response.get("body")
     if not isinstance(body, dict):
         body = {}
-    provider_id = kwargs.get("provider_request_id") or response.get("id") or body.get("id")
-    if isinstance(provider_id, str) and provider_id:
+    provider_id = _first_string(
+        kwargs.get("provider_request_id"), response.get("id"), body.get("id"),
+    )
+    with _STATE_LOCK:
+        candidates = [
+            key for key, item in _PREPARED.items()
+            if item["arguments"]["host_session_id"] == observed_session
+            and (not requested_api_id or key == requested_api_id)
+            and (not requested_turn_id or item["arguments"]["turn_id"] == requested_turn_id)
+        ]
+        if len(candidates) == 0:
+            reason = "duplicate_result" if requested_api_id in _RECORDED_REQUESTS else "correlation_missing"
+            _emit_correlation_receipt(reason, observed_session, 0, kwargs)
+            return
+        if len(candidates) > 1:
+            _emit_correlation_receipt("correlation_ambiguous", observed_session, len(candidates), kwargs)
+            return
+        candidate_key = candidates[0]
+        if provider_id and provider_id in _RECORDED_PROVIDER_IDS:
+            _PREPARED.pop(candidate_key, None)
+            _emit_correlation_receipt("duplicate_result", observed_session, 1, kwargs)
+            return
+        prepared = _PREPARED.pop(candidate_key)
+        _bounded_insert(_RECORDED_REQUESTS, candidate_key, observed_session)
+        if provider_id:
+            _bounded_insert(_RECORDED_PROVIDER_IDS, provider_id, candidate_key)
+    original = prepared["arguments"]
+    arguments = {
+        key: original[key] for key in (
+            "repo", "host", "host_session_id", "turn_id", "api_request_id", "logical_request_id",
+            "attempt_id", "provider", "model", "synthetic", "synthetic_ids", "hermes_capabilities",
+        )
+    }
+    arguments.update(
+        status=status, prepared_receipt=prepared["receipt"],
+        coverage_proven=not original["synthetic"],
+        coverage={
+            "provider_path_active": not original["synthetic"],
+            "identity": "real" if not original["synthetic"] else "synthetic",
+        },
+    )
+    arguments.update(_token_usage(kwargs))
+    if provider_id:
         arguments["provider_request_id"] = provider_id
     try:
         _BRIDGE.call("simplicio_record_model_result", arguments)
+        with _STATE_LOCK:
+            _RECORDED_REQUESTS[candidate_key] = observed_session
     except Exception as error:
         _warn("result recording", error)
 
@@ -571,8 +912,11 @@ def _api_request_error(session_id: str = "", **kwargs: Any) -> None:
 
 
 def _on_session_start(session_id: str = "", **kwargs: Any) -> None:
-    arguments = _arguments(session_id, **kwargs)
-    key = arguments["repo"]
+    warmup_kwargs = dict(kwargs)
+    warmup_kwargs["lifecycle"] = "warmup"
+    arguments = _arguments(session_id, **warmup_kwargs)
+    arguments["warmup"] = True
+    key = f"{arguments['repo']}\x00{arguments['host_session_id']}"
     with _STATE_LOCK:
         if key in _WARMING:
             return
@@ -591,9 +935,14 @@ def _on_session_start(session_id: str = "", **kwargs: Any) -> None:
 
 def _on_session_end(session_id: str = "", **_kwargs: Any) -> None:
     with _STATE_LOCK:
+        for key in [key for key in _WARMING if key.endswith(f"\x00{session_id}")]:
+            _WARMING.discard(key)
         for key in [key for key, item in _PREPARED.items()
                     if item["arguments"]["host_session_id"] == session_id]:
             _PREPARED.pop(key, None)
+        for key in [key for key, item in _RECORDED_REQUESTS.items()
+                    if item == session_id]:
+            _RECORDED_REQUESTS.pop(key, None)
 
 
 def register(ctx: Any) -> None:
@@ -613,4 +962,5 @@ def register(ctx: Any) -> None:
 atexit.register(_BRIDGE.close)
 
 
-__all__ = ["RUNTIME_MODE", "RuntimeMcpBridge", "SimplicioHermesError", "register"]
+__all__ = ["RUNTIME_MODE", "VERSION", "MapperResolution", "RuntimeMcpBridge",
+           "SimplicioHermesError", "correlation_receipts", "register"]

--- a/plugins/simplicio-hermes/index.mjs
+++ b/plugins/simplicio-hermes/index.mjs
@@ -5,6 +5,8 @@ const HOOK_NAMES = [
 ];
 export const HERMES_HOOKS = Object.freeze([...HOOK_NAMES]);
 export const RUNTIME_MODE = "mapper-only";
+export const VERSION = "0.4.0";
+const MAX_CORRELATION_RECEIPTS = 128;
 
 export class HermesProtectionError extends Error {
   constructor(reasonCode) {
@@ -18,11 +20,41 @@ function firstValue(...values) {
   return values.find((value) => typeof value === "string" && value.length > 0);
 }
 
+function safeCapabilities(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return Object.fromEntries(Object.entries(value).filter(([key, item]) =>
+      typeof key === "string" && key.length <= 80 &&
+      ["boolean", "number", "string"].includes(typeof item)));
+  }
+  if (Array.isArray(value)) return value.filter((item) => typeof item === "string" && item.length <= 80);
+  return undefined;
+}
+
+function requestIdentity(request, session) {
+  const values = {
+    host_session_id: firstValue(request.session_id, request.sessionId, session.session_id),
+    turn_id: firstValue(request.turn_id, request.turnId, session.turn_id),
+    api_request_id: firstValue(request.api_request_id, request.request_id),
+    logical_request_id: firstValue(request.logical_request_id, request.hermes_request_id, request.request_id),
+    attempt_id: firstValue(request.attempt_id, request.hermes_attempt_id),
+  };
+  const synthetic_ids = Object.keys(values).filter((key) => !values[key]);
+  for (const key of synthetic_ids) values[key] = randomUUID();
+  return {
+    ...values, synthetic: synthetic_ids.length > 0, synthetic_ids,
+    provider: request.provider ?? "unknown", model: request.model ?? "unknown",
+    hermes_capabilities: safeCapabilities(request.hermes_capabilities ?? request.capabilities),
+  };
+}
+
 function mapperContext(prepared, maxBytes) {
   const packet = prepared?.context_packet ?? prepared?.contextPacket;
   const content = packet?.content;
   if (prepared?.status !== "prepared" || prepared?.protected !== true ||
-      packet?.complete_map_artifacts !== true || packet?.producer !== "simplicio-native-mapper" ||
+      packet?.complete_map_artifacts !== true ||
+      !["simplicio-native-mapper", "simplicio-mapper"].includes(packet?.producer) ||
+      (packet?.producer === "simplicio-mapper" && prepared?.mapper_backend !== "python") ||
+      (packet?.producer === "simplicio-native-mapper" && prepared?.mapper_backend === "python") ||
       typeof content !== "string" || content.length === 0) {
     throw new HermesProtectionError("authenticated_mapper_context_required");
   }
@@ -115,10 +147,32 @@ export function createHermesPlugin({ runtime, mode = RUNTIME_MODE, maxContextByt
   const runtimeBridge = runtime ?? {};
   const session = {};
   const pending = new Map();
+  const recorded = new Map();
+  const recordedProviders = new Map();
+  const correlation = [];
   const state = {
     context_path_active: false, provider_path_active: false, usage_collector_active: false,
     provider_cache_status: "unknown", last_reason_code: "session_not_started",
+    hermes_capabilities: undefined,
   };
+
+  function correlationReceipt(reasonCode, event = {}, candidateCount = 0) {
+    const receipt = {
+      schema: "simplicio.hermes-correlation-receipt/v1", status: "not_recorded",
+      reason_code: reasonCode, host: "hermes", candidate_count: candidateCount,
+    };
+    for (const key of ["session_id", "turn_id", "api_request_id", "logical_request_id", "attempt_id"]) {
+      if (typeof event[key] === "string" && event[key]) receipt[key] = event[key];
+    }
+    correlation.push(receipt);
+    if (correlation.length > MAX_CORRELATION_RECEIPTS) correlation.shift();
+    state.last_reason_code = reasonCode;
+    return receipt;
+  }
+
+  function correlationReceipts() {
+    return correlation.map((item) => ({ ...item }));
+  }
 
   function status() {
     return {
@@ -144,35 +198,34 @@ export function createHermesPlugin({ runtime, mode = RUNTIME_MODE, maxContextByt
     if (typeof runtimeBridge.prepare_model_call !== "function") {
       throw new HermesProtectionError("runtime_prepare_unavailable");
     }
-    const identity = {
-      host: "hermes",
-      host_session_id: firstValue(request.session_id, session.session_id) ?? randomUUID(),
-      turn_id: firstValue(request.turn_id, session.turn_id) ?? randomUUID(),
-      api_request_id: firstValue(request.api_request_id, request.request_id) ?? randomUUID(),
-      provider: request.provider ?? "unknown", model: request.model ?? "unknown",
-    };
-    pending.delete(identity.api_request_id);
+    const request_identity = { host: "hermes", ...requestIdentity(request, session) };
+    state.hermes_capabilities = request_identity.hermes_capabilities;
+    pending.delete(request_identity.api_request_id);
     try {
       const prepared = await runtimeBridge.prepare_model_call({
-        ...identity, repo: request.repo ?? request.cwd ?? process.cwd(), protection_mode: "best_effort",
+        ...request_identity, repo: request.repo ?? request.cwd ?? process.cwd(), lifecycle: "provider_request",
+        protection_mode: "best_effort",
       });
       const content = mapperContext(prepared, maxContextBytes);
       const updated = injectContext(request, content);
       const packet = prepared.context_packet ?? prepared.contextPacket;
       const { content: omitted, ...packetMetadata } = packet;
       if (pending.size >= 128) pending.delete(pending.keys().next().value);
-      pending.set(identity.api_request_id, {
-        identity, repo: request.repo ?? request.cwd ?? process.cwd(),
+      pending.set(request_identity.api_request_id, {
+        identity: request_identity, repo: request.repo ?? request.cwd ?? process.cwd(),
         receipt: { ...prepared, context_packet: { ...packetMetadata, content_omitted_from_receipt: true } },
       });
       // Avoid a camelCase duplicate carrying source context into result receipts.
-      delete pending.get(identity.api_request_id).receipt.contextPacket;
-      state.context_path_active = state.provider_path_active = true;
+      delete pending.get(request_identity.api_request_id).receipt.contextPacket;
+      state.context_path_active = true;
+      state.provider_path_active = !request_identity.synthetic;
       state.last_reason_code = "context_prepared";
       return { ...updated, simplicio: {
         protected: true, mode: RUNTIME_MODE, reason_code: "context_prepared",
-        session_id: identity.host_session_id, turn_id: identity.turn_id,
-        api_request_id: identity.api_request_id, provider_cache_status: "unknown",
+        session_id: request_identity.host_session_id, turn_id: request_identity.turn_id,
+        api_request_id: request_identity.api_request_id, logical_request_id: request_identity.logical_request_id,
+        attempt_id: request_identity.attempt_id, synthetic: request_identity.synthetic,
+        synthetic_ids: request_identity.synthetic_ids, provider_cache_status: "unknown",
       } };
     } catch (error) {
       if (error instanceof HermesProtectionError) throw error;
@@ -184,19 +237,40 @@ export function createHermesPlugin({ runtime, mode = RUNTIME_MODE, maxContextByt
     const id = firstValue(event.api_request_id, event.request_id, event.simplicio?.api_request_id);
     const prepared = pending.get(id);
     if (!prepared || (event.session_id && event.session_id !== prepared.identity.host_session_id)) {
-      return failed(event, "request_not_prepared");
+      const reasonCode = recorded.has(id) ? "duplicate_result" : "correlation_missing";
+      correlationReceipt(reasonCode, event);
+      return failed(event, reasonCode);
     }
-    pending.delete(id);
     if (typeof runtimeBridge.record_model_result !== "function") {
+      pending.delete(id);
       return failed(event, "runtime_record_unavailable");
     }
     const providerId = firstValue(event.provider_request_id, event.response?.id, event.response?.body?.id, event.result?.id);
+    if (providerId && recordedProviders.has(providerId)) {
+      pending.delete(id);
+      correlationReceipt("duplicate_result", event, 1);
+      return failed(event, "duplicate_result");
+    }
+    pending.delete(id);
     try {
       const receipt = await runtimeBridge.record_model_result({
         ...prepared.identity, repo: prepared.repo, prepared_receipt: prepared.receipt,
         status: event.error ? "error" : "completed", ...tokenUsage(event),
+        coverage_proven: !prepared.identity.synthetic,
+        coverage: {
+          provider_path_active: !prepared.identity.synthetic,
+          identity: prepared.identity.synthetic ? "synthetic" : "real",
+        },
         ...(providerId ? { provider_request_id: providerId } : {}),
       });
+      if (recorded.size >= MAX_CORRELATION_RECEIPTS) recorded.delete(recorded.keys().next().value);
+      recorded.set(id, prepared.identity.host_session_id);
+      if (providerId) {
+        if (recordedProviders.size >= MAX_CORRELATION_RECEIPTS) {
+          recordedProviders.delete(recordedProviders.keys().next().value);
+        }
+        recordedProviders.set(providerId, prepared.identity.host_session_id);
+      }
       state.usage_collector_active = true;
       state.provider_cache_status = receipt?.savings?.provider_cache_status ?? "unknown";
       state.last_reason_code = "receipt_recorded";
@@ -221,8 +295,8 @@ export function createHermesPlugin({ runtime, mode = RUNTIME_MODE, maxContextByt
   };
 
   return Object.freeze({
-    name: "simplicio-hermes", version: "0.3.1", mode: RUNTIME_MODE,
-    hooks, status, prepare_model_call, record_model_result,
+    name: "simplicio-hermes", version: VERSION, mode: RUNTIME_MODE,
+    hooks, status, prepare_model_call, record_model_result, correlationReceipts,
   });
 }
 

--- a/plugins/simplicio-hermes/manifest.json
+++ b/plugins/simplicio-hermes/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "host": "hermes",
   "entry": "./index.mjs",
   "hooks": [
@@ -17,7 +17,15 @@
     "prepare": "prepare_model_call",
     "record": "record_model_result",
     "mode": "mapper-only",
-    "login_required": true
+    "login_required": true,
+    "mapper_fallback": {
+      "producer": "simplicio-mapper",
+      "version_command": "version --json",
+      "protocol": "simplicio.mapper/v1",
+      "schema": "simplicio.mapper-prefix/v1",
+      "requires_digest": true,
+      "requires_compatibility_range": true
+    }
   },
   "failure_policy": "best_effort"
 }

--- a/plugins/simplicio-hermes/package.json
+++ b/plugins/simplicio-hermes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.3.1",
-  "description": "Authenticated Mapper-only context and provider cache telemetry for Hermes.",
+  "version": "0.4.0",
+  "description": "Authenticated Mapper-only context and observable Hermes request receipts.",
   "type": "module",
   "main": "./index.mjs",
   "exports": "./index.mjs",

--- a/plugins/simplicio-hermes/plugin.yaml
+++ b/plugins/simplicio-hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: simplicio-hermes
-version: 0.3.1
-description: Authenticated Mapper-only context and provider cache telemetry for Hermes Agent.
+version: 0.4.0
+description: Authenticated Mapper-only context and observable request receipts for Hermes Agent.
 author: Wesley Simplicio
 provides_hooks:
   - on_session_start

--- a/plugins/simplicio-hermes/test.mjs
+++ b/plugins/simplicio-hermes/test.mjs
@@ -167,3 +167,48 @@ test("execution is always the host's original event", () => {
   const event = { execute: () => "native" };
   assert.equal(createHermesPlugin().hooks.llm_execution(event), event);
 });
+
+test("forwards real Hermes identity and records host capabilities", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime });
+  await plugin.hooks.llm_request({
+    messages: [], provider: "provider/name", model: "model/name",
+    session_id: "session-real", turn_id: "turn-real", api_request_id: "api-real",
+    logical_request_id: "logical-real", attempt_id: "attempt-real",
+    hermes_capabilities: { middleware: true, version: "0.20.4" },
+  });
+  assert.deepEqual(runtime.calls.prepare[0], {
+    host: "hermes", host_session_id: "session-real", turn_id: "turn-real",
+    api_request_id: "api-real", logical_request_id: "logical-real", attempt_id: "attempt-real",
+    synthetic: false, synthetic_ids: [], provider: "provider/name", model: "model/name",
+    hermes_capabilities: { middleware: true, version: "0.20.4" },
+    repo: process.cwd(), lifecycle: "provider_request", protection_mode: "best_effort",
+  });
+  assert.equal(plugin.status().provider_path_active, true);
+});
+
+test("synthetic identity is explicit and cannot prove provider coverage", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime });
+  const prepared = await plugin.prepare_model_call({ messages: [], api_request_id: "synthetic-api" });
+  const result = await plugin.record_model_result({
+    session_id: prepared.simplicio.session_id, api_request_id: "synthetic-api",
+  });
+  assert.equal(result.simplicio.reason_code, "receipt_recorded");
+  assert.equal(runtime.calls.record[0].coverage_proven, false);
+  assert.equal(plugin.status().provider_path_active, false);
+});
+
+test("missing and duplicate results emit bounded correlation receipts", async () => {
+  const runtime = runtimeFixture();
+  const plugin = createHermesPlugin({ runtime });
+  await plugin.prepare_model_call({ messages: [], session_id: "s", turn_id: "t", api_request_id: "a" });
+  const missing = await plugin.record_model_result({ session_id: "s", api_request_id: "unknown" });
+  assert.equal(missing.simplicio.reason_code, "correlation_missing");
+  await plugin.record_model_result({ session_id: "s", turn_id: "t", api_request_id: "a" });
+  const duplicate = await plugin.record_model_result({ session_id: "s", turn_id: "t", api_request_id: "a" });
+  assert.equal(duplicate.simplicio.reason_code, "duplicate_result");
+  assert.deepEqual(plugin.correlationReceipts().map((item) => item.reason_code), [
+    "correlation_missing", "duplicate_result",
+  ]);
+});

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -181,8 +181,15 @@ def test_runtime_outage_uses_python_mapper_fallback_and_reuses_cache(tmp_path, m
     log = tmp_path / "mapper.log"
     mapper.write_text(
         "#!" + sys.executable + "\n"
-        "import os, pathlib, sys\n"
-        "pathlib.Path(os.environ['PYTHON_MAPPER_LOG']).open('a').write(repr(sys.argv[1:]) + '\\n')\n"
+        "import hashlib, json, os, pathlib, sys\n"
+        "if sys.argv[1:3] == ['version', '--json']:\n"
+        "    print(json.dumps({'producer': 'simplicio-mapper', 'version': '0.26.25',\n"
+        "        'protocol': 'simplicio.mapper/v1', 'schema': 'simplicio.mapper-prefix/v1',\n"
+        "        'capabilities': ['map', 'docs'],\n"
+        "        'sha256': hashlib.sha256(pathlib.Path(sys.argv[0]).read_bytes()).hexdigest(),\n"
+        "        'compatibility': {'min_version': '0.26.25', 'max_version': '0.99.99'}}))\n"
+        "    raise SystemExit(0)\n"
+        f"pathlib.Path({str(log)!r}).open('a').write(repr(sys.argv[1:]) + '\\n')\n"
         "docs = pathlib.Path.cwd() / '.simplicio' / 'docs'\n"
         "docs.mkdir(parents=True, exist_ok=True)\n"
         "(docs / 'architecture.md').write_text('# Python Hermes fallback\\n', encoding='utf-8')\n",
@@ -190,7 +197,6 @@ def test_runtime_outage_uses_python_mapper_fallback_and_reuses_cache(tmp_path, m
     )
     mapper.chmod(0o755)
     monkeypatch.setenv("SIMPLICIO_MAPPER_BIN", str(mapper))
-    monkeypatch.setenv("PYTHON_MAPPER_LOG", str(log))
     adapter._BRIDGE = FakeBridge()
     adapter._BRIDGE.failure = RuntimeError("runtime unavailable")
     context = FakeContext()
@@ -267,6 +273,7 @@ def test_session_start_warms_authenticated_mapper_without_waiting():
     context.hooks["on_session_start"](session_id="s", cwd=str(ROOT))
     try:
         assert entered.wait(1)
+        assert not adapter._PREPARED
     finally:
         release.set()
 
@@ -370,6 +377,78 @@ def test_canonical_hermes_usage_keeps_total_prompt_and_cache_buckets():
     assert adapter._token_usage({"usage": {"cache_read_tokens": True}}) == {}
 
 
+def test_hermes_ids_are_preserved_and_missing_ids_are_marked_synthetic(tmp_path):
+    adapter = load_adapter()
+    real = adapter._arguments(
+        "session-real", turn_id="turn-real", api_request_id="api-real",
+        logical_request_id="logical-real", attempt_id="attempt-real",
+        provider="provider/name", model="model/name", cwd=str(tmp_path),
+        hermes_capabilities={"middleware": True, "version": "0.20.4"},
+    )
+    assert real["synthetic"] is False
+    assert real["synthetic_ids"] == []
+    assert real["provider"] == "provider/name" and real["model"] == "model/name"
+    assert real["hermes_capabilities"] == {"middleware": True, "version": "0.20.4"}
+
+    synthetic = adapter._arguments(cwd=str(tmp_path))
+    assert synthetic["synthetic"] is True
+    assert set(synthetic["synthetic_ids"]) == {
+        "host_session_id", "turn_id", "api_request_id", "logical_request_id", "attempt_id",
+    }
+
+
+def test_effective_project_generation_changes_when_bytes_change(tmp_path):
+    adapter = load_adapter()
+    source = tmp_path / "module.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    first = adapter._project_generation(tmp_path)
+    source.write_text("value = 2\n", encoding="utf-8")
+    second = adapter._project_generation(tmp_path)
+    assert first != second
+
+
+def test_missing_ambiguous_and_duplicate_results_emit_redacted_receipts():
+    adapter, bridge, context = setup_plugin()
+    context.middleware["llm_request"](
+        request={"messages": []}, session_id="s", turn_id="t", api_request_id="a",
+        logical_request_id="l-a", attempt_id="attempt-a", model="m", provider="p", cwd=str(ROOT),
+    )
+    context.hooks["post_api_request"](session_id="s", api_request_id="missing")
+    assert adapter.correlation_receipts()[-1]["reason_code"] == "correlation_missing"
+    context.hooks["post_api_request"](session_id="s", turn_id="t", api_request_id="a")
+    assert bridge.calls[-1][0] == "simplicio_record_model_result"
+    context.hooks["post_api_request"](session_id="s", turn_id="t", api_request_id="a")
+    assert adapter.correlation_receipts()[-1]["reason_code"] == "duplicate_result"
+
+    for request in ("b", "c"):
+        context.middleware["llm_request"](
+            request={"messages": []}, session_id="s2", turn_id="t2", api_request_id=request,
+            model="m", provider="p", cwd=str(ROOT),
+        )
+    context.hooks["post_api_request"](session_id="s2", turn_id="t2")
+    assert adapter.correlation_receipts()[-1]["reason_code"] == "correlation_ambiguous"
+    assert all("complete_map_tail" not in json.dumps(item) for item in adapter.correlation_receipts())
+
+
+def test_real_ids_prove_provider_path_but_synthetic_ids_do_not():
+    adapter, bridge, context = setup_plugin()
+    context.middleware["llm_request"](
+        request={"messages": []}, session_id="s", turn_id="t", api_request_id="a",
+        logical_request_id="l", attempt_id="attempt", model="m", provider="p", cwd=str(ROOT),
+    )
+    context.hooks["post_api_request"](session_id="s", turn_id="t", api_request_id="a")
+    args = bridge.calls[-1][1]
+    assert args["coverage_proven"] is True
+    assert args["logical_request_id"] == "l" and args["attempt_id"] == "attempt"
+
+    context.middleware["llm_request"](
+        request={"messages": []}, session_id="s2", api_request_id="synthetic",
+        model="m", provider="p", cwd=str(ROOT),
+    )
+    context.hooks["post_api_request"](session_id="s2", api_request_id="synthetic")
+    assert bridge.calls[-1][1]["coverage_proven"] is False
+
+
 def test_stdio_transport_enforces_mode_and_rejects_login_errors(tmp_path, monkeypatch):
     import os
     import sys
@@ -381,6 +460,7 @@ def test_stdio_transport_enforces_mode_and_rejects_login_errors(tmp_path, monkey
         "#!" + sys.executable + "\n"
         "import json, os, pathlib, sys\n"
         "assert os.environ['SIMPLICIO_RUNTIME_MODE'] == 'mapper-only'\n"
+        "assert 'HERMES_SECRET' not in os.environ\n"
         "tools = " + repr(sorted(adapter._MAPPER_TOOLS)) + "\n"
         "receipt = " + repr(receipt) + "\n"
         "marker = pathlib.Path(" + repr(str(marker)) + ")\n"
@@ -401,6 +481,7 @@ def test_stdio_transport_enforces_mode_and_rejects_login_errors(tmp_path, monkey
     if os.name == "nt":
         pytest.skip("POSIX test fixture executable")
     monkeypatch.setenv("SIMPLICIO_RUNTIME_MODE", "full")
+    monkeypatch.setenv("HERMES_SECRET", "do-not-forward")
     bridge = adapter.RuntimeMcpBridge(binary=program, timeout=2)
     try:
         with pytest.raises(adapter.SimplicioHermesError):


### PR DESCRIPTION
## Summary

Implements the verifiable adapter portion of #318:

- forwards Hermes request/session/turn/logical/attempt IDs when supplied;
- marks generated IDs as synthetic and prevents them from proving provider coverage;
- keeps warmup out of provider-result candidates;
- emits bounded redacted correlation receipts for missing, ambiguous, and duplicate results;
- deduplicates request/provider receipts and carries host capability metadata;
- replaces git status-only cache identity with effective project-byte hashing;
- attests Python Mapper with `version --json`, producer, version range, protocol/schema, capabilities, digest, and resolution source;
- uses a minimal subprocess environment, validated roots, timeout, and process-group isolation;
- upgrades the plugin/package/manifest to 0.4.0 and documents the migration contract.

## Verification

- `node --test plugins/simplicio-hermes/test.mjs`: 17 passed locally.
- `python3 -m py_compile plugins/simplicio-hermes/hermes_plugin.py tests/test_hermes_native_plugin.py`: passed locally.
- Direct Python checks covered effective-byte generation, version/digest attestation, fallback provenance, and secret-free environment.

## Environment limitations

This environment has no pytest runner, no installed official Hermes 0.20.4+ checkout, and no native clean-profile installer. Those mandatory integration/release proofs remain explicitly open and are not claimed by this PR.

Refs #318