### PR TITLE
docs: correct Claude and MCP command paths

### DIFF
--- a/MCP-CONNECT.md
+++ b/MCP-CONNECT.md
@@ -86,7 +86,7 @@ Add this server entry to any MCP-compatible client that supports STDIO:
 {
   "mcpServers": {
     "simplicio": {
-      "command": "simplicio",
+      "command": "/absolute/path/to/.simplicio/bin/simplicio",
       "args": ["serve", "--mcp", "--stdio"]
     }
   }
@@ -97,13 +97,13 @@ Common locations:
 
 | Client | File |
 |---|---|
-| Claude Code | `~/.claude/settings.json` |
+| Claude Code | `~/.claude.json` (user/local) or project `.mcp.json` |
 | Cursor | `~/.cursor/mcp.json` |
 | VS Code | `.vscode/mcp.json` |
 | Cline | `~/.config/cline/mcp_settings.json` |
 | Continue | `~/.continue/config.json` |
 
-Reload the client after editing its configuration. STDIO does not require a manually copied bearer token, but the local Runtime still requires the Google login above.
+Replace the placeholder with the installed binary's absolute path. Claude Code plugin-provided servers follow the plugin lifecycle; do not copy them into project configuration unless the host requires it. Reload the client after editing its configuration. STDIO does not require a manually copied bearer token, but the local Runtime still requires the Google login above.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- update the Claude Code MCP location to user `~/.claude.json` or project `.mcp.json`
- make the generic STDIO example use an explicit absolute-path placeholder
- clarify that plugin-provided Claude servers follow the plugin lifecycle

Follow-up to #336. This keeps the per-platform examples intact and aligns the generic example with the document's direct-process launch rule.

## Validation
- fetched the current MCP-CONNECT.md from master before editing
- replacements were guarded by exact expected source text
- branch content was re-read after the update
- diff is limited to MCP documentation; no installer or runtime behavior changed