### PR TITLE
fix(desktop): export unified usage through Runtime

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod local_projects;
 mod native_menu;
 mod project_discovery_process;
 mod project_usage;
+mod projection_exports;
 mod projection_queries;
 mod runtime_install;
 mod runtime_lifecycle;
@@ -308,6 +309,41 @@ async fn desktop_unified_usage(query: Value, repo_path: Option<String>) -> Resul
     })
     .await
     .map_err(|_| "unified_usage_unavailable".to_string())?
+}
+
+#[tauri::command]
+async fn desktop_export_unified_usage(
+    app: tauri::AppHandle,
+    query: Value,
+    repo_path: Option<String>,
+    format: String,
+    expected_report_digest: Option<String>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        require_active_access()?;
+        let default_repo = default_projection_repo()?;
+        let args = projection_queries::query_args(
+            "desktop-unified-usage",
+            &query,
+            repo_path.as_deref(),
+            &default_repo,
+        )?;
+        let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let projection =
+            run_runtime_json(&borrowed).map_err(|_| "unified_usage_export_unavailable")?;
+        let downloads = app
+            .path()
+            .download_dir()
+            .map_err(|_| "unified_usage_export_downloads_unavailable")?;
+        projection_exports::save(
+            &projection,
+            &format,
+            expected_report_digest.as_deref(),
+            &downloads,
+        )
+    })
+    .await
+    .map_err(|_| "unified_usage_export_unavailable".to_string())?
 }
 
 #[tauri::command]
@@ -750,6 +786,7 @@ pub fn run() {
             desktop_usage_projects,
             desktop_usage_changefeed,
             desktop_unified_usage,
+            desktop_export_unified_usage,
             desktop_cost_projection,
             desktop_context_report,
             desktop_token_report,

--- a/apps/desktop/src-tauri/src/projection_exports.rs
+++ b/apps/desktop/src-tauri/src/projection_exports.rs
@@ -1,0 +1,398 @@
+//! Native, redacted exports of the Runtime-owned unified usage projection.
+use serde_json::{json, Map, Value};
+use std::fs::OpenOptions;
+use std::io::{ErrorKind, Write};
+use std::path::Path;
+
+const MAX_EXPORT_BYTES: usize = 65_536;
+const QUALIFICATION: &str =
+    "Recorded usage, not verified billing or savings. The Runtime projection is exported as received.";
+const QUERY_FIELDS: &[&str] = &[
+    "from_epoch",
+    "to_epoch",
+    "provider",
+    "model",
+    "host",
+    "project_id",
+    "session_id",
+];
+const ROW_FIELDS: &[&str] = &[
+    "provider",
+    "model",
+    "host",
+    "project_id",
+    "session_id",
+    "execution",
+    "input_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reported_output_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "total_tokens",
+    "cost_usd",
+    "provenance",
+    "reasoning_semantics",
+    "reasoning_semantics_provenance",
+    "reasoning_semantics_reason",
+    "event_count",
+    "source_completeness",
+    "incomplete_events",
+    "missing_usage_events",
+    "unpriced_events",
+    "metric_provenance",
+    "missing_metrics",
+];
+const TOTAL_FIELDS: &[&str] = &[
+    "event_count",
+    "input_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reported_output_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "total_tokens",
+    "cost_usd",
+];
+const METADATA_FIELDS: &[&str] = &[
+    "source",
+    "generated_by",
+    "generated_at_epoch",
+    "report_digest",
+    "revision",
+    "pricing_version",
+    "pricing_sources",
+    "coverage",
+    "redacted",
+];
+const COVERAGE_FIELDS: &[&str] = &[
+    "status",
+    "missing_usage_events",
+    "unpriced_events",
+    "providers",
+    "reason",
+];
+
+fn object<'a>(value: &'a Value) -> Result<&'a Map<String, Value>, String> {
+    value
+        .as_object()
+        .ok_or_else(|| "unified_usage_export_invalid".to_string())
+}
+
+fn copy_fields(source: &Map<String, Value>, fields: &[&str]) -> Map<String, Value> {
+    fields
+        .iter()
+        .filter_map(|field| {
+            source
+                .get(*field)
+                .map(|value| ((*field).to_string(), value.clone()))
+        })
+        .collect()
+}
+
+fn digest(value: &Value) -> Result<&str, String> {
+    let value = value
+        .as_str()
+        .filter(|value| {
+            value.len() == 71
+                && value.starts_with("sha256:")
+                && value[7..].bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+        .ok_or_else(|| "unified_usage_export_invalid".to_string())?;
+    Ok(value)
+}
+
+/// Keep only the versioned, redacted Runtime contract before writing a file.
+fn project(value: &Value, expected_digest: Option<&str>) -> Result<Value, String> {
+    let root = object(value)?;
+    if root.get("schema") != Some(&Value::String("simplicio.desktop-unified-usage/v1".into())) {
+        return Err("unified_usage_export_invalid".into());
+    }
+
+    let metadata = object(root.get("metadata").ok_or("unified_usage_export_invalid")?)?;
+    if metadata.get("source") != Some(&Value::String("runtime".into()))
+        || metadata.get("generated_by") != Some(&Value::String("runtime_usage_ledger".into()))
+        || metadata.get("redacted") != Some(&Value::Bool(true))
+    {
+        return Err("unified_usage_export_untrusted_source".into());
+    }
+    let report_digest = digest(
+        metadata
+            .get("report_digest")
+            .ok_or("unified_usage_export_invalid")?,
+    )?;
+    if let Some(expected) = expected_digest {
+        if expected != report_digest {
+            return Err("unified_usage_report_changed".into());
+        }
+    }
+
+    let query = object(root.get("query").ok_or("unified_usage_export_invalid")?)?;
+    let rows = root
+        .get("rows")
+        .and_then(Value::as_array)
+        .filter(|rows| rows.len() <= 512)
+        .ok_or("unified_usage_export_invalid")?;
+    let rows = rows
+        .iter()
+        .map(|row| Ok(Value::Object(copy_fields(object(row)?, ROW_FIELDS))))
+        .collect::<Result<Vec<_>, String>>()?;
+    let totals = copy_fields(
+        object(root.get("totals").ok_or("unified_usage_export_invalid")?)?,
+        TOTAL_FIELDS,
+    );
+    let metadata = {
+        let mut metadata = copy_fields(metadata, METADATA_FIELDS);
+        let coverage = object(
+            metadata
+                .get("coverage")
+                .ok_or("unified_usage_export_invalid")?,
+        )?;
+        metadata.insert(
+            "coverage".into(),
+            Value::Object(copy_fields(coverage, COVERAGE_FIELDS)),
+        );
+        metadata
+    };
+
+    Ok(json!({
+        "schema": "simplicio.desktop-unified-usage/v1",
+        "generated_at_epoch": root.get("generated_at_epoch").cloned().ok_or("unified_usage_export_invalid")?,
+        "query": Value::Object(copy_fields(query, QUERY_FIELDS)),
+        "rows": rows,
+        "totals": totals,
+        "metadata": metadata,
+    }))
+}
+
+fn csv_cell(value: &Value) -> String {
+    let raw = match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.clone(),
+        _ => value.to_string(),
+    };
+    format!("\"{}\"", raw.replace('"', "\"\""))
+}
+
+fn csv_value(row: &Map<String, Value>, field: &str) -> String {
+    csv_cell(row.get(field).unwrap_or(&Value::Null))
+}
+
+fn encode(projection: &Value, format: &str) -> Result<Vec<u8>, String> {
+    let body = if format == "json" {
+        serde_json::to_vec_pretty(&json!({
+            "projection": projection,
+            "qualification": QUALIFICATION,
+        }))
+        .map_err(|_| "unified_usage_export_failed")?
+    } else {
+        let rows = projection
+            .get("rows")
+            .and_then(Value::as_array)
+            .ok_or("unified_usage_export_invalid")?;
+        let fields = [
+            "provider",
+            "model",
+            "host",
+            "project_id",
+            "session_id",
+            "execution",
+            "input_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reported_output_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+            "cost_usd",
+            "provenance",
+            "reasoning_semantics",
+            "reasoning_semantics_provenance",
+            "source_completeness",
+            "incomplete_events",
+            "missing_usage_events",
+            "unpriced_events",
+            "event_count",
+        ];
+        let mut csv = format!("{}\n", fields.join(","));
+        for row in rows {
+            let row = object(row)?;
+            csv.push_str(
+                &fields
+                    .iter()
+                    .map(|field| csv_value(row, field))
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+            csv.push('\n');
+        }
+        csv.into_bytes()
+    };
+    if body.len() > MAX_EXPORT_BYTES {
+        return Err("unified_usage_export_too_large".into());
+    }
+    Ok(body)
+}
+
+/// Save a fresh, redacted Runtime projection to an OS-selected Downloads path.
+pub fn save(
+    value: &Value,
+    format: &str,
+    expected_digest: Option<&str>,
+    downloads: &Path,
+) -> Result<Value, String> {
+    if !matches!(format, "json" | "csv") {
+        return Err("unified_usage_export_invalid_format".into());
+    }
+    if !downloads.is_absolute() || !downloads.is_dir() {
+        return Err("unified_usage_export_downloads_unavailable".into());
+    }
+    let projection = project(value, expected_digest)?;
+    let body = encode(&projection, format)?;
+    for suffix in 0..1000 {
+        let filename = if suffix == 0 {
+            format!("simplicio-unified-usage.{format}")
+        } else {
+            format!("simplicio-unified-usage ({suffix}).{format}")
+        };
+        let path = downloads.join(filename);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = match options.open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(write_error(error.kind()).into()),
+        };
+        if let Err(error) = file.write_all(&body).and_then(|_| file.sync_all()) {
+            drop(file);
+            let _ = std::fs::remove_file(&path);
+            return Err(write_error(error.kind()).into());
+        }
+        return Ok(json!({
+            "schema": "simplicio.desktop-unified-usage-export/v1",
+            "format": format,
+            "path": path.to_string_lossy(),
+            "bytes": body.len(),
+            "report_digest": projection["metadata"]["report_digest"],
+        }));
+    }
+    Err("unified_usage_export_names_exhausted".into())
+}
+
+fn write_error(kind: ErrorKind) -> &'static str {
+    match kind {
+        ErrorKind::PermissionDenied => "unified_usage_export_permission_denied",
+        ErrorKind::NotFound => "unified_usage_export_downloads_unavailable",
+        _ => "unified_usage_export_failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn projection() -> Value {
+        json!({
+            "schema": "simplicio.desktop-unified-usage/v1",
+            "generated_at_epoch": 1700000100,
+            "query": {"provider":"openai","prompt":"private query"},
+            "rows": [{
+                "provider":"openai","model":"gpt-5","host":"codex",
+                "input_tokens":100,"cache_read_tokens":20,"cache_write_tokens":5,
+                "reported_output_tokens":40,"output_tokens":40,"reasoning_tokens":10,
+                "total_tokens":150,"cost_usd":0.02,"provenance":"provider-reported",
+                "prompt":"private row"
+            }],
+            "totals": {
+                "event_count":1,"input_tokens":100,"cache_read_tokens":20,"cache_write_tokens":5,
+                "reported_output_tokens":40,"output_tokens":40,"reasoning_tokens":10,
+                "total_tokens":150,"cost_usd":0.02
+            },
+            "metadata": {
+                "source":"runtime","generated_by":"runtime_usage_ledger","redacted":true,
+                "generated_at_epoch":1700000100,
+                "report_digest":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "revision":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                "coverage":{"status":"complete","missing_usage_events":0,"unpriced_events":0,"providers":["openai"],"reason":null},
+                "pricing_version":null,"pricing_sources":[]
+            }
+        })
+    }
+
+    struct Downloads(PathBuf);
+    impl Downloads {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "simplicio-unified-export-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+    impl Drop for Downloads {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn exports_only_allowlisted_runtime_fields() {
+        let downloads = Downloads::new();
+        let receipt = save(
+            &projection(),
+            "json",
+            Some("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            &downloads.0,
+        )
+        .unwrap();
+        let body = fs::read_to_string(receipt["path"].as_str().unwrap()).unwrap();
+        assert!(body.contains("gpt-5"));
+        assert!(!body.contains("private query"));
+        assert!(!body.contains("private row"));
+        assert_eq!(
+            receipt["schema"],
+            "simplicio.desktop-unified-usage-export/v1"
+        );
+    }
+
+    #[test]
+    fn rejects_stale_projection_and_preserves_existing_file() {
+        let downloads = Downloads::new();
+        fs::write(downloads.0.join("simplicio-unified-usage.json"), b"keep").unwrap();
+        let error = save(
+            &projection(),
+            "json",
+            Some("sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            &downloads.0,
+        )
+        .unwrap_err();
+        assert_eq!(error, "unified_usage_report_changed");
+        assert_eq!(
+            fs::read(downloads.0.join("simplicio-unified-usage.json")).unwrap(),
+            b"keep"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_format_without_touching_downloads() {
+        let downloads = Downloads::new();
+        assert_eq!(
+            save(&projection(), "xml", None, &downloads.0).unwrap_err(),
+            "unified_usage_export_invalid_format"
+        );
+        assert_eq!(fs::read_dir(&downloads.0).unwrap().count(), 0);
+    }
+}

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -66,6 +66,47 @@ export function exportDesktopUnifiedUsage(
   return exportUnifiedUsageProjection(projection, format);
 }
 
+export async function exportDesktopUnifiedUsageReport(
+  query: UsageQuery,
+  repoPath: string | undefined,
+  format: "json" | "csv",
+  expectedReportDigest: string,
+): Promise<{ schema: string; format: "json" | "csv"; path: string; bytes: number; reportDigest: string }> {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  const value = await withTimeout(
+    invoke<unknown>("desktop_export_unified_usage", {
+      query,
+      repoPath: repoPath || null,
+      format,
+      expectedReportDigest,
+    }),
+    90_000,
+    "unified_usage_export_timeout",
+  );
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("unified_usage_export_unconfirmed");
+  }
+  const receipt = value as Record<string, unknown>;
+  if (receipt.schema !== "simplicio.desktop-unified-usage-export/v1"
+    || receipt.format !== format
+    || typeof receipt.path !== "string" || !receipt.path
+    || typeof receipt.bytes !== "number" || !Number.isSafeInteger(receipt.bytes)
+    || receipt.bytes < 1 || receipt.bytes > 65_536
+    || typeof receipt.report_digest !== "string"
+    || !/^sha256:[a-f0-9]{64}$/.test(receipt.report_digest)) {
+    throw new Error("unified_usage_export_unconfirmed");
+  }
+  return {
+    schema: receipt.schema,
+    format,
+    path: receipt.path,
+    bytes: receipt.bytes,
+    reportDigest: receipt.report_digest,
+  };
+}
+
+
+
 export async function loadDesktopCostProjection(query: CostQuery = {}, repoPath?: string): Promise<CostProjection> {
   if (!isTauri()) throw new Error("preview_no_runtime");
   return parseCostProjection(await withTimeout(

--- a/apps/desktop/src/bridge.unified_usage.test.ts
+++ b/apps/desktop/src/bridge.unified_usage.test.ts
@@ -67,6 +67,34 @@ describe("desktop unified usage bridge", () => {
     expect(result.rows).toEqual([]);
   });
 
+  it("routes unified exports through the native Runtime command and validates its receipt", async () => {
+    invokeMock.mockResolvedValue({
+      schema: "simplicio.desktop-unified-usage-export/v1",
+      format: "json",
+      path: "/Users/test/Downloads/simplicio-unified-usage.json",
+      bytes: 128,
+      report_digest: NO_DATA.metadata.report_digest,
+    });
+    const bridge = await import("./bridge");
+
+    const result = await bridge.exportDesktopUnifiedUsageReport(
+      { provider: "openai" },
+      "/tmp/project",
+      "json",
+      NO_DATA.metadata.report_digest,
+    );
+
+    expect(invokeMock).toHaveBeenCalledOnce();
+    expect(invokeMock).toHaveBeenCalledWith("desktop_export_unified_usage", {
+      query: { provider: "openai" },
+      repoPath: "/tmp/project",
+      format: "json",
+      expectedReportDigest: NO_DATA.metadata.report_digest,
+    });
+    expect(result.path).toContain("simplicio-unified-usage.json");
+    expect(result.reportDigest).toBe(NO_DATA.metadata.report_digest);
+  });
+
   it("does not offer a browser preview when no packaged Runtime boundary exists", async () => {
     vi.stubGlobal("window", {});
     const bridge = await import("./bridge");

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -4,10 +4,10 @@ import { ContextSavings } from "../components/ContextSavings";
 import { TokenProjects } from "../components/TokenProjects";
 import { ConsolidatedTokens } from "../components/ConsolidatedTokens";
 import type { UsageProjects } from "../project_usage";
-import { buildUnifiedUsageQuery, exportUnifiedUsageProjection, UNIFIED_USAGE_ACCOUNT_LIMITS, UnifiedUsageRequestGuard, unifiedUsageState, type UnifiedUsageProjection } from "../unified_usage";
+import { buildUnifiedUsageQuery, UNIFIED_USAGE_ACCOUNT_LIMITS, UnifiedUsageRequestGuard, unifiedUsageState, type UnifiedUsageProjection, type UsageQuery } from "../unified_usage";
 import type { CostProjection } from "../cost_projection";
 import type { DesktopUsageState } from "../usage_store";
-import { exportDesktopTokenReport, loadDesktopTokenReport, loadDesktopUnifiedUsage, loadDesktopCostProjection } from "../bridge";
+import { exportDesktopTokenReport, exportDesktopUnifiedUsageReport, loadDesktopTokenReport, loadDesktopUnifiedUsage, loadDesktopCostProjection } from "../bridge";
 import { TOKEN_PERIODS, tokenErrorMessage, tokenExportErrorMessage, type TokenPeriod, type TokenQuery, type TokenUsageReport } from "../token_usage";
 
 interface TokenScreenPeriodActions {
@@ -44,6 +44,9 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
   const [unifiedProjection, setUnifiedProjection] = useState<UnifiedUsageProjection | null>(null);
   const [unifiedBusy, setUnifiedBusy] = useState(false);
   const [unifiedError, setUnifiedError] = useState<string | null>(null);
+  const [unifiedExporting, setUnifiedExporting] = useState(false);
+  const [unifiedExportPath, setUnifiedExportPath] = useState<string | null>(null);
+  const [unifiedExportError, setUnifiedExportError] = useState<string | null>(null);
   const [costProjection, setCostProjection] = useState<CostProjection | null>(null);
   const [costBusy, setCostBusy] = useState(false);
   const [costError, setCostError] = useState<string | null>(null);
@@ -55,6 +58,8 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
   const exportLock = useRef(false);
   const sequence = useRef(0);
   const unifiedRequests = useRef(new UnifiedUsageRequestGuard());
+  const unifiedExportSequence = useRef(0);
+  const unifiedExportLock = useRef(false);
 
   async function load(query: TokenQuery) {
     const request = ++sequence.current;
@@ -80,8 +85,11 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
 
   function invalidateUnifiedUsage() {
     unifiedRequests.current.invalidate();
+    unifiedExportSequence.current += 1;
     setUnifiedProjection(null);
     setUnifiedError(null);
+    setUnifiedExportPath(null);
+    setUnifiedExportError(null);
     setUnifiedBusy(false);
     setCostProjection(null);
     setCostError(null);
@@ -117,6 +125,21 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
     void load(query);
   }
 
+  function currentUnifiedQuery(): UsageQuery {
+    const customFrom = Math.floor(new Date(from).getTime() / 1000);
+    const customTo = Math.floor(new Date(to).getTime() / 1000);
+    return buildUnifiedUsageQuery({
+      period,
+      now_epoch: Math.floor(Date.now() / 1000),
+      selected_range: selected ? { from_epoch: selected.from_epoch, to_epoch: selected.to_epoch } : undefined,
+      custom_range: period === "custom" ? { from_epoch: customFrom, to_epoch: customTo } : undefined,
+      provider,
+      model,
+      host,
+      session_id: sessionId,
+    });
+  }
+
   async function loadUnifiedUsage() {
     if (unifiedBusy) return;
     const request = unifiedRequests.current.begin();
@@ -126,18 +149,7 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
     try {
       // Project paths are intentionally not sent to this contract. Runtime owns
       // project identity and redaction; the public v1 query supports session scope.
-      const customFrom = Math.floor(new Date(from).getTime() / 1000);
-      const customTo = Math.floor(new Date(to).getTime() / 1000);
-      const query = buildUnifiedUsageQuery({
-        period,
-        now_epoch: Math.floor(Date.now() / 1000),
-        selected_range: selected ? { from_epoch: selected.from_epoch, to_epoch: selected.to_epoch } : undefined,
-        custom_range: period === "custom" ? { from_epoch: customFrom, to_epoch: customTo } : undefined,
-        provider,
-        model,
-        host,
-        session_id: sessionId,
-      });
+      const query = currentUnifiedQuery();
       const next = await loadDesktopUnifiedUsage(query, repoPath.trim() || undefined);
       if (unifiedRequests.current.isCurrent(request)) setUnifiedProjection(next);
     } catch (cause) {
@@ -149,17 +161,34 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
     }
   }
 
-  function downloadUnifiedUsage(format: "json" | "csv") {
-    if (!unifiedProjection || typeof document === "undefined") return;
-    const payload = exportUnifiedUsageProjection(unifiedProjection, format);
-    const url = URL.createObjectURL(new Blob([payload], {
-      type: format === "json" ? "application/json" : "text/csv",
-    }));
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `simplicio-usage-${unifiedProjection.metadata.report_digest.slice(7, 19)}.${format}`;
-    link.click();
-    URL.revokeObjectURL(url);
+  async function exportUnifiedUsage(format: "json" | "csv") {
+    if (!unifiedProjection || unifiedExportLock.current) return;
+    unifiedExportLock.current = true;
+    const request = unifiedExportSequence.current;
+    setUnifiedExporting(true);
+    setUnifiedExportPath(null);
+    setUnifiedExportError(null);
+    try {
+      const receipt = await exportDesktopUnifiedUsageReport(
+        currentUnifiedQuery(),
+        repoPath.trim() || undefined,
+        format,
+        unifiedProjection.metadata.report_digest,
+      );
+      if (request === unifiedExportSequence.current) setUnifiedExportPath(receipt.path);
+    } catch (cause) {
+      if (request === unifiedExportSequence.current) {
+        const reason = cause instanceof Error ? cause.message : String(cause);
+        setUnifiedExportError(reason === "unified_usage_report_changed"
+          ? "O uso mudou desde a consulta. Consulte novamente antes de exportar."
+          : reason === "unified_usage_export_timeout"
+            ? "A exportação demorou demais e foi cancelada sem afirmar sucesso."
+            : "Não foi possível confirmar a exportação pelo Runtime. Nenhum arquivo foi presumido.");
+      }
+    } finally {
+      unifiedExportLock.current = false;
+      if (request === unifiedExportSequence.current) setUnifiedExporting(false);
+    }
   }
 
   async function loadCostProjection() {
@@ -168,18 +197,7 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
     setCostProjection(null);
     setCostError(null);
     try {
-      const customFrom = Math.floor(new Date(from).getTime() / 1000);
-      const customTo = Math.floor(new Date(to).getTime() / 1000);
-      const query = buildUnifiedUsageQuery({
-        period,
-        now_epoch: Math.floor(Date.now() / 1000),
-        selected_range: selected ? { from_epoch: selected.from_epoch, to_epoch: selected.to_epoch } : undefined,
-        custom_range: period === "custom" ? { from_epoch: customFrom, to_epoch: customTo } : undefined,
-        provider,
-        model,
-        host,
-        session_id: sessionId,
-      });
+      const query = currentUnifiedQuery();
       setCostProjection(await loadDesktopCostProjection(query, repoPath.trim() || undefined));
     } catch (cause) {
       setCostError(cause instanceof Error ? cause.message : "cost_projection_unavailable");
@@ -262,11 +280,14 @@ export function TokensScreen({ initialRepoPath = "", projectPaths = [], usage }:
       <section className="panel token-evidence" aria-label="Uso unificado">
         <h2>Uso unificado</h2>
         <p>Provider, modelo, host e sessão só aparecem quando o Runtime fornecer a projeção versionada e redigida.</p>
-        <button className="button button-secondary" type="button" disabled={unifiedBusy || exporting} onClick={() => void loadUnifiedUsage()}>
+        <button className="button button-secondary" type="button" disabled={unifiedBusy || exporting || unifiedExporting} onClick={() => void loadUnifiedUsage()}>
           {unifiedBusy ? "Consultando projeção…" : "Consultar uso unificado"}
         </button>
-        <button className="button button-secondary" type="button" disabled={!unifiedProjection || exporting} onClick={() => downloadUnifiedUsage("json")}>Exportar uso JSON</button>
-        <button className="button button-secondary" type="button" disabled={!unifiedProjection || exporting} onClick={() => downloadUnifiedUsage("csv")}>Exportar uso CSV</button>
+        <button className="button button-secondary" type="button" disabled={!unifiedProjection || exporting || unifiedBusy || unifiedExporting} onClick={() => void exportUnifiedUsage("json")}>Exportar uso JSON</button>
+        <button className="button button-secondary" type="button" disabled={!unifiedProjection || exporting || unifiedBusy || unifiedExporting} onClick={() => void exportUnifiedUsage("csv")}>Exportar uso CSV</button>
+        {unifiedExporting && <p role="status">Salvando a projeção atual pelo Runtime em Downloads…</p>}
+        {unifiedExportPath && <p role="status">Projeção exportada para <code>{unifiedExportPath}</code></p>}
+        {unifiedExportError && <p role="alert">Exportação indisponível: {unifiedExportError}</p>}
         {unifiedError && <p role="status">Projeção indisponível: <code>{unifiedError}</code>. Nenhum zero foi inferido.</p>}
         <p>Histórico local: eventos redigidos do ledger do Runtime para o projeto selecionado.</p>
         <p role="status">Limites remotos da conta: {UNIFIED_USAGE_ACCOUNT_LIMITS.status}. O contrato v1 não fornece cota, saldo restante ou data de renovação; nenhum zero foi inferido.</p>


### PR DESCRIPTION
## Summary
- Routes the unified usage JSON/CSV export buttons through the native Runtime command and Downloads destination.
- Adds a bounded, redacted Runtime projection exporter with digest validation, collision-safe atomic files, and an explicit receipt.
- Prevents stale projection exports and reports timeout/correlation failures in the UI instead of claiming success.

## Issue
Refs #344

## Validation
- `cargo test` compiled the Tauri library; direct focused binary execution: 3 projection export tests passed, 0 failed.
- `npm test` focused: 2 files passed, 4 tests passed (`bridge.unified_usage.test.ts`, `TokensScreen.period.test.ts`).
- `npm run build --prefix apps/desktop`: TypeScript checks and Vite build passed.
- `git diff --check`: passed.

## Coordination
- No GitHub Actions or release was run.
- `apps/desktop/src-tauri/src/lib.rs` adds the `desktop_export_unified_usage` command and registers it in `generate_handler!`; this file overlaps the #342 work. Please resolve that handler/module overlap during merge without force-rebasing this branch.
- The issue remains open for installed-app exercise/acceptance because this PR specifically fixes the previously freezing Exportar uso JSON/CSV path.