### PR TITLE
fix(desktop): model runtime evidence states

### DIFF
--- a/apps/desktop/src/contracts.ts
+++ b/apps/desktop/src/contracts.ts
@@ -30,15 +30,15 @@ export interface RuntimeStatus {
   lastReceiptAt: string | null;
   deterministic: {
     ready: boolean;
-    cpuFirst: true;
-    mapper: "canonical";
-    mapCache: "generation_scoped";
-    hookContext: "receipt_only";
+    cpuFirst: boolean;
+    mapper: "canonical" | "legacy" | "unknown";
+    mapCache: "generation_scoped" | "legacy" | "unknown";
+    hookContext: "receipt_only" | "legacy" | "unknown";
   };
   optionalFast: {
-    required: false;
-    hookInjected: false;
-    status: "not_required";
+    required: boolean;
+    hookInjected: boolean;
+    status: "not_required" | "injected" | "unknown";
   };
 }
 


### PR DESCRIPTION
## Summary
- make RuntimeStatus represent invalid/legacy evidence states instead of literal-only healthy values
- keep runtimeIsValid fail-closed while allowing tests and real snapshots to express bad hook/fast states
- integrate the already-converged Desktop/Mapper/installer work from the cloud branches without reapplying duplicate commits

## Verified locally
- npm test --prefix apps/desktop: 58 files, 374 tests passed
- npm run build --prefix apps/desktop: exit 0, Vite production bundle generated
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml -j 1: 155 passed, 0 failed, 3 ignored
- python3 -m pytest -q tests/test_claude_mapper_only_hooks.py tests/test_install_transaction_contract.py: 11 passed
- python3 scripts/verify_distribution_consistency.py: 8 OK, 0 errors, 0 warnings
- native package: Tauri release .app built with Runtime 3.8.46 arm64 sidecar; manual APFS/UDZO DMG created because Finder AppleScript cannot run headless; hdiutil verify passed; mounted DMG contains Mach-O arm64 app and sidecar, sidecar reports simplicio 3.8.46

## Scope / remaining gates
- no GitHub Actions are configured; no CI checks are expected
- Playwright E2E was attempted on an isolated port but exceeded the 300s supervised timeout and is not claimed as passed
- the DMG is a local candidate only; signing/notarization, clean-profile install/login/update/relaunch and public release publication remain separate acceptance gates
- no public release is requested by this PR
