### PR TITLE
Verify logout and relogin preserve Runtime state

### DIFF
--- a/apps/desktop/e2e/entry-state-machine.spec.ts
+++ b/apps/desktop/e2e/entry-state-machine.spec.ts
@@ -169,3 +169,20 @@ test("logout returns only to login and does not reinstall Runtime or mutate plug
   expect(count(calls, "desktop_login")).toBe(0);
   expectNoHostPluginEffects(calls);
 });
+
+
+test("logout and relogin preserve the installed Runtime without reinstalling", async ({ page }) => {
+  await mockEntryFlow(page, "active");
+  await page.goto("/?view=settings");
+  await page.getByRole("button", { name: "Sair da conta", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Começar", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Começar", exact: true }).click();
+  await page.getByRole("button", { name: "Continuar com Google", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Simplicio", exact: true })).toBeVisible();
+
+  const calls = await entryCalls(page);
+  expect(count(calls, "desktop_logout")).toBe(1);
+  expect(count(calls, "desktop_login")).toBe(1);
+  expect(count(calls, "desktop_install_runtime")).toBe(0);
+  expectNoHostPluginEffects(calls);
+});


### PR DESCRIPTION
Related: #341

## Summary
- add a browser state-machine regression for logout followed by relogin
- prove the installed managed Runtime is reused
- prove host-plugin operations are not repeated by auth lifecycle changes

## Quality evidence
- Existing entry E2E fixture runs the actual app routing and bridge calls
- New assertion requires exactly one logout and one login with zero Runtime installs