### PR TITLE
docs: repair translated README relative links

### DIFF
--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -1,14 +1,14 @@
 # 🔥 سيمپليسيو — العميل الذكي الذي يُوَفّرُ لَكَ حَتّى 96% مِنَ التوكينز
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="سيمپليسيو — عميل برمجة ذكي" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="سيمپليسيو — عميل برمجة ذكي" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="أحدث إصدار"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="النجوم"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="التنزيلات"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="الرخصة"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="الرخصة"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 اللغات:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 الرخصة
 
 مملوكة. الملف الثنائي مجاني للتنزيل والاستخدام. ميزات الذكاء الاصطناعي مجانية خلال
-النسخة التجريبية العامة. انظر [LICENSE](LICENSE).
+النسخة التجريبية العامة. انظر [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.ar-SA.md
+++ b/READMEs/README.ar-SA.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="أحدث إصدار"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="النجوم"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="التنزيلات"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="الرخصة"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="الرخصة"></a>
 </p>
 
 <p align="center">
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 الرخصة
 
 مملوكة. الملف الثنائي مجاني للتنزيل والاستخدام. ميزات الذكاء الاصطناعي مجانية خلال
-النسخة التجريبية العامة. انظر [LICENSE](../LICENSE).
+النسخة التجريبية العامة. انظر [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Última versión"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrellas"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Descargas"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licencia"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licencia"></a>
 </p>
 
 <p align="center">
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Licencia
 
 Propietaria. El binario es gratuito para descargar y usar. Las funciones de IA son gratuitas durante la
-beta pública. Consulta [LICENSE](../LICENSE).
+beta pública. Consulta [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — El agente de IA que AHORRA HASTA EL 96% DE TUS TOKENS
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — agente de IA para programación" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — agente de IA para programación" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Última versión"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrellas"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Descargas"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licencia"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licencia"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Idiomas:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Licencia
 
 Propietaria. El binario es gratuito para descargar y usar. Las funciones de IA son gratuitas durante la
-beta pública. Consulta [LICENSE](LICENSE).
+beta pública. Consulta [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — L'agent IA qui économise JUSQU'À 96 % DE VOS TOKENS
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Langues :</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Licence
 
 Propriétaire. Binaire gratuit à télécharger et à utiliser. Fonctionnalités IA gratuites pendant la
-bêta publique. Voir [LICENSE](LICENSE).
+bêta publique. Voir [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.fr-FR.md
+++ b/READMEs/README.fr-FR.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Licence
 
 Propriétaire. Binaire gratuit à télécharger et à utiliser. Fonctionnalités IA gratuites pendant la
-bêta publique. Voir [LICENSE](../LICENSE).
+bêta publique. Voir [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="גרסה אחרונה"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="כוכבים"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="הורדות"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="רישיון"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="רישיון"></a>
 </p>
 
 <p align="center">
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 רישיון
 
 קנייני. הבינארי חופשי להורדה ולשימוש. תכונות AI בחינם במהלך
-הבטא הציבורית. ראה [LICENSE](../LICENSE).
+הבטא הציבורית. ראה [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.he-IL.md
+++ b/READMEs/README.he-IL.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — סוכן הבינה המלאכותית שחוסך עד 96% מהטוקנים שלך
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — סוכן קידוד בינה מלאכותית" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — סוכן קידוד בינה מלאכותית" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="גרסה אחרונה"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="כוכבים"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="הורדות"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="רישיון"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="רישיון"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 שפות:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 רישיון
 
 קנייני. הבינארי חופשי להורדה ולשימוש. תכונות AI בחינם במהלך
-הבטא הציבורית. ראה [LICENSE](LICENSE).
+הבטא הציבורית. ראה [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — AI एजेंट जो आपके 96% टोकन बचाता है
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI कोडिंग एजेंट" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI कोडिंग एजेंट" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 भाषाएँ:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 लाइसेंस
 
 Proprietary. बाइनरी डाउनलोड और उपयोग करने के लिए मुफ्त है। AI सुविधाएँ
-सार्वजनिक बीटा के दौरान मुफ्त हैं। [LICENSE](LICENSE) देखें।
+सार्वजनिक बीटा के दौरान मुफ्त हैं। [LICENSE](../LICENSE) देखें।
 
 ---
 

--- a/READMEs/README.hi-IN.md
+++ b/READMEs/README.hi-IN.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -270,7 +270,7 @@ simplicio license status
 ## 📄 लाइसेंस
 
 Proprietary. बाइनरी डाउनलोड और उपयोग करने के लिए मुफ्त है। AI सुविधाएँ
-सार्वजनिक बीटा के दौरान मुफ्त हैं। [LICENSE](../LICENSE) देखें।
+सार्वजनिक बीटा के दौरान मुफ्त हैं। [LICENSE](../plugins/simplicio/LICENSE) देखें।
 
 ---
 

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — Agen AI yang MENGHEMAT HINGGA 96% TOKEN ANDA
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Rilis Terbaru"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Unduhan"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Lisensi"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Lisensi"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Bahasa:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Lisensi
 
 Kepemilikan. Biner gratis untuk diunduh dan digunakan. Fitur AI gratis selama
-beta publik. Lihat [LICENSE](LICENSE).
+beta publik. Lihat [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.id-ID.md
+++ b/READMEs/README.id-ID.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Rilis Terbaru"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Unduhan"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Lisensi"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Lisensi"></a>
 </p>
 
 <p align="center">
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Lisensi
 
 Kepemilikan. Biner gratis untuk diunduh dan digunakan. Fitur AI gratis selama
-beta publik. Lihat [LICENSE](../LICENSE).
+beta publik. Lihat [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Ultima versione"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stelle"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Download"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licenza"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licenza"></a>
 </p>
 
 <p align="center">
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Licenza
 
 Proprietaria. Binario gratuito da scaricare e utilizzare. Funzionalità AI gratuite durante la
-beta pubblica. Vedi [LICENSE](../LICENSE).
+beta pubblica. Vedi [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.it-IT.md
+++ b/READMEs/README.it-IT.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — L'Agente AI CHE RISPARMIA FINO AL 96% DEI TUOI TOKEN
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Ultima versione"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stelle"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Download"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licenza"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licenza"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Lingue:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Licenza
 
 Proprietaria. Binario gratuito da scaricare e utilizzare. Funzionalità AI gratuite durante la
-beta pubblica. Vedi [LICENSE](LICENSE).
+beta pubblica. Vedi [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新リリース"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="スター"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="ダウンロード数"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="ライセンス"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="ライセンス"></a>
 </p>
 
 <p align="center">
@@ -263,7 +263,7 @@ simplicio license status
 
 ## 📄 ライセンス
 
-Proprietary（プロプライエタリ）。バイナリは無料でダウンロードして使用できます。AI機能はパブリックベータ期間中無料です。詳しくは [LICENSE](../LICENSE) をご覧ください。
+Proprietary（プロプライエタリ）。バイナリは無料でダウンロードして使用できます。AI機能はパブリックベータ期間中無料です。詳しくは [LICENSE](../plugins/simplicio/LICENSE) をご覧ください。
 
 ---
 

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — トークンを最大96%削減するAIエージェント
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AIコーディングエージェント" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AIコーディングエージェント" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新リリース"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="スター"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="ダウンロード数"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="ライセンス"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="ライセンス"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 言語:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -263,7 +263,7 @@ simplicio license status
 
 ## 📄 ライセンス
 
-Proprietary（プロプライエタリ）。バイナリは無料でダウンロードして使用できます。AI機能はパブリックベータ期間中無料です。詳しくは [LICENSE](LICENSE) をご覧ください。
+Proprietary（プロプライエタリ）。バイナリは無料でダウンロードして使用できます。AI機能はパブリックベータ期間中無料です。詳しくは [LICENSE](../LICENSE) をご覧ください。
 
 ---
 

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -269,7 +269,7 @@ simplicio license status
 ## 📄 라이선스
 
 Proprietary. 바이너리는 무료로 다운로드 및 사용 가능합니다. AI 기능은
-공개 베타 기간 동안 무료입니다. [LICENSE](../LICENSE)를 참조하세요.
+공개 베타 기간 동안 무료입니다. [LICENSE](../plugins/simplicio/LICENSE)를 참조하세요.
 
 ---
 

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — 토큰을 최대 96%까지 절약하는 AI 에이전트
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI 코딩 에이전트" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI 코딩 에이전트" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 언어:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -269,7 +269,7 @@ simplicio license status
 ## 📄 라이선스
 
 Proprietary. 바이너리는 무료로 다운로드 및 사용 가능합니다. AI 기능은
-공개 베타 기간 동안 무료입니다. [LICENSE](LICENSE)를 참조하세요.
+공개 베타 기간 동안 무료입니다. [LICENSE](../LICENSE)를 참조하세요.
 
 ---
 

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — Ejen AI Yang MENJIMATKAN SEHINGGA 96% TOKEN ANDA
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — ejen pengekodan AI" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — ejen pengekodan AI" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=terkini" alt="Keluaran Terkini"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Muat Turun"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/licensi-Proprietary-red" alt="Lesen"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/licensi-Proprietary-red" alt="Lesen"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Bahasa:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Lesen
 
 Proprietari. Binari percuma untuk dimuat turun dan digunakan. Ciri AI percuma
-semasa beta awam. Lihat [LICENSE](LICENSE).
+semasa beta awam. Lihat [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.ms-MY.md
+++ b/READMEs/README.ms-MY.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=terkini" alt="Keluaran Terkini"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Bintang"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Muat Turun"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/licensi-Proprietary-red" alt="Lesen"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/licensi-Proprietary-red" alt="Lesen"></a>
 </p>
 
 <p align="center">
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Lesen
 
 Proprietari. Binari percuma untuk dimuat turun dan digunakan. Ciri AI percuma
-semasa beta awam. Lihat [LICENSE](../LICENSE).
+semasa beta awam. Lihat [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — Agent AI, KTÓRY OSZCZĘDZA DO 96% TWOICH TOKENÓW
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — agent AI do kodowania" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — agent AI do kodowania" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Języki:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Licencja
 
 Proprietary. Plik binarny darmowy do pobrania i użytku. Funkcje AI darmowe podczas
-publicznej bety. Zobacz [LICENSE](LICENSE).
+publicznej bety. Zobacz [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.pl-PL.md
+++ b/READMEs/README.pl-PL.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -271,7 +271,7 @@ simplicio license status
 ## 📄 Licencja
 
 Proprietary. Plik binarny darmowy do pobrania i użytku. Funkcje AI darmowe podczas
-publicznej bety. Zobacz [LICENSE](../LICENSE).
+publicznej bety. Zobacz [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Último Lançamento"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrelas"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licença"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licença"></a>
 </p>
 
 <p align="center">
@@ -256,7 +256,7 @@ simplicio license status
 ## 📄 Licença
 
 Proprietária. Binário gratuito para baixar e usar. Funcionalidades de IA gratuitas
-durante o beta público. Consulte [LICENSE](../LICENSE).
+durante o beta público. Consulte [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.pt-BR.md
+++ b/READMEs/README.pt-BR.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — O Agente de IA que ECONOMIZA ATÉ 96% DOS SEUS TOKENS
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — Agente de IA para codificação" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — Agente de IA para codificação" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Último Lançamento"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Estrelas"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licença"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="Licença"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Idiomas:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -256,7 +256,7 @@ simplicio license status
 ## 📄 Licença
 
 Proprietária. Binário gratuito para baixar e usar. Funcionalidades de IA gratuitas
-durante o beta público. Consulte [LICENSE](LICENSE).
+durante o beta público. Consulte [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Лицензия
 
 Проприетарная. Бинарный файл можно бесплатно скачивать и использовать. AI-функции бесплатны в период
-публичной беты. См. [LICENSE](../LICENSE).
+публичной беты. См. [LICENSE](../plugins/simplicio/LICENSE).
 
 ---
 

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — AI-агент, который ЭКОНОМИТ ДО 96% ВАШИХ ТОКЕНОВ
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI coding agent" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="Latest Release"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="Stars"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="Downloads"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="License"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 Языки:</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -272,7 +272,7 @@ simplicio license status
 ## 📄 Лицензия
 
 Проприетарная. Бинарный файл можно бесплатно скачивать и использовать. AI-функции бесплатны в период
-публичной беты. См. [LICENSE](LICENSE).
+публичной беты. См. [LICENSE](../LICENSE).
 
 ---
 

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -1,14 +1,14 @@
 # 🔥 Simplicio — 最多可节省高达 96% 的 Token 的 AI 智能体
 
 <p align="center">
-  <img src="assets/simplicio-hero.png" alt="Simplicio — AI 编程助手" width="920" />
+  <img src="../assets/simplicio-hero.png" alt="Simplicio — AI 编程助手" width="920" />
 </p>
 
 <p align="center">
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新版本"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="星标"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="下载量"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="许可证"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="许可证"></a>
 </p>
 
 <p align="center">
@@ -20,21 +20,21 @@
 
 <p align="center">
   <strong>🌍 语言：</strong><br>
-  <a href="README.md">🇬🇧 English</a> |
-  <a href="READMEs/README.pt-BR.md">🇧🇷 Português</a> |
-  <a href="READMEs/README.es-ES.md">🇪🇸 Español</a> |
-  <a href="READMEs/README.fr-FR.md">🇫🇷 Français</a> |
-  <a href="READMEs/README.ja-JP.md">🇯🇵 日本語</a> |
-  <a href="READMEs/README.ko-KR.md">🇰🇷 한국어</a> |
-  <a href="READMEs/README.zh-CN.md">🇨🇳 简体中文</a> |
-  <a href="READMEs/README.it-IT.md">🇮🇹 Italiano</a> |
-  <a href="READMEs/README.ru-RU.md">🇷🇺 Русский</a> |
-  <a href="READMEs/README.pl-PL.md">🇵🇱 Polski</a> |
-  <a href="READMEs/README.hi-IN.md">🇮🇳 हिन्दी</a> |
-  <a href="READMEs/README.ar-SA.md">🇸🇦 العربية</a> |
-  <a href="READMEs/README.he-IL.md">🇮🇱 עברית</a> |
-  <a href="READMEs/README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
-  <a href="READMEs/README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
+  <a href="../README.md">🇬🇧 English</a> |
+  <a href="README.pt-BR.md">🇧🇷 Português</a> |
+  <a href="README.es-ES.md">🇪🇸 Español</a> |
+  <a href="README.fr-FR.md">🇫🇷 Français</a> |
+  <a href="README.ja-JP.md">🇯🇵 日本語</a> |
+  <a href="README.ko-KR.md">🇰🇷 한국어</a> |
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a> |
+  <a href="README.it-IT.md">🇮🇹 Italiano</a> |
+  <a href="README.ru-RU.md">🇷🇺 Русский</a> |
+  <a href="README.pl-PL.md">🇵🇱 Polski</a> |
+  <a href="README.hi-IN.md">🇮🇳 हिन्दी</a> |
+  <a href="README.ar-SA.md">🇸🇦 العربية</a> |
+  <a href="README.he-IL.md">🇮🇱 עברית</a> |
+  <a href="README.ms-MY.md">🇲🇾 Bahasa Melayu</a> |
+  <a href="README.id-ID.md">🇮🇩 Bahasa Indonesia</a>
 </p>
 
 ---
@@ -269,7 +269,7 @@ simplicio license status
 ## 📄 许可证
 
 专有许可。二进制文件可免费下载和使用。AI 功能在公开
-公测期间免费。详见 [LICENSE](LICENSE)。
+公测期间免费。详见 [LICENSE](../LICENSE)。
 
 ---
 

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/wesleysimplicio/simplicio/releases/latest"><img src="https://img.shields.io/github/v/release/wesleysimplicio/simplicio?color=blue&label=latest" alt="最新版本"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/stargazers"><img src="https://img.shields.io/github/stars/wesleysimplicio/simplicio?style=social" alt="星标"></a>
   <a href="https://github.com/wesleysimplicio/simplicio/releases"><img src="https://img.shields.io/github/downloads/wesleysimplicio/simplicio/total?color=green" alt="下载量"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="许可证"></a>
+  <a href="../plugins/simplicio/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red" alt="许可证"></a>
 </p>
 
 <p align="center">
@@ -269,7 +269,7 @@ simplicio license status
 ## 📄 许可证
 
 专有许可。二进制文件可免费下载和使用。AI 功能在公开
-公测期间免费。详见 [LICENSE](../LICENSE)。
+公测期间免费。详见 [LICENSE](../plugins/simplicio/LICENSE)。
 
 ---
 


### PR DESCRIPTION
## Summary
- repair relative asset paths in all 14 translated READMEs
- repair language-switch links and root README references
- point license links to the existing canonical `plugins/simplicio/LICENSE`

Closes the concrete link-hygiene portion of #336. The root repository has no `LICENSE` file, so this PR does not invent one or point to a nonexistent target.

## Validation
- `simplicio-loop 3.43.7 task compile --input batch-004.loop.md`
- `simplicio-loop 3.43.7 task validate batch-004.loop.json`: 10 tasks, 0 errors, 0 warnings
- remote branch audit: 14/14 files updated; 0 remaining `src="assets/`, `href="LICENSE"`, `](LICENSE)`, `href="README.md"`, or `href="READMEs/` occurrences
- remote target audit: 14/14 language links, 14/14 assets, and 14/14 canonical license links resolve

The full #336 first-use MacBook evidence remains separate from this documentation hygiene patch.