### PR TITLE
Complete Hermes measurement cache-state contract

### DIFF
--- a/plugins/simplicio-hermes/hermes_plugin.py
+++ b/plugins/simplicio-hermes/hermes_plugin.py
@@ -47,7 +47,9 @@ _BRIDGE_TOOLS = frozenset({
 })
 
 
-_CACHE_STATUSES = frozenset({"hit", "miss", "unknown", "unsupported", "not_collected", "failed"})
+_CACHE_STATUSES = frozenset({
+    "hit", "miss", "unknown", "unsupported", "not_reported", "not_collected", "failed",
+})
 _MEASUREMENT_MODES = frozenset({"normal", "strict", "benchmark"})
 _STABLE_CORRELATION_IDS = frozenset({"host_session_id", "turn_id", "api_request_id"})
 
@@ -466,9 +468,7 @@ def _python_receipt(arguments: dict[str, Any], data: bytes, resolution: MapperRe
         "project_map_markdown": data.decode("utf-8"),
     }, ensure_ascii=False, separators=(",", ":"))
     raw = content.encode("utf-8")
-    mapper_cache_status = mapper_cache_status if mapper_cache_status in {
-        "hit", "miss", "unknown", "unsupported", "not_collected", "failed"
-    } else "unknown"
+    mapper_cache_status = mapper_cache_status if mapper_cache_status in _CACHE_STATUSES else "unknown"
     mapper_cache = {
         "status": mapper_cache_status,
         "map_build_count": max(0, int(map_build_count)),

--- a/tests/test_hermes_native_plugin.py
+++ b/tests/test_hermes_native_plugin.py
@@ -495,6 +495,25 @@ def test_mapper_cache_metadata_never_infers_provider_cache_status():
     }
 
 
+def test_not_reported_cache_status_is_preserved_without_becoming_unknown():
+    adapter = load_adapter()
+    assert adapter._provider_cache_status(
+        {"provider_prompt_cache_status": "not_reported"}, {},
+    ) == "not_reported"
+    arguments = adapter._arguments(
+        "s", turn_id="t", api_request_id="a", logical_request_id="l",
+        attempt_id="attempt", provider="p", model="m", cwd=str(ROOT),
+    )
+    final = adapter._final_usage_receipt(
+        arguments, {"receipt": mapper_receipt(arguments)},
+        {"provider_prompt_cache_status": "not_reported"},
+        {"input_tokens": 0, "output_tokens": 0}, "succeeded", "completed", None,
+    )
+    assert final["provider_prompt_cache_status"] == "not_reported"
+    assert final["usage"]["input_tokens"] == 0
+    assert final["usage"]["output_tokens"] == 0
+
+
 def test_local_mapper_hit_with_absent_provider_usage_is_explicitly_unmeasured():
     adapter, bridge, context = setup_plugin()
     bridge.call = lambda tool, arguments: (


### PR DESCRIPTION
Related: #335

## Summary
- add the explicit `not_reported` cache state to the shared receipt vocabulary
- preserve provider-reported `not_reported` instead of collapsing it to `unknown`
- cover numeric zero usage values alongside the new state

## Quality evidence
- Focused local audit: `47 passed, 1 skipped`
- The skip is the existing installed-Hermes integration check requiring `HERMES_SOURCE`
- Existing endpoint/API-mode provenance, stable IDs, strict measurement, and run-outcome separation tests remain green