### PR TITLE
docs: align public installation channel claims

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,12 @@
 # Installing Simplicio
 
-Simplicio is a terminal-based AI coding agent and runtime. The PyPI package
-installs a small launcher with no runtime package dependencies. The launcher
-resolves its versioned GitHub Release, verifies the signed manifest and target
-asset, and refuses to finish when the public release contract is incomplete.
+Simplicio is an intended Desktop-first product with a verified terminal-based
+AI coding agent and runtime. The signed Desktop package is not included in the
+current public release; until it is published, the CLI bootstrap below is the
+supported public installation path. The PyPI package installs a small launcher
+with no runtime package dependencies. The launcher resolves its versioned
+GitHub Release, verifies the signed manifest and target asset, and refuses to
+finish when the public release contract is incomplete.
 
 ## Quick Install
 
@@ -35,8 +38,10 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/wesleysimplicio/simplicio/master/install.ps1 | iex
 ```
 
-The PyPI package is the recommended bootstrap: it installs the launcher, verifies
-the signed SHA256/Ed25519 Runtime release, and installs the platform binary.
+Until a signed Desktop package is published, the verified CLI bootstrap is the
+current supported path. The PyPI package is one supported CLI bootstrap: it
+installs the launcher, verifies the signed SHA256/Ed25519 Runtime release, and
+installs the platform binary.
 If the Python script directory is not already on `PATH`, add it before running
 `simplicio install`.
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -93,9 +93,10 @@ revalidates the project generation and refreshes or reuses the Mapper cache.
 | `simplicio-prompt` | Tuple-Space/Yool prompt contract, fan-out commands, and opt-in prompt adapter | [`simplicio-prompt`](https://github.com/wesleysimplicio/simplicio-prompt) |
 | `simplicio-hermes` | Native `pre_llm_call` context preparation and post-call Runtime receipts for Hermes Agent | This repository |
 
-The Loop plugin is the default integration. Prompt remains a separate
-installable plugin so its hooks and commands do not create duplicate runtime
-activation or hidden provider calls.
+The main `simplicio` plugin is the default integration entry point.
+The Loop plugin remains available for explicit orchestration workflows. Prompt
+remains a separate installable plugin so its hooks and commands do not create
+duplicate runtime activation or hidden provider calls.
 
 ## Verification
 

--- a/docs/BOOTSTRAP_PROFILES.md
+++ b/docs/BOOTSTRAP_PROFILES.md
@@ -1,14 +1,16 @@
 # Bootstrap profiles
 
-The public download surface offers exactly two channels:
+The product defines two installation channels; public availability is
+release-dependent:
 
-1. `recommended-desktop` — the recommended signed Desktop shell. Desktop
+1. `recommended-desktop` — the intended default signed Desktop shell. Desktop
    includes the CLI and bootstraps the Runtime, state, skills, managed
    integrations, updater, rollback metadata, uninstall ledger, and savings
-   receipts after login.
-2. `recommended-cli` — a per-user CLI bootstrap for terminals and headless
-   environments. It uses the same Runtime transaction, component lock, state
-   profile, and receipts, but excludes the Desktop shell.
+   receipts after login. This channel is not included in the current public
+   release until a signed Desktop package is published.
+2. `recommended-cli` — the current public per-user CLI bootstrap for terminals
+   and headless environments. It uses the same Runtime transaction, component
+   lock, state profile, and receipts, but excludes the Desktop shell.
 
 The machine-readable contract is
 [`distribution/bootstrap-profiles.json`](../distribution/bootstrap-profiles.json).
@@ -18,8 +20,8 @@ this repository owns the stable public profile IDs and download choices.
 ## Happy path
 
 ```text
-Desktop download → open → login → bootstrap apply → ready
-CLI bootstrap    → login → bootstrap apply → ready
+Desktop download (when published) → open → login → bootstrap apply → ready
+Current public CLI  → login → bootstrap apply → ready
 ```
 
 The application must not add a mode wizard, technical preflight, embedded


### PR DESCRIPTION
## Summary
- state clearly that the signed Desktop package is intended but not in the current public release
- describe the verified CLI bootstrap as the current public path until Desktop is published
- align bootstrap profiles with actual release availability
- make the main `simplicio` plugin, rather than `simplicio-loop`, the default integration entry point

## Issue
Follow-up to #336. This keeps the Desktop-first product direction while removing claims that the current release already provides a downloadable signed Desktop channel.

## Validation
- fetched and reviewed the current `INSTALL.md`, `docs/BOOTSTRAP_PROFILES.md`, and `PLUGIN.md` from master
- re-fetched the branch after edits
- verified the old contradictory claims are absent and the new unavailable-channel wording is present
- no code, menus, release assets, or installer behavior changed