### PR TITLE
feat: add fail-closed operator bundle verifier

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -38,6 +38,22 @@ publish the root `signing_pubkey` exactly as
 Do not publish a new release from a checkout where `version.txt` and the
 manifest disagree.
 
+When a Runtime release promotes an external Loop fallback composition, its
+operator bundle is a separate signed, offline asset set. Validate the promoted
+composition and the staged bytes before publication:
+
+```bash
+python3 scripts/verify_operator_bundle_manifest.py \
+  /absolute/path/to/simplicio-operator-bundle.json \
+  --bundle /absolute/path/to/operator-bundle
+```
+
+The gate requires exact Runtime, Loop, Mapper, Dev CLI, Fast, and Prompt
+identities, Ed25519 signatures, SBOM and provenance sidecars, absolute
+entrypoints, atomic Runtime/operator slots, native-first fallback policy, and
+separate host-plugin consent. An unsigned upstream package or an unavailable
+operator release is release-blocking; it must not be relabeled as verified.
+
 The Codex hooks are versioned tag files rather than GitHub Release assets.
 Before tagging, execute `bash tests/test_codex_hooks.sh` and require every
 allow-unchanged case to exit zero with empty stdout. A bare

--- a/scripts/verify_operator_bundle_manifest.py
+++ b/scripts/verify_operator_bundle_manifest.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Fail-closed verifier for the Runtime-managed external operator bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from verify_ed25519 import verify_signature_for_digest
+
+SCHEMA = "simplicio.operator-bundle-manifest/v1"
+REPORT_SCHEMA = "simplicio.operator-bundle-verification/v1"
+REQUIRED_COMPONENTS = {
+    "simplicio-runtime",
+    "simplicio-loop",
+    "simplicio-mapper",
+    "simplicio-dev-cli",
+    "simplicio-fast",
+    "simplicio-prompt",
+}
+REQUIRED_POLICIES = {
+    "offline_install": True,
+    "absolute_entrypoints": True,
+    "native_loop_default": True,
+    "external_loop_fallback_only": True,
+    "hooks_provision_packages": False,
+    "host_plugin_consent_required": True,
+    "atomic_runtime_operator_activation": True,
+    "active_run_slot_pinning": True,
+}
+SAFE_FILENAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _failure(code: str, detail: str) -> dict[str, str]:
+    return {"code": code, "detail": detail}
+
+
+def _object(value: Any, code: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(code)
+    return value
+
+
+def _safe_filename(value: Any) -> bool:
+    return isinstance(value, str) and SAFE_FILENAME.fullmatch(value) is not None
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_component(raw: Any, failures: list[dict[str, str]]) -> str | None:
+    try:
+        component = _object(raw, "component_invalid")
+    except ValueError:
+        failures.append(_failure("component_invalid", "component must be an object"))
+        return None
+    name = component.get("name")
+    if name not in REQUIRED_COMPONENTS:
+        failures.append(_failure("component_unknown", f"unsupported component {name!r}"))
+        return None
+    if not isinstance(component.get("version"), str) or not SEMVER.fullmatch(component["version"]):
+        failures.append(_failure("component_version_invalid", f"{name} needs an exact semantic version"))
+    if component.get("tag") != f"v{component.get('version')}":
+        failures.append(_failure("component_tag_invalid", f"{name} tag must match its exact version"))
+    if not isinstance(component.get("source_commit"), str) or not COMMIT.fullmatch(component["source_commit"]):
+        failures.append(_failure("component_commit_invalid", f"{name} needs a 40-character source commit"))
+    repository = component.get("repository")
+    if not isinstance(repository, str) or not repository.startswith("https://github.com/wesleysimplicio/"):
+        failures.append(_failure("component_repository_invalid", f"{name} repository is not approved"))
+    schemas = component.get("schemas")
+    if not isinstance(schemas, list) or not schemas or any(not isinstance(item, str) or not item for item in schemas):
+        failures.append(_failure("component_schemas_invalid", f"{name} needs explicit schema capabilities"))
+    entrypoint = component.get("entrypoint")
+    if not isinstance(entrypoint, str) or not entrypoint.startswith("/"):
+        failures.append(_failure("component_entrypoint_invalid", f"{name} entrypoint must be absolute"))
+    compatibility = component.get("compatible_runtime")
+    if not isinstance(compatibility, str) or not compatibility:
+        failures.append(_failure("component_compatibility_invalid", f"{name} needs an explicit Runtime compatibility range"))
+    skill_digest = component.get("skill_bundle_sha256")
+    if not isinstance(skill_digest, str) or not SHA256.fullmatch(skill_digest):
+        failures.append(_failure("component_skill_digest_invalid", f"{name} needs a skill or script bundle digest"))
+    if component.get("revoked") is not False:
+        failures.append(_failure("component_revoked", f"{name} must not be revoked"))
+    return name
+
+
+def verify_manifest(document: Any, bundle_dir: Path | None = None) -> dict[str, Any]:
+    failures: list[dict[str, str]] = []
+    try:
+        root = _object(document, "manifest_invalid")
+    except ValueError:
+        return {"schema": REPORT_SCHEMA, "ready": False, "failures": [_failure("manifest_invalid", "manifest must be an object")]}
+
+    if root.get("schema") != SCHEMA:
+        failures.append(_failure("schema_invalid", f"expected {SCHEMA}"))
+    public_key = root.get("signing_pubkey")
+    if not isinstance(public_key, str) or not public_key:
+        failures.append(_failure("signing_key_missing", "signing_pubkey is required"))
+
+    composition = root.get("composition")
+    if not isinstance(composition, dict):
+        failures.append(_failure("composition_invalid", "composition must be an object"))
+    else:
+        digest = composition.get("runtime_release_manifest_sha256")
+        if not isinstance(digest, str) or not SHA256.fullmatch(digest):
+            failures.append(_failure("runtime_manifest_digest_invalid", "Runtime release manifest digest is required"))
+        lock_digest = composition.get("composition_lock_sha256")
+        if not isinstance(lock_digest, str) or not SHA256.fullmatch(lock_digest):
+            failures.append(_failure("composition_lock_invalid", "promoted composition lock digest is required"))
+        if composition.get("runtime_slot") == composition.get("operator_slot"):
+            failures.append(_failure("slot_identity_invalid", "Runtime and operator slots must be distinct"))
+        for field in ("runtime_slot", "operator_slot"):
+            value = composition.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(_failure("composition_field_missing", f"{field} is required"))
+        for field in (
+            "operator_bundle_sha256",
+            "host_plugin_bundle_sha256",
+            "rollback_composition_sha256",
+        ):
+            value = composition.get(field)
+            if not isinstance(value, str) or not SHA256.fullmatch(value):
+                failures.append(_failure("composition_digest_invalid", f"{field} is required"))
+
+    components = root.get("components")
+    names: list[str] = []
+    if not isinstance(components, list):
+        failures.append(_failure("components_invalid", "components must be an array"))
+    else:
+        for component in components:
+            name = _validate_component(component, failures)
+            if name is not None:
+                names.append(name)
+        if len(names) != len(set(names)):
+            failures.append(_failure("component_duplicate", "component names must be unique"))
+        missing = sorted(REQUIRED_COMPONENTS - set(names))
+        extra = sorted(set(names) - REQUIRED_COMPONENTS)
+        if missing:
+            failures.append(_failure("component_missing", ", ".join(missing)))
+        if extra:
+            failures.append(_failure("component_unknown", ", ".join(extra)))
+
+    policies = root.get("policies")
+    if not isinstance(policies, dict):
+        failures.append(_failure("policies_invalid", "policies must be an object"))
+    else:
+        for field, expected in REQUIRED_POLICIES.items():
+            if policies.get(field) is not expected:
+                failures.append(_failure("policy_invalid", f"{field} must be {str(expected).lower()}"))
+
+    artifacts = root.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        failures.append(_failure("artifacts_invalid", "at least one signed artifact is required"))
+    else:
+        seen: set[str] = set()
+        for index, raw in enumerate(artifacts):
+            if not isinstance(raw, dict):
+                failures.append(_failure("artifact_invalid", f"artifact {index} must be an object"))
+                continue
+            component = raw.get("component")
+            if component not in REQUIRED_COMPONENTS:
+                failures.append(_failure("artifact_component_invalid", f"artifact {index} component is invalid"))
+            platform = raw.get("platform")
+            if not _safe_filename(platform):
+                failures.append(_failure("artifact_platform_invalid", f"artifact {index} platform is invalid"))
+            python_abi = raw.get("python_abi")
+            if python_abi is not None and not _safe_filename(python_abi):
+                failures.append(_failure("artifact_python_abi_invalid", f"artifact {index} Python ABI is invalid"))
+            filename = raw.get("filename")
+            signature_file = raw.get("signature_file")
+            sbom_file = raw.get("sbom_file")
+            provenance_file = raw.get("provenance_file")
+            filenames = (filename, signature_file, sbom_file, provenance_file)
+            if any(not _safe_filename(item) for item in filenames):
+                failures.append(_failure("artifact_filename_invalid", f"artifact {index} has an unsafe filename"))
+                continue
+            if len(set(filenames)) != len(filenames) or any(item in seen for item in filenames):
+                failures.append(_failure("artifact_filename_duplicate", f"artifact {index} reuses a filename"))
+            seen.update(filenames)
+            digest = raw.get("sha256")
+            signature = raw.get("signature")
+            if not isinstance(digest, str) or not SHA256.fullmatch(digest):
+                failures.append(_failure("artifact_digest_invalid", f"artifact {index} digest is invalid"))
+                continue
+            if not isinstance(signature, str) or not signature.startswith("ed25519:"):
+                failures.append(_failure("artifact_signature_invalid", f"artifact {index} signature is missing"))
+            elif isinstance(public_key, str):
+                try:
+                    if not verify_signature_for_digest(public_key, signature, digest):
+                        failures.append(_failure("artifact_signature_invalid", f"artifact {index} signature does not verify"))
+                except ValueError:
+                    failures.append(_failure("artifact_signature_invalid", f"artifact {index} signature encoding is invalid"))
+            if bundle_dir is not None:
+                for item in filenames:
+                    path = bundle_dir / item
+                    if path.is_symlink() or not path.is_file():
+                        failures.append(_failure("artifact_file_missing", str(item)))
+                payload = bundle_dir / filename
+                if payload.is_file() and not payload.is_symlink() and _sha256_file(payload) != digest:
+                    failures.append(_failure("artifact_digest_mismatch", str(filename)))
+                signature_path = bundle_dir / signature_file
+                if signature_path.is_file() and not signature_path.is_symlink():
+                    try:
+                        sidecar = signature_path.read_text(encoding="utf-8").strip()
+                    except (OSError, UnicodeError):
+                        sidecar = ""
+                    if sidecar != signature:
+                        failures.append(_failure("signature_sidecar_mismatch", str(signature_file)))
+
+        missing_artifacts = sorted(REQUIRED_COMPONENTS - {item.get("component") for item in artifacts if isinstance(item, dict)})
+        if missing_artifacts:
+            failures.append(_failure("component_artifact_missing", ", ".join(missing_artifacts)))
+        if bundle_dir is not None and bundle_dir.is_dir():
+            actual = {item.name for item in bundle_dir.iterdir() if item.is_file() or item.is_symlink()}
+            extra = sorted(actual - seen)
+            if extra:
+                failures.append(_failure("bundle_file_unexpected", ", ".join(extra)))
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "ready": not failures,
+        "components_verified": sorted(set(names)),
+        "artifacts_verified": len(artifacts) if isinstance(artifacts, list) and not failures else 0,
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--bundle", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        document = json.loads(args.manifest.read_text(encoding="utf-8"))
+        report = verify_manifest(document, args.bundle)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        report = {"schema": REPORT_SCHEMA, "ready": False, "failures": [_failure("manifest_read_failed", str(exc))]}
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_operator_bundle_manifest.py
+++ b/tests/test_operator_bundle_manifest.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import verify_operator_bundle_manifest as verifier
+
+PUBLIC_KEY = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok="
+SIGNATURE = "ed25519:/Tt+wpY4VedOmsOJRPAaAz470OfD4QprLGnTed7QGkkWgyqLoeg2U/dr6PD3EWl4rvHLiok2UWALeDBvG9KmCQ=="
+DIGEST = "12681adb6fa49bc2a5d39f8feca42baabe5d97b61cfdf40a5d452d890a8be83a"
+
+
+def valid_manifest() -> dict:
+    components = []
+    artifacts = []
+    for index, name in enumerate(sorted(verifier.REQUIRED_COMPONENTS)):
+        version = "3.8.41" if name == "simplicio-runtime" else "1.2.3"
+        components.append({
+            "name": name,
+            "version": version,
+            "tag": f"v{version}",
+            "source_commit": f"{index + 1:040x}",
+            "repository": f"https://github.com/wesleysimplicio/{name}",
+            "schemas": [f"{name}.contract/v1"],
+            "entrypoint": f"/managed/operators/slot-b/{name}",
+            "compatible_runtime": ">=3.8.41,<3.9.0",
+            "skill_bundle_sha256": f"{index + 10:064x}",
+            "revoked": False,
+        })
+        artifacts.append({
+            "component": name,
+            "platform": "any",
+            "python_abi": "cp311",
+            "filename": f"{name}.bin",
+            "sha256": DIGEST,
+            "signature": SIGNATURE,
+            "signature_file": f"{name}.bin.sig",
+            "sbom_file": f"{name}.bin.spdx.json",
+            "provenance_file": f"{name}.bin.provenance.json",
+        })
+    return {
+        "schema": verifier.SCHEMA,
+        "signing_pubkey": PUBLIC_KEY,
+        "composition": {
+            "runtime_release_manifest_sha256": "a" * 64,
+            "composition_lock_sha256": "b" * 64,
+            "runtime_slot": "runtime-slot-b",
+            "operator_slot": "operator-slot-b",
+            "operator_bundle_sha256": "c" * 64,
+            "host_plugin_bundle_sha256": "d" * 64,
+            "rollback_composition_sha256": "e" * 64,
+        },
+        "components": components,
+        "artifacts": artifacts,
+        "policies": dict(verifier.REQUIRED_POLICIES),
+    }
+
+
+def failure_codes(report: dict) -> set[str]:
+    return {item["code"] for item in report["failures"]}
+
+
+def test_valid_signed_manifest_is_ready() -> None:
+    report = verifier.verify_manifest(valid_manifest())
+    assert report["ready"] is True
+    assert report["components_verified"] == sorted(verifier.REQUIRED_COMPONENTS)
+
+
+def test_unsigned_or_incomplete_component_fails_closed() -> None:
+    manifest = valid_manifest()
+    manifest["components"].pop()
+    manifest["artifacts"][0]["signature"] = "unsigned"
+    report = verifier.verify_manifest(manifest)
+    assert report["ready"] is False
+    assert {"component_missing", "artifact_signature_invalid"} <= failure_codes(report)
+
+
+def test_security_policies_cannot_be_relaxed() -> None:
+    manifest = valid_manifest()
+    manifest["policies"]["native_loop_default"] = False
+    manifest["policies"]["host_plugin_consent_required"] = False
+    manifest["policies"]["hooks_provision_packages"] = True
+    report = verifier.verify_manifest(manifest)
+    assert report["ready"] is False
+    assert "policy_invalid" in failure_codes(report)
+
+
+def test_bundle_rejects_missing_extra_and_symlink_files(tmp_path: Path) -> None:
+    manifest = valid_manifest()
+    first = manifest["artifacts"][0]
+    (tmp_path / first["filename"]).symlink_to(tmp_path / "outside")
+    (tmp_path / "unexpected.whl").write_bytes(b"extra")
+    report = verifier.verify_manifest(copy.deepcopy(manifest), tmp_path)
+    assert report["ready"] is False
+    assert {"artifact_file_missing", "bundle_file_unexpected"} <= failure_codes(report)
+
+
+def test_component_entrypoints_must_be_absolute() -> None:
+    manifest = valid_manifest()
+    manifest["components"][0]["entrypoint"] = "ambient/simplicio-loop"
+    report = verifier.verify_manifest(manifest)
+    assert report["ready"] is False
+    assert "component_entrypoint_invalid" in failure_codes(report)


### PR DESCRIPTION
Refs #322. Adds the public operator bundle manifest verifier, adversarial regression tests, and the manual release runbook gate. The manifest contract rejects unsigned, incomplete, incompatible, symlinked, or drifted bundles. This does not close #322 because immutable upstream Loop and Mapper release evidence and multi-platform installed conformance are still required.