### PR TITLE
Fail closed before host integration effects

### DIFF
--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -10,6 +10,7 @@ import {
   createPreviewHostPluginResult,
   createPreviewIntegrationPlan,
   parseHostPluginOperationResult,
+  isHostPluginDigest,
   parseIntegrationPlan,
   type HostPluginOperationResult,
   type IntegrationPlan,
@@ -221,12 +222,14 @@ export async function exportDesktopTokenReport(reportHash: string, format: "json
 }
 
 export async function applyDesktopHostPlugins(planDigest: string): Promise<HostPluginOperationResult> {
+  if (!isHostPluginDigest(planDigest)) throw new Error("host_plugin_plan_digest_invalid");
   if (!isTauri()) return createPreviewHostPluginResult(planDigest);
   // A side effect is never timed out or replayed by the frontend.
   return parseHostPluginOperationResult(await invoke<unknown>("desktop_apply_host_plugins", { planDigest }), "apply");
 }
 
 export async function reconcileDesktopHostPlugins(receiptId: string): Promise<HostPluginOperationResult> {
+  if (!isHostPluginDigest(receiptId)) throw new Error("host_plugin_receipt_id_invalid");
   if (!isTauri()) return createPreviewHostPluginResult(receiptId, "reconcile");
   // Reconciliation is an explicit Runtime operation, never part of snapshot refresh.
   return parseHostPluginOperationResult(await invoke<unknown>("desktop_reconcile_host_plugins", { receiptId }), "reconcile");

--- a/apps/desktop/src/integration_setup.test.ts
+++ b/apps/desktop/src/integration_setup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   HOST_PLUGIN_IDS,
   createPreviewIntegrationPlan,
+  isHostPluginDigest,
   hostPluginOutcomeLabel,
   integrationChangeLabel,
   parseHostPluginOperationResult,
@@ -59,6 +60,11 @@ function runtimeSnapshot(state: "complete" | "partial" | "requires_reconcile" = 
 }
 
 describe("Runtime host-plugin plan review", () => {
+  it("accepts only opaque SHA-256 identifiers for effect commands", () => {
+    expect(isHostPluginDigest(digest("a"))).toBe(true);
+    expect(isHostPluginDigest("sha256:private")).toBe(false);
+    expect(isHostPluginDigest("/Users/private/receipt")).toBe(false);
+  });
   it("requires and shows exactly the eight canonical native/plugin hosts", () => {
     const result = parseIntegrationPlan(runtimePlan());
     expect(result.hosts.map(({ host }) => host)).toEqual(HOST_PLUGIN_IDS);

--- a/apps/desktop/src/integration_setup.ts
+++ b/apps/desktop/src/integration_setup.ts
@@ -50,6 +50,10 @@ const FAILURE_CODES = new Set<string>([
 const VERIFICATIONS = new Set<string>(["none", "manager_version", "installed_tree", "installed_tree_and_manager"]);
 const RECONCILE = new Set<string>(["committed", "not_applied", "partial", "drifted", "ambiguous", "not_applicable"]);
 
+export function isHostPluginDigest(value: unknown): value is string {
+  return typeof value === "string" && DIGEST.test(value);
+}
+
 export interface IntegrationPlanHost {
   host: HostPluginId;
   mode: HostPluginMode;


### PR DESCRIPTION
Related: #343

## Summary
- centralize opaque SHA-256 validation for host-plugin plan and receipt identifiers
- reject invalid identifiers in the Desktop bridge before any native IPC effect
- cover paths and malformed values so local paths cannot be treated as receipts

## Quality evidence
- Focused integration contract tests cover the eight-host plan, redaction, terminal receipts, reconciliation, and the new bridge identifier guard
- Native Runtime remains the owner of detection, ownership, merge, readback, and repair effects