### PR TITLE
fix desktop version identity 3.8.46

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.41",
+  "version": "3.8.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@simplicio/desktop",
-      "version": "3.8.41",
+      "version": "3.8.46",
       "dependencies": {
         "@tauri-apps/api": "2.11.1",
         "@tauri-apps/plugin-dialog": "2.7.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplicio/desktop",
-  "version": "3.8.41",
+  "version": "3.8.46",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simplicio-desktop"
-version = "3.8.41"
+version = "3.8.46"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicio-desktop"
-version = "3.8.41"
+version = "3.8.46"
 description = "Public desktop shell for the Simplicio Runtime"
 authors = ["SimpleTI"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Simplicio",
-  "version": "3.8.41",
+  "version": "3.8.46",
   "identifier": "br.com.simpleti.simplicio",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Alinha package.json, package-lock.json, tauri.conf.json e Cargo.toml/Cargo.lock com o Runtime 3.8.46. npm test (374 testes), npm build e verify_distribution_consistency passam. O pacote nativo arm64 local foi recompilado e verificado; não publica release nem inventa assinatura/notarização.