### PR TITLE
Gate login on complete managed Runtime evidence

### DIFF
--- a/apps/desktop/src/setup_flow.test.ts
+++ b/apps/desktop/src/setup_flow.test.ts
@@ -26,6 +26,19 @@ describe("guided setup evidence", () => {
     expect(canConfigureRuntime({ ...snapshot, runtime: { ...snapshot.runtime, transport: "unavailable" } })).toBe(false);
   });
 
+  it("does not treat a healthy transport as a complete managed Runtime", () => {
+    const snapshot = createDemoSnapshot("signed_out");
+    expect(runtimeIsValid({ ...snapshot, runtime: {
+      ...snapshot.runtime, deterministic: { ...snapshot.runtime.deterministic, ready: false },
+    } })).toBe(false);
+    expect(runtimeIsValid({ ...snapshot, runtime: {
+      ...snapshot.runtime, deterministic: { ...snapshot.runtime.deterministic, hookContext: "legacy" as "receipt_only" },
+    } })).toBe(false);
+    expect(runtimeIsValid({ ...snapshot, runtime: {
+      ...snapshot.runtime, optionalFast: { ...snapshot.runtime.optionalFast, hookInjected: true },
+    } })).toBe(false);
+  });
+
   it("uses only a reachable healthy Runtime to skip core installation", () => {
     const snapshot = createDemoSnapshot("signed_out");
     expect(runtimeIsValid(snapshot)).toBe(true);

--- a/apps/desktop/src/setup_flow.ts
+++ b/apps/desktop/src/setup_flow.ts
@@ -23,6 +23,14 @@ export function canConfigureRuntime(snapshot: DesktopSnapshot): boolean {
 }
 
 export function runtimeIsValid(snapshot: DesktopSnapshot): boolean {
-  return snapshot.runtime.transport !== "unavailable"
-    && snapshot.runtime.state === "healthy";
+  const runtime = snapshot.runtime;
+  return runtime.transport !== "unavailable"
+    && runtime.state === "healthy"
+    && runtime.deterministic.ready
+    && runtime.deterministic.mapper === "canonical"
+    && runtime.deterministic.mapCache === "generation_scoped"
+    && runtime.deterministic.hookContext === "receipt_only"
+    && runtime.optionalFast.required === false
+    && runtime.optionalFast.hookInjected === false
+    && runtime.optionalFast.status === "not_required";
 }


### PR DESCRIPTION
Related: #340

## Summary
- make the Desktop entry gate require the complete deterministic Runtime contract, not only healthy transport
- reject snapshots that lack canonical Mapper/generation-scoped hook evidence or accidentally enable Fast in hooks
- add regressions for incomplete healthy-looking snapshots

## Quality evidence
- Focused Vitest contract coverage added in `setup_flow.test.ts`
- Existing entry E2E already proves installation occurs once before login and host plugins remain untouched