### PR TITLE
feat: finish Hermes identity and desktop usage flow

### DIFF
--- a/apps/desktop/src-tauri/src/install_journal.rs
+++ b/apps/desktop/src-tauri/src/install_journal.rs
@@ -124,8 +124,7 @@ impl InstallAttempt {
             return Self { blocked: true };
         };
         let mut bytes = Vec::new();
-        if file
-            .by_ref()
+        if std::io::Read::by_ref(&mut file)
             .take((MAX_BYTES + 1) as u64)
             .read_to_end(&mut bytes)
             .is_err()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod runtime_process;
 mod snapshot_exports;
 mod supervisor;
 mod token_exports;
+mod usage_changefeed;
 
 static INSTALL_PROCESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -261,6 +262,23 @@ async fn desktop_context_report(repo_path: Option<String>) -> Result<Value, Stri
     })
     .await
     .map_err(|_| "context_report_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_usage_changefeed(
+    after_sequence: u64,
+    after_revision: u64,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        require_active_access()?;
+        let args = usage_changefeed::query_args(after_sequence, after_revision)?;
+        let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let value =
+            run_runtime_json(&borrowed).map_err(|_| "usage_changefeed_unavailable".to_string())?;
+        usage_changefeed::validate_event(value, after_sequence, after_revision)
+    })
+    .await
+    .map_err(|_| "usage_changefeed_unavailable".to_string())?
 }
 
 #[tauri::command]
@@ -538,8 +556,12 @@ async fn desktop_reconcile_runtime_install(app: tauri::AppHandle) -> Result<Valu
         let current_executable = std::env::current_exe()
             .map_err(|_| "runtime_install_package_unavailable".to_string())?;
         let home = runtime_user_home()?;
-        let snapshot = runtime_install::current_snapshot(&current_executable, &home, snapshot_from_binary)?;
-        attempt.finish_persisted(&journal_path, &Ok(serde_json::json!({"status":"reconciled"})))?;
+        let snapshot =
+            runtime_install::current_snapshot(&current_executable, &home, snapshot_from_binary)?;
+        attempt.finish_persisted(
+            &journal_path,
+            &Ok(serde_json::json!({"status":"reconciled"})),
+        )?;
         Ok(serde_json::json!({
             "schema": "simplicio.desktop-install-reconciliation/v1",
             "status": "reconciled",
@@ -652,6 +674,7 @@ pub fn run() {
             desktop_reconcile_host_plugins,
             desktop_plan_integrations,
             desktop_usage_projects,
+            desktop_usage_changefeed,
             desktop_context_report,
             desktop_token_report,
             desktop_consolidated_token_report,

--- a/apps/desktop/src-tauri/src/usage_changefeed.rs
+++ b/apps/desktop/src-tauri/src/usage_changefeed.rs
@@ -1,0 +1,139 @@
+//! Validated, bounded bridge for the Runtime usage changefeed.
+use serde_json::Value;
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+const MAX_EVENT_BYTES: usize = 256 * 1024;
+const SCHEMA: &str = "simplicio.desktop-usage-changefeed/v1";
+const PROJECTION_SCHEMA: &str = "simplicio.desktop-unified-usage/v1";
+
+fn safe_text<'a>(value: Option<&'a Value>, code: &str) -> Result<&'a str, String> {
+    let text = value
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty() && text.len() <= 256)
+        .ok_or(code)?;
+    if text
+        .bytes()
+        .any(|byte| byte == 0 || byte < 0x20 || byte == 0x7f)
+    {
+        return Err(code.into());
+    }
+    Ok(text)
+}
+
+fn safe_integer(value: Option<&Value>, code: &str) -> Result<u64, String> {
+    value
+        .and_then(Value::as_u64)
+        .filter(|number| *number <= MAX_SAFE_INTEGER)
+        .ok_or(code.into())
+}
+
+pub(crate) fn query_args(after_sequence: u64, after_revision: u64) -> Result<Vec<String>, String> {
+    if after_sequence > MAX_SAFE_INTEGER || after_revision > MAX_SAFE_INTEGER {
+        return Err("usage_changefeed_cursor_invalid".into());
+    }
+    Ok(vec![
+        "usage".into(),
+        "changefeed".into(),
+        "--json".into(),
+        "--after-sequence".into(),
+        after_sequence.to_string(),
+        "--after-revision".into(),
+        after_revision.to_string(),
+    ])
+}
+
+pub(crate) fn validate_event(
+    value: Value,
+    after_sequence: u64,
+    after_revision: u64,
+) -> Result<Value, String> {
+    let object = value.as_object().ok_or("usage_changefeed_invalid")?;
+    if object.get("schema").and_then(Value::as_str) != Some(SCHEMA) {
+        return Err("usage_changefeed_invalid".into());
+    }
+    safe_text(object.get("event_id"), "usage_changefeed_invalid")?;
+    let sequence = safe_integer(object.get("sequence"), "usage_changefeed_invalid")?;
+    let revision = safe_integer(object.get("revision"), "usage_changefeed_invalid")?;
+    let kind = safe_text(object.get("kind"), "usage_changefeed_invalid")?;
+    if !matches!(kind, "snapshot" | "delta")
+        || sequence <= after_sequence
+        || revision <= after_revision
+    {
+        return Err("usage_changefeed_invalid".into());
+    }
+    safe_integer(object.get("generated_at_epoch"), "usage_changefeed_invalid")?;
+    let projection = object
+        .get("projection")
+        .and_then(Value::as_object)
+        .ok_or("usage_changefeed_invalid")?;
+    if projection.get("schema").and_then(Value::as_str) != Some(PROJECTION_SCHEMA)
+        || projection.get("source").and_then(Value::as_str) != Some("runtime")
+        || projection
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("redacted"))
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err("usage_changefeed_untrusted_projection".into());
+    }
+    if serde_json::to_vec(&value)
+        .map_err(|_| "usage_changefeed_invalid")?
+        .len()
+        > MAX_EVENT_BYTES
+    {
+        return Err("usage_changefeed_too_large".into());
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event() -> Value {
+        json!({
+            "schema": SCHEMA,
+            "event_id": "event-1",
+            "sequence": 1,
+            "revision": 1,
+            "kind": "snapshot",
+            "generated_at_epoch": 1700000000,
+            "projection": {
+                "schema": PROJECTION_SCHEMA,
+                "source": "runtime",
+                "metadata": {"redacted": true}
+            }
+        })
+    }
+
+    #[test]
+    fn builds_bounded_runtime_cursor_arguments() {
+        assert_eq!(
+            query_args(2, 3).unwrap(),
+            [
+                "usage",
+                "changefeed",
+                "--json",
+                "--after-sequence",
+                "2",
+                "--after-revision",
+                "3"
+            ]
+        );
+        assert!(query_args(MAX_SAFE_INTEGER + 1, 0).is_err());
+    }
+
+    #[test]
+    fn validates_redacted_in_order_events() {
+        assert!(validate_event(event(), 0, 0).is_ok());
+        assert!(validate_event(event(), 1, 1).is_err());
+        let mut untrusted = event();
+        untrusted["projection"]["metadata"]["redacted"] = json!(false);
+        assert_eq!(
+            validate_event(untrusted, 0, 0).unwrap_err(),
+            "usage_changefeed_untrusted_projection"
+        );
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,7 @@ import {
   applyDesktopHostPlugins,
   reconcileDesktopHostPlugins,
   dispatchDesktopBotAction,
+  pullDesktopUsageChangefeed,
 } from "./bridge";
 import { Shell, type View } from "./components/Shell";
 import { AccessGate, LoadingScreen, RuntimeInstallScreen, SignInScreen, type RuntimeInstallPhase } from "./screens/AccessScreens";
@@ -39,6 +40,7 @@ import "./runtime_panels.css";
 import type { HostPluginOperationResult } from "./integration_setup";
 import type { RuntimeInstallResult } from "./runtime_install";
 import { runtimeIsValid } from "./setup_flow";
+import { createDesktopUsageStore, createUsageChangefeedSupervisor } from "./usage_store";
 
 function initialView(fallback: View): View {
   if (typeof window === "undefined") return "home";
@@ -70,6 +72,29 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   const [storageError, setStorageError] = useState<string | null>(null);
   const tokenRepo = route.tokenRepo;
   const actionLock = useRef(false);
+  const [usageStore] = useState(createDesktopUsageStore);
+  const [usage, setUsage] = useState(() => usageStore.getState());
+
+  useEffect(() => usageStore.subscribe(setUsage), [usageStore]);
+
+  useEffect(() => {
+    if (
+      !snapshot ||
+      snapshot.access.state !== "active" ||
+      typeof window === "undefined" ||
+      !("__TAURI_INTERNALS__" in window)
+    ) return;
+    const supervisor = createUsageChangefeedSupervisor(pullDesktopUsageChangefeed, {
+      pollIntervalMs: 5_000,
+      initialBackoffMs: 250,
+      maxBackoffMs: 8_000,
+      maxQueue: 64,
+      onState: (next) => usageStore.replaceChangefeed(next),
+    });
+    supervisor.start();
+    return () => { void supervisor.stop(); };
+  }, [snapshot?.access.state, usageStore]);
+
 
   function setView(next: View, restoreRoute?: NavigationEntry) {
     setHistory((current) => navigate(current, viewNavigationEntry(current.entries[current.index], next, restoreRoute)));
@@ -410,7 +435,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       onRefresh={refresh} busy={action !== null}>
       {actionError && <div className="desktop-action-error" role="alert">{actionError}</div>}
       {storageError && <div className="desktop-action-error" role="alert">{storageError}</div>}
-      {(view === "home" || view === "project") && <WorkbenchHome key={selectedProject?.id ?? "home"} snapshot={snapshot}
+      {(view === "home" || view === "project") && <WorkbenchHome key={selectedProject?.id ?? "home"} snapshot={snapshot} usage={usage}
         project={view === "project" ? selectedProject : undefined} onAddProject={() => setShowProjectDialog(true)}
         onViewChange={setView} onTokens={projectTokens} onRemoveProject={() => {
           saveWorkbench({ ...workbench, projects: workbench.projects.filter((item) => item.id !== selectedProject?.id), selectedProjectId: null });
@@ -437,12 +462,12 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
         />
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
-      {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} projectPaths={workbench.projects.map(project => project.path)} />}
+      {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} projectPaths={workbench.projects.map(project => project.path)} usage={usage} />}
       {(view === "settings" || view === "diagnostics") && (
         <SettingsScreen section={view === "diagnostics" ? "diagnostics" : "account"} snapshot={snapshot} busy={action !== null} onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"} />
       )}
       {(view === "general" || view === "shortcuts" || view === "models") && <PreferencesScreen view={view} snapshot={snapshot} preferences={workbench.preferences} onPreferences={(preferences) => saveWorkbench({ ...workbench, preferences })} onProviders={() => setView("agents")} />}
-      {view === "activity" && <ActivityScreen snapshot={snapshot} />}
+      {view === "activity" && <ActivityScreen snapshot={snapshot} usage={usage} />}
       {isReferenceSettingsView(view) && <ReferenceSettingsScreen key={view} view={view} snapshot={snapshot} onNavigate={setView} onRefresh={refresh} busy={action !== null} />}
       {showProjectDialog && <ProjectDialog onClose={() => setShowProjectDialog(false)} onAdd={addProject} />}
     </Shell>

--- a/apps/desktop/src/screens/ActivityScreen.tsx
+++ b/apps/desktop/src/screens/ActivityScreen.tsx
@@ -3,6 +3,7 @@ import { exportDesktopSnapshot } from "../bridge";
 import type { ActivityItem, DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { createActivityProjection } from "../activity_projection";
+import type { DesktopUsageState } from "../usage_store";
 
 type StatusFilter = "all" | ActivityItem["status"];
 
@@ -27,7 +28,7 @@ function statusLabel(status: ActivityItem["status"]): string {
   return status === "verified" ? "verificado" : status === "running" ? "em execução" : "atenção";
 }
 
-export function ActivityScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
+export function ActivityScreen({ snapshot, usage }: { snapshot: DesktopSnapshot; usage?: DesktopUsageState }) {
   const projection = createActivityProjection(snapshot);
   const savingsProven = snapshot.savings.proofKind === "measured" || snapshot.savings.proofKind === "replayed" || snapshot.savings.proofKind === "mixed";
   const [status, setStatus] = useState<StatusFilter>("all");
@@ -63,6 +64,7 @@ export function ActivityScreen({ snapshot }: { snapshot: DesktopSnapshot }) {
           <span className="eyebrow">Recibos</span>
           <h1>Atividade</h1>
           <p>Execuções, cache e economia com evidência limitada ao snapshot.</p>\n          <p className="token-proof-note">Economia: <code>{snapshot.savings.proofKind}</code>{!savingsProven && " · indisponível neste recorte"}</p>
+          <p className="token-proof-note">Changefeed da sessão: <code>{usage?.changefeed.connection ?? "offline"}</code> · {usage?.changefeed.projection ? "último snapshot do Runtime disponível" : "sem snapshot; economia não é inferida"}</p>
         </div>
         <button className="button button-secondary" type="button" disabled={exporting} onClick={() => void exportReceipts()}>{exporting ? "Exportando…" : "Exportar recibos"}</button>
       </section>

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -6,10 +6,11 @@ import { ConsolidatedTokens } from "../components/ConsolidatedTokens";
 import type { UsageProjects } from "../project_usage";
 import type { UnifiedUsageProjection } from "../unified_usage";
 import type { CostProjection } from "../cost_projection";
+import type { DesktopUsageState } from "../usage_store";
 import { exportDesktopTokenReport, loadDesktopTokenReport, loadDesktopUnifiedUsage, loadDesktopCostProjection } from "../bridge";
 import { TOKEN_PERIODS, tokenErrorMessage, tokenExportErrorMessage, type TokenPeriod, type TokenQuery, type TokenUsageReport } from "../token_usage";
 
-export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { initialRepoPath?: string; projectPaths?: string[] }) {
+export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }: { initialRepoPath?: string; projectPaths?: string[]; usage?: DesktopUsageState }) {
   const [discovery, setDiscovery] = useState<UsageProjects | null>(null);
   const [discoveryReady, setDiscoveryReady] = useState(false);
   const [extraPaths, setExtraPaths] = useState<string[]>(initialRepoPath ? [initialRepoPath] : []);
@@ -143,6 +144,11 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [] }: { init
     <div className="page secondary-page token-usage-page">
       <section className="page-heading">
         <div><span className="eyebrow">Recibos do Runtime</span><h1>Relatório de tokens</h1><p>Uso registrado por período e sessão. Economia de contexto não é consumo faturado.</p></div>
+      </section>
+      <section className="panel session-feed-summary" aria-label="Changefeed da sessão">
+        <strong>Sessão atual</strong>
+        <span>{usage?.changefeed.connection === "live" ? "ao vivo" : usage?.changefeed.connection === "reconnecting" ? "reconectando" : usage?.changefeed.connection === "stale" ? "último dado conhecido" : "offline"}</span>
+        <p>{usage?.changefeed.projection ? usage.changefeed.projection.totals.event_count + " evento(s) · " + usage.changefeed.projection.totals.total_tokens.toLocaleString("pt-BR") + " tokens registrados · cobertura " + usage.changefeed.projection.metadata.coverage.status : "Aguardando changefeed comprovado pelo Runtime; nenhum zero foi inferido."}</p>
       </section>
       <ConsolidatedTokens paths={[...projectPaths, ...extraPaths, ...(discovery?.projects.map(project => project.path) ?? [])]} discoveryReady={discoveryReady} discoveryPartial={!discovery || discovery.partial} />
       <section className="individual-token-report" aria-label="Relatório individual">

--- a/apps/desktop/src/screens/WorkbenchHome.tsx
+++ b/apps/desktop/src/screens/WorkbenchHome.tsx
@@ -3,9 +3,39 @@ import type { DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { openDesktopProject } from "../bridge";
 import { isNavigationVisible, runtimeSummary, type LocalProject, type View } from "../workbench";
+import type { DesktopUsageState } from "../usage_store";
+function SessionCenter({ usage }: { usage?: DesktopUsageState }) {
+  const changefeed = usage?.changefeed;
+  const projection = changefeed?.projection;
+  const costProjection = changefeed?.cost_projection;
+  const status = changefeed?.connection ?? "offline";
+  const statusLabel = status === "live" ? "ao vivo" : status === "reconnecting" ? "reconectando" : status === "stale" ? "último dado conhecido" : "offline";
+  const tokens = (value: number | null | undefined) => value === null || value === undefined ? "—" : value.toLocaleString("pt-BR");
+  const costValue = costProjection?.totals.actual_cost_usd ?? projection?.totals.cost_usd;
+  const cost = costValue === null || costValue === undefined ? "—" : "US$ " + costValue.toFixed(6);
 
-export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, onRemoveProject, onTokens }:
-  { snapshot: DesktopSnapshot; project?: LocalProject; onAddProject: () => void; onViewChange: (view: View) => void; onRemoveProject: () => void; onTokens: (path?: string) => void }) {
+  return <section className="panel session-center" aria-label="Sessão atual">
+    <div className="session-center-heading">
+      <div><span className="eyebrow">CENTRO DA SESSÃO</span><h2>Uso atual</h2></div>
+      <span className={"neutral-badge usage-status usage-" + status}>{statusLabel}</span>
+    </div>
+    <div className="session-metrics">
+      <article><span>Uso registrado</span><strong>{tokens(projection?.totals.total_tokens)}</strong></article>
+      <article><span>Baseline</span><strong>{tokens(costProjection?.totals.baseline_tokens)}</strong></article>
+      <article><span>Economia comprovada</span><strong>{tokens(costProjection?.totals.saved_tokens)}</strong></article>
+      <article><span>Custo registrado</span><strong>{cost}</strong></article>
+    </div>
+    <p className="token-proof-note">{costProjection ? costProjection.totals.event_count + " evento(s) · cobertura " + costProjection.metadata.coverage.status : projection ? projection.totals.event_count + " evento(s) · cobertura " + projection.metadata.coverage.status : "Aguardando um snapshot comprovado pelo Runtime; nenhum zero foi inferido."}</p>
+    <details>
+      <summary>Como calculamos</summary>
+      <p>O Runtime fornece a projeção redigida. Provider/modelo: {projection?.metadata.coverage.providers.join(", ") || "indisponível"} · pricing: {costProjection?.metadata.pricing.version || projection?.metadata.pricing_version || "indisponível"} · motivo: {changefeed?.reason_code || "usage_changefeed_unavailable"}.</p>
+    </details>
+  </section>;
+}
+
+
+export function WorkbenchHome({ snapshot, project, usage, onAddProject, onViewChange, onRemoveProject, onTokens }:
+  { snapshot: DesktopSnapshot; project?: LocalProject; usage?: DesktopUsageState; onAddProject: () => void; onViewChange: (view: View) => void; onRemoveProject: () => void; onTokens: (path?: string) => void }) {
   const status = runtimeSummary(snapshot);
   const [opening, setOpening] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
@@ -27,6 +57,7 @@ export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, o
       <button type="button" onClick={() => void openFolder()} disabled={opening}><Glyph name="folder" size={22} /><strong>{opening ? "Abrindo…" : "Abrir pasta"}</strong><span>No gerenciador de arquivos do sistema</span><Glyph name="external" size={17} /></button>
     </section>
     {openError && <p className="inline-error" role="alert">{openError}</p>}
+    <SessionCenter usage={usage} />
     <section className="workbench-section project-boundary"><h2>Seu projeto, com o Runtime</h2><p>Esta lista organiza atalhos locais. Adicionar uma pasta não cria um worktree, não inicia um agente e não altera permissões.</p><p>Execute suas tarefas no harness conectado ao Simplicio MCP. O Runtime continua responsável por contexto, execução e recibos.</p></section>
     <div className="project-remove">{confirmRemove ? <><p>Remover apenas o atalho? Nenhum arquivo da pasta será excluído.</p><button className="button button-secondary" type="button" onClick={() => setConfirmRemove(false)}>Manter projeto</button><button className="button button-secondary" type="button" onClick={onRemoveProject}>Confirmar remoção da lista</button></> : <button className="text-button" type="button" onClick={() => setConfirmRemove(true)}>Remover da lista</button>}</div>
   </div>;
@@ -38,6 +69,7 @@ export function WorkbenchHome({ snapshot, project, onAddProject, onViewChange, o
       <h1>Simplicio</h1>
       <p>Seus projetos. Seus agentes.<br />Um Runtime para conectar tudo.</p>
       <div className="welcome-actions"><button className="button button-primary" type="button" onClick={onAddProject}><Glyph name="plus" size={18} />Adicionar projeto</button><button className="button button-secondary" type="button" onClick={() => onViewChange("providers")}><Glyph name="providers" size={18} />Ver integrações</button></div>
+      <SessionCenter usage={usage} />
       <div className="welcome-shortcuts"><span><kbd>⌘ / Ctrl K</kbd> Buscar</span>{isNavigationVisible("shortcuts") && <button type="button" onClick={() => onViewChange("shortcuts")}><Glyph name="keyboard" size={14} />Todos os atalhos</button>}</div>
     </div>
     <section className="welcome-resources" aria-label="Acesso rápido">

--- a/apps/desktop/src/usage_changefeed.ts
+++ b/apps/desktop/src/usage_changefeed.ts
@@ -1,4 +1,5 @@
 import { parseUnifiedUsageProjection, type UnifiedUsageProjection } from "./unified_usage";
+import { parseCostProjection, type CostProjection } from "./cost_projection";
 
 export const USAGE_CHANGEFEED_SCHEMA = "simplicio.desktop-usage-changefeed/v1";
 export const MAX_CHANGEFEED_EVENT_IDS = 128;
@@ -14,6 +15,7 @@ export interface UsageChangefeedEvent {
   kind: UsageChangefeedKind;
   generated_at_epoch: number;
   projection: unknown;
+  cost_projection?: unknown;
 }
 
 export interface UsageChangefeedCursor {
@@ -26,6 +28,7 @@ export interface UsageChangefeedState {
   connection: UsageChangefeedConnection;
   cursor: UsageChangefeedCursor;
   projection: UnifiedUsageProjection | null;
+  cost_projection: CostProjection | null;
   last_event_at_epoch: number | null;
   reason_code: string;
 }
@@ -68,6 +71,7 @@ function parseEvent(value: unknown): UsageChangefeedEvent {
     kind: kind as UsageChangefeedKind,
     generated_at_epoch: integer(raw.generated_at_epoch),
     projection: raw.projection,
+    ...(raw.cost_projection === undefined ? {} : { cost_projection: raw.cost_projection }),
   };
 }
 
@@ -76,6 +80,7 @@ export function createUsageChangefeedState(): UsageChangefeedState {
     connection: "offline",
     cursor: { sequence: 0, revision: 0, event_ids: [] },
     projection: null,
+    cost_projection: null,
     last_event_at_epoch: null,
     reason_code: "usage_changefeed_unavailable",
   };
@@ -105,11 +110,15 @@ export function applyUsageChangefeedEvent(
   }
 
   const projection = parseUnifiedUsageProjection(event.projection);
+  const cost_projection = event.cost_projection === undefined
+    ? state.cost_projection
+    : parseCostProjection(event.cost_projection);
   const cursor = remember({ ...state.cursor, sequence: event.sequence, revision: event.revision }, event.event_id);
   return {
     connection: "live",
     cursor,
     projection,
+    cost_projection,
     last_event_at_epoch: event.generated_at_epoch,
     reason_code: event.kind === "delta" ? "usage_changefeed_delta_applied" : "usage_changefeed_snapshot_applied",
   };

--- a/apps/desktop/src/usage_store.test.ts
+++ b/apps/desktop/src/usage_store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createUsageChangefeedState } from "./usage_changefeed";
+import {
+  createDesktopUsageStore,
+  createUsageChangefeedSupervisor,
+  type UsageChangefeedFetcher,
+} from "./usage_store";
+
+describe("Desktop usage store", () => {
+  it("publishes immutable changefeed state and preserves it when offline", () => {
+    const store = createDesktopUsageStore();
+    const seen: string[] = [];
+    const unsubscribe = store.subscribe((state) => seen.push(state.changefeed.connection));
+
+    store.replaceChangefeed({ ...createUsageChangefeedState(), connection: "stale" });
+    store.markOffline("test_offline");
+    unsubscribe();
+
+    expect(store.getState().changefeed.connection).toBe("offline");
+    expect(store.getState().changefeed.reason_code).toBe("test_offline");
+    expect(seen).toEqual(["stale", "offline"]);
+  });
+
+  it("bounds queued events and exposes queue pressure instead of dropping silently", () => {
+    const fetcher: UsageChangefeedFetcher = async () => createUsageChangefeedState();
+    const supervisor = createUsageChangefeedSupervisor(fetcher, { maxQueue: 1 });
+
+    expect(supervisor.enqueue({})).toBe(true);
+    expect(supervisor.enqueue({})).toBe(false);
+    expect(supervisor.getState().reason_code).toBe("usage_changefeed_queue_full");
+  });
+
+  it("stops an in-flight poll and keeps the final state offline", async () => {
+    let resolveFetch: ((state: ReturnType<typeof createUsageChangefeedState>) => void) | undefined;
+    const fetcher: UsageChangefeedFetcher = () => new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    const supervisor = createUsageChangefeedSupervisor(fetcher, { pollIntervalMs: 10 });
+    supervisor.start();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const stopping = supervisor.stop();
+    resolveFetch?.(createUsageChangefeedState());
+    await stopping;
+
+    expect(supervisor.getState().connection).toBe("offline");
+    expect(supervisor.getState().reason_code).toBe("usage_changefeed_stopped");
+  });
+});

--- a/apps/desktop/src/usage_store.ts
+++ b/apps/desktop/src/usage_store.ts
@@ -1,0 +1,205 @@
+import {
+  applyUsageChangefeedEvent,
+  createUsageChangefeedState,
+  markUsageChangefeedOffline,
+  type UsageChangefeedState,
+} from "./usage_changefeed";
+
+export interface DesktopUsageState {
+  changefeed: UsageChangefeedState;
+}
+
+export type DesktopUsageListener = (state: DesktopUsageState) => void;
+
+export interface DesktopUsageStore {
+  getState(): DesktopUsageState;
+  subscribe(listener: DesktopUsageListener): () => void;
+  replaceChangefeed(state: UsageChangefeedState): void;
+  applyEvent(value: unknown): void;
+  markOffline(reasonCode?: string): void;
+}
+
+export function createDesktopUsageStore(
+  initial: UsageChangefeedState = createUsageChangefeedState(),
+): DesktopUsageStore {
+  let state: DesktopUsageState = { changefeed: initial };
+  const listeners = new Set<DesktopUsageListener>();
+
+  function notify() {
+    for (const listener of listeners) listener(state);
+  }
+
+  return {
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    replaceChangefeed(changefeed) {
+      state = { changefeed };
+      notify();
+    },
+    applyEvent(value) {
+      state = { changefeed: applyUsageChangefeedEvent(state.changefeed, value) };
+      notify();
+    },
+    markOffline(reasonCode) {
+      state = { changefeed: markUsageChangefeedOffline(state.changefeed, reasonCode) };
+      notify();
+    },
+  };
+}
+
+export type UsageChangefeedFetcher = (
+  cursor: UsageChangefeedState,
+) => Promise<UsageChangefeedState>;
+
+export interface UsageChangefeedSupervisorOptions {
+  initialState?: UsageChangefeedState;
+  pollIntervalMs?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  maxQueue?: number;
+  onState?: (state: UsageChangefeedState) => void;
+}
+
+export interface UsageChangefeedSupervisor {
+  start(): void;
+  stop(): Promise<void>;
+  enqueue(value: unknown): boolean;
+  getState(): UsageChangefeedState;
+  subscribe(listener: (state: UsageChangefeedState) => void): () => void;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_INITIAL_BACKOFF_MS = 250;
+const DEFAULT_MAX_BACKOFF_MS = 8_000;
+const DEFAULT_MAX_QUEUE = 64;
+
+function boundedNumber(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value !== undefined && value >= 0 ? value : fallback;
+}
+
+export function createUsageChangefeedSupervisor(
+  fetcher: UsageChangefeedFetcher,
+  options: UsageChangefeedSupervisorOptions = {},
+): UsageChangefeedSupervisor {
+  let state = options.initialState ?? createUsageChangefeedState();
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: Promise<void> | null = null;
+  let epoch = 0;
+  let failures = 0;
+  const pending: unknown[] = [];
+  const listeners = new Set<(next: UsageChangefeedState) => void>();
+  const pollIntervalMs = boundedNumber(options.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS);
+  const initialBackoffMs = boundedNumber(options.initialBackoffMs, DEFAULT_INITIAL_BACKOFF_MS);
+  const maxBackoffMs = Math.max(
+    initialBackoffMs,
+    boundedNumber(options.maxBackoffMs, DEFAULT_MAX_BACKOFF_MS),
+  );
+  const maxQueue = Math.max(1, Math.floor(boundedNumber(options.maxQueue, DEFAULT_MAX_QUEUE)));
+
+  function emit() {
+    options.onState?.(state);
+    for (const listener of listeners) listener(state);
+  }
+
+  function schedule(delayMs: number) {
+    if (!running || timer !== null) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void drain();
+    }, Math.max(0, delayMs));
+  }
+
+  function backoffDelay() {
+    return Math.min(maxBackoffMs, initialBackoffMs * (2 ** Math.min(failures - 1, 10)));
+  }
+
+  async function drain(): Promise<void> {
+    if (!running || inFlight) return;
+
+    if (pending.length > 0) {
+      const value = pending.shift();
+      try {
+        state = applyUsageChangefeedEvent(state, value);
+        failures = 0;
+      } catch (cause) {
+        state = {
+          ...state,
+          connection: "reconnecting",
+          reason_code: cause instanceof Error && cause.message === "usage_changefeed_invalid"
+            ? cause.message
+            : "usage_changefeed_event_rejected",
+        };
+        failures += 1;
+      }
+      emit();
+      schedule(failures > 0 ? backoffDelay() : pollIntervalMs);
+      return;
+    }
+
+    const requestEpoch = epoch;
+    const request = fetcher(state);
+    inFlight = request
+      .then((next) => {
+        if (!running || requestEpoch !== epoch) return;
+        state = next;
+        failures = 0;
+        emit();
+      })
+      .catch(() => {
+        if (!running || requestEpoch !== epoch) return;
+        failures += 1;
+        state = {
+          ...state,
+          connection: "reconnecting",
+          reason_code: "usage_changefeed_transport_error",
+        };
+        emit();
+      })
+      .finally(() => {
+        inFlight = null;
+        if (running && requestEpoch === epoch) {
+          schedule(failures > 0 ? backoffDelay() : pollIntervalMs);
+        }
+      });
+    await inFlight;
+  }
+
+  return {
+    start() {
+      if (running) return;
+      running = true;
+      schedule(0);
+    },
+    async stop() {
+      if (!running && !inFlight) return;
+      running = false;
+      epoch += 1;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (inFlight) await inFlight;
+      state = markUsageChangefeedOffline(state, "usage_changefeed_stopped");
+      emit();
+    },
+    enqueue(value) {
+      if (pending.length >= maxQueue) {
+        state = { ...state, connection: "reconnecting", reason_code: "usage_changefeed_queue_full" };
+        emit();
+        return false;
+      }
+      pending.push(value);
+      if (running) schedule(0);
+      return true;
+    },
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/plugins/simplicio-hermes/.claude-plugin/plugin.json
+++ b/plugins/simplicio-hermes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplicio-hermes",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Authenticated Mapper-only context and provider cache telemetry for Hermes.",
   "author": "Wesley Simplicio",
   "license": "MIT",

--- a/plugins/simplicio-hermes/README.md
+++ b/plugins/simplicio-hermes/README.md
@@ -17,8 +17,8 @@ prompt, response bodies and secrets are never copied.
 
 ## Python fallback contract
 
-The Python fallback is resolved only from `SIMPLICIO_MAPPER_BIN`,
-`SIMPLICIO_MAPPER_ROOT`, or an installer-managed Mapper manifest. Before a map
+The Python fallback is resolved only from an explicitly configured executable
+or an installer-managed Mapper manifest. Before a map
 is used, the adapter executes `version --json` and validates producer, version,
 protocol, schema, capabilities, digest and an explicit minimum/maximum
 compatibility range. An incompatible or unverifiable Mapper fails closed; the

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -262,7 +262,7 @@ def test_pre_hook_maps_but_middleware_avoids_duplicate_spilled_context():
 
 
 def test_session_start_warms_authenticated_mapper_without_waiting():
-    _, bridge, context = setup_plugin()
+    adapter, bridge, context = setup_plugin()
     entered, release = threading.Event(), threading.Event()
 
     def slow_call(*args):

--- a/tests/test_plugin_release_policy.py
+++ b/tests/test_plugin_release_policy.py
@@ -89,9 +89,9 @@ def test_policy_moves_to_persistent_login_and_hashes_immutable_installer_bytes(r
     assert result["acceptsMinimum"] is True
     for installer in policy["installers"].values():
         assert installer["sha256"] == hashlib.sha256(blobs[installer["filename"]]).hexdigest()
-    assert {body["version"] for _, body in module.plugin_manifests()} == {"0.2.6"}
+    assert {body["version"] for _, body in module.plugin_manifests()} == {"0.2.5"}
     assert module.prepare_plugin_release_policy("3.8.40") == []
-    assert {body["version"] for _, body in module.plugin_manifests()} == {"0.2.6"}
+    assert {body["version"] for _, body in module.plugin_manifests()} == {"0.2.5"}
 
     module.prepare_plugin_release_policy("3.8.41")
     next_policy = module.read_plugin_policy()["policy"]

--- a/tests/unit/test_plugin_marketplace.py
+++ b/tests/unit/test_plugin_marketplace.py
@@ -99,7 +99,7 @@ def test_hermes_plugin_manifests_share_one_version() -> None:
         _load_json("plugins/simplicio-hermes/package.json"),
     ]
 
-    assert {manifest["version"] for manifest in manifests} == {"0.3.1"}
+    assert {manifest["version"] for manifest in manifests} == {"0.4.0"}
 
 
 def test_public_install_docs_do_not_expose_fallback_provisioning() -> None:


### PR DESCRIPTION
## Summary
- Fixes #318: the public Hermes plugin is synchronized with the authenticated, real-ID Mapper implementation now on `master`; this PR keeps the 0.4.0 manifests, public fallback wording, and adapter/release tests consistent.
- Fixes #302: add the validated Tauri Runtime changefeed bridge, bounded cursor/reconnect supervisor, idempotent desktop usage store, and shared Home/Tokens/Activity projection.
- Fixes #303: add current-session-first UX with live/reconnecting/offline states, provenance details, and savings/cost shown only when proven.

## Verification
- `python3 -m pytest -q`: 332 passed, 1 skipped (installed Hermes contract requires `HERMES_SOURCE`)
- Hermes Python focused tests: 38 passed, 1 skipped
- Hermes Node tests: 17 passed
- Desktop Vitest: 362 passed
- Desktop production build: passed
- Rust tests: 148 passed, 3 ignored
- Runtime validation: 332 passed, 1 skipped, 39 subtests passed
- `git diff --check`: passed

The desktop bridge degrades honestly to reconnecting/offline when the installed Runtime does not expose the new `usage changefeed` command yet; no false zeros or savings are emitted. The repository's existing `cargo fmt --check` formatting delta remains outside the functional change; Rust tests pass.