### PR TITLE
Document the Desktop-first onboarding path

### DIFF
--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -135,7 +135,8 @@ A successful response contains the tool definitions. A `login required` error me
 
 The official PyPI bootstrap verifies the binary checksum, Ed25519 signature,
 and release-manifest contract, then requires active login. Codex MCP registration
-and routing hooks are opt-in; enable them explicitly after `simplicio install`.
+and routing hooks are registered by the installer for supported hosts;
+review the JSON receipt and any requested consent before relying on the integration.
 Other MCP clients can use the local STDIO entry above without copying tokens.
 
 A quick PyPI bootstrap is:

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -62,7 +62,7 @@ In Claude Code:
 ```
 
 The main `simplicio` package bootstraps the verified Runtime automatically and
-installs mandatory Mapper-only Claude hooks. The hooks keep the project map in
+installs mandatory Mapper-only Claude hooks. Complete Runtime installation before login, restart Claude after registration, and make a harmless first Mapper/MCP call before project work. The hooks keep the project map in
 `.simplicio/hook-context/`, reuse it while the project generation is unchanged,
 and refresh it after a visible project change. They call the Runtime map
 operation first and use the bundled Mapper fallback already maintained inside

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ optional, not required.**
 > **🔥 Save up to 96% of tokens on controlled workloads.**
 > Simplicio records the baseline and proof type; the actual result depends on the task and model.
 
+## 🖥️ Desktop-first setup
+
+The public Desktop shell is the preferred product journey, but a signed
+downloadable Desktop package is not part of the current release yet. Until that
+package is published, use the verified CLI bootstrap below; it is the supported
+way to install the Runtime today.
+
+When a signed Desktop package is available, the first-run order is:
+
+1. Open Desktop and let it install its bundled, verified Runtime before login.
+2. Complete Google login and confirm active identity and entitlement in the app.
+3. Review and consent to the exact host-integration plan before any client files
+   are changed.
+4. Restart open MCP clients so they reload the registered command and hooks.
+5. Make one harmless tools/list or simplicio_map call and confirm the live
+   schema/receipt before starting project work.
+
+Login is never a substitute for installation, and a successful process exit is
+not proof that a host is configured. If the Desktop package is unavailable, the
+CLI path below follows the same Runtime, authentication, consent, reload, and
+first-call contract.
+
 ## 🚀 Installation
 
 ### Desktop source (public foundation)


### PR DESCRIPTION
Related: #336

## Summary
- document the current Desktop package availability truthfully
- define the first-run order: Runtime install, login, consent, client reload, first live MCP call
- reconcile the MCP and plugin guides so automatic registration is not described as opt-in

## Quality evidence
- Documentation-only change
- Cross-checked against the current Desktop README and Runtime ownership contract
- No unsupported claim that a signed downloadable Desktop artifact is already published