### PR TITLE
Make Mapper bootstrap recovery actionable

### DIFF
--- a/plugins/simplicio/hooks/mapper_context.py
+++ b/plugins/simplicio/hooks/mapper_context.py
@@ -395,6 +395,31 @@ def _emit_context(event: str, body: str | None) -> None:
     print(json.dumps({"hookSpecificOutput": hook_output}, separators=(",", ":")))
 
 
+def _recovery_command(payload: dict[str, Any]) -> str | None:
+    """Recognize only explicit non-project recovery commands.
+
+    Hooks must not infer intent from arbitrary prose: a normal project action
+    remains denied when the Mapper is unavailable. These commands only expose
+    static guidance so a user can recover the managed installation or inspect
+    help without an MCP/provider dependency.
+    """
+    for key in ("command", "command_name", "action"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip().lower() in {"help", "login", "repair"}:
+            return value.strip().lower()
+    return None
+
+
+def _emit_recovery(event: str, command: str) -> None:
+    _emit_context(
+        event,
+        "Simplicio Mapper is unavailable for this project. "
+        f"The explicit '{command}' recovery action may continue without MCP context. "
+        "Run the managed Simplicio installer or repair command outside this hook, "
+        "then start a new session; this hook never installs, downloads, or changes hosts.",
+    )
+
+
 def _fail(event: str, reason: str) -> None:
     print(json.dumps({
         "hookSpecificOutput": {
@@ -428,6 +453,11 @@ def main() -> int:
     except SystemExit:
         raise
     except Exception as error:
+        if "payload" in locals():
+            command = _recovery_command(payload)
+            if command is not None:
+                _emit_recovery(event if "event" in locals() else "", command)
+                return 0
         _fail(event if "event" in locals() else "", _safe_reason(error))
     return 2
 

--- a/tests/test_claude_mapper_only_hooks.py
+++ b/tests/test_claude_mapper_only_hooks.py
@@ -174,6 +174,24 @@ def test_mapper_failure_is_not_a_silent_native_bypass(tmp_path: Path) -> None:
     assert "Mapper obrigatório" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
+def test_explicit_recovery_commands_get_static_guidance_without_bypass(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "simplicio"
+    _fake_mapper(runtime, runtime.with_name("mapper.log"))
+    result = _run_hook(
+        "UserPromptSubmit",
+        repo,
+        runtime,
+        payload_extra={"command": "repair"},
+        extra_env={"FAKE_MAPPER_FAIL": "1", "PATH": str(tmp_path / "empty-path")},
+    )
+    assert result.returncode == 0
+    hook_output = json.loads(result.stdout)["hookSpecificOutput"]
+    assert "repair" in hook_output["additionalContext"]
+    assert "permissionDecision" not in hook_output
+
+
 def test_python_mapper_is_a_mapper_only_runtime_failover(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Related: #337

## Summary
- allow only explicit `help`, `login`, and `repair` recovery commands to receive static guidance when Mapper is unavailable
- keep ordinary project actions denied
- keep installation, downloads, MCP calls, and host changes out of the hook

## Quality evidence
- Focused local test subset: `11 passed`
- Regression covers recovery guidance and confirms no permission bypass
- Runtime/Mapper-only policy remains unchanged for normal execution