### PR TITLE
Keep preview data out of live menu evidence

### DIFF
--- a/apps/desktop/src/workbench.test.ts
+++ b/apps/desktop/src/workbench.test.ts
@@ -149,6 +149,8 @@ describe("workbench navigation and evidence", () => {
     snapshot.savings.proofKind = "mixed";
     expect(runtimeSummary(snapshot).measuredSavings).toBeNull();
     snapshot.savings.proofKind = "measured"; snapshot.savings.ledgerStatus = "valid";
+    expect(runtimeSummary(snapshot).measuredSavings).toBeNull();
+    snapshot.source = "runtime";
     expect(runtimeSummary(snapshot).measuredSavings).toBe(snapshot.savings.monthTokens);
   });
 });

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -127,7 +127,9 @@ export function runtimeSummary(snapshot: DesktopSnapshot) {
     healthy: snapshot.runtime.state === "healthy",
     connected: providers.filter((provider) => provider.state === "connected").length,
     installed: providers.filter((provider) => provider.installState === "installed").length,
-    measuredSavings: snapshot.savings.proofKind === "measured" && snapshot.savings.ledgerStatus === "valid"
+    measuredSavings: snapshot.source === "runtime"
+      && snapshot.savings.proofKind === "measured"
+      && snapshot.savings.ledgerStatus === "valid"
       ? snapshot.savings.monthTokens : null,
   };
 }


### PR DESCRIPTION
Related: #344

## Summary
- require a Runtime-sourced snapshot before showing token savings as live evidence
- keep the visible Desktop navigation driven by the canonical snapshot/projection path
- add a regression distinguishing browser preview data from live Runtime data

## Quality evidence
- Focused workbench Vitest coverage remains deterministic
- Preview surfaces stay explicitly labeled and action controls remain disabled until Runtime capabilities are present