### PR TITLE
issue-345-desktop-package

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -34,6 +34,29 @@ npm run build
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
 
+## Manual macOS package
+
+The checked-in package command stages the exact Runtime asset for the native
+Mac architecture, verifies its version, SHA-256 and Ed25519 release signature,
+then invokes the local Tauri CLI. It never publishes a release or uses GitHub
+Actions. The default Runtime source is the installed verified binary at
+~/.simplicio/bin/simplicio; pass --runtime /absolute/path when using a
+separately downloaded release asset.
+
+```bash
+npm ci
+npm run package:stage       # verify/stage only
+npm run package:local       # stage and create the .app/DMG locally
+```
+
+The command writes a redacted local receipt to reports/desktop-build-*.json
+and marks code-signing/notarization as observed or unavailable; it never invents
+Apple signing credentials. The staged target-specific sidecar is ignored by Git.
+
+runtime_install accepts both the Tauri target-suffixed sidecar name and the
+base name after bundling, so the packaged app can locate its verified Runtime
+without consulting PATH or a writable user binary.
+
 ## Runtime boundary
 
 The Tauri process invokes one fixed executable, without a shell. The production

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json && vite build",
+    "package:local": "python3 ../../scripts/build_desktop.py",
+    "package:stage": "python3 ../../scripts/build_desktop.py --stage-only",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "preview": "vite preview",

--- a/apps/desktop/src-tauri/src/runtime_install.rs
+++ b/apps/desktop/src-tauri/src/runtime_install.rs
@@ -139,10 +139,40 @@ fn executable_name() -> &'static str {
     }
 }
 
+fn runtime_target_suffix() -> &'static str {
+    if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "aarch64-apple-darwin"
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        "x86_64-apple-darwin"
+    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        "x86_64-pc-windows-msvc"
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        "x86_64-unknown-linux-gnu"
+    } else {
+        ""
+    }
+}
+
 pub fn bundled_runtime_path(current_executable: &Path) -> Result<PathBuf, String> {
     let parent = current_executable.parent().ok_or_else(invalid_path)?;
     require_directory(parent, "runtime_install_package_unavailable")?;
-    Ok(parent.join(executable_name()))
+
+    // Tauri places an externalBin beside the app executable using the target
+    // suffix. Keep the unsuffixed name as a compatibility path for direct
+    // fixtures and manually unpacked bundles.
+    let base = parent.join(executable_name());
+    let suffix = runtime_target_suffix();
+    if !suffix.is_empty() {
+        let target_specific = parent.join(format!(
+            "simplicio-{}{}",
+            suffix,
+            if cfg!(windows) { ".exe" } else { "" }
+        ));
+        if target_specific.is_file() {
+            return Ok(target_specific);
+        }
+    }
+    Ok(base)
 }
 
 fn install_paths(home: &Path) -> (PathBuf, PathBuf, PathBuf) {
@@ -1388,6 +1418,21 @@ mod tests {
         });
         fs::write(bundle.join(executable_name()), b"runtime-current").unwrap();
         (root, app, home)
+    }
+
+    #[test]
+    fn target_specific_bundle_name_is_preferred_when_present() {
+        let (root, app, _home) = fixture();
+        let base = bundled_runtime_path(&app).unwrap();
+        fs::remove_file(&base).unwrap();
+        let target = app.parent().unwrap().join(format!(
+            "simplicio-{}{}",
+            runtime_target_suffix(),
+            if cfg!(windows) { ".exe" } else { "" }
+        ));
+        fs::write(&target, b"runtime-target-specific").unwrap();
+        assert_eq!(bundled_runtime_path(&app).unwrap(), target);
+        fs::remove_dir_all(root).unwrap();
     }
 
     fn versioned_snapshot(version: &str) -> Value {

--- a/scripts/build_desktop.py
+++ b/scripts/build_desktop.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Build the native Simplicio Desktop package from one verified Runtime asset.
+
+This is the manual, local release path for issue #345.  It deliberately does
+not publish or mutate GitHub/PyPI.  The Runtime sidecar is staged into the
+Tauri input directory, verified against the checked-in release manifest, and
+then bundled by the local Tauri CLI.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DESKTOP = ROOT / "apps" / "desktop"
+TAURI = DESKTOP / "src-tauri"
+VERSION_FILE = ROOT / "version.txt"
+MANIFEST_FILE = ROOT / "simplicio-update-manifest.json"
+PACKAGE_FILE = DESKTOP / "package.json"
+TAURI_CONFIG = TAURI / "tauri.conf.json"
+CARGO_MANIFEST = TAURI / "Cargo.toml"
+SIDECAR_NAME = "simplicio"
+
+
+class BuildError(RuntimeError):
+    """A fail-closed local package error."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BuildError(f"cannot read JSON contract: {path}") from exc
+    if not isinstance(value, dict):
+        raise BuildError(f"JSON contract must be an object: {path}")
+    return value
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def command_output(command: list[str], *, cwd: Path | None = None, timeout: int = 90) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BuildError("command could not complete: " + " ".join(command)) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout)[-800:].strip()
+        raise BuildError(f"command failed ({result.returncode}): {' '.join(command)}: {detail}")
+    return result
+
+
+def native_target() -> tuple[str, str]:
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system != "Darwin":
+        raise BuildError(f"issue #345 is a native macOS build; host is {system}/{machine}")
+    if machine in {"arm64", "aarch64"}:
+        return "macos-arm64", "aarch64-apple-darwin"
+    if machine in {"x86_64", "amd64"}:
+        return "macos-x64", "x86_64-apple-darwin"
+    raise BuildError(f"unsupported native macOS architecture: {machine}")
+
+
+def source_versions() -> tuple[str, dict[str, Any], str, str]:
+    version = VERSION_FILE.read_text(encoding="utf-8").strip()
+    package = load_json(PACKAGE_FILE)
+    tauri = load_json(TAURI_CONFIG)
+    cargo = CARGO_MANIFEST.read_text(encoding="utf-8")
+    cargo_version = next(
+        (line.split("=", 1)[1].strip().strip('"') for line in cargo.splitlines() if line.startswith("version =")),
+        "",
+    )
+    versions = {
+        "version.txt": version,
+        "apps/desktop/package.json": str(package.get("version", "")),
+        "apps/desktop/src-tauri/tauri.conf.json": str(tauri.get("version", "")),
+        "apps/desktop/src-tauri/Cargo.toml": cargo_version,
+    }
+    if not version or any(value != version for value in versions.values()):
+        raise BuildError("Desktop version sources disagree: " + json.dumps(versions, sort_keys=True))
+    return version, package, tauri, cargo_version
+
+
+def manifest_record(version: str, target_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    manifest = load_json(MANIFEST_FILE)
+    if str(manifest.get("version")) != version or str(manifest.get("release_tag")) != "v" + version:
+        raise BuildError("release manifest is not bound to Desktop version " + version)
+    records = manifest.get("artifacts")
+    if not isinstance(records, list):
+        raise BuildError("release manifest has no artifact records")
+    record = next((item for item in records if isinstance(item, dict) and item.get("target") == target_id), None)
+    if record is None:
+        raise BuildError(f"release manifest has no Runtime asset for {target_id}")
+    digest = str(record.get("sha256", "")).lower()
+    signature = str(record.get("signature", ""))
+    if len(digest) != 64 or not all(char in "0123456789abcdef" for char in digest):
+        raise BuildError(f"manifest digest is invalid for {target_id}")
+    if not signature.startswith("ed25519:"):
+        raise BuildError(f"manifest signature is missing for {target_id}")
+    return manifest, record
+
+
+def runtime_version(binary: Path) -> str:
+    result = command_output([str(binary), "version", "--json"], timeout=60)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise BuildError("Runtime sidecar version --json is invalid") from exc
+    candidates: list[Any] = [payload.get("version")] if isinstance(payload, dict) else []
+    if isinstance(payload, dict):
+        for key in ("runtime", "executable"):
+            value = payload.get(key)
+            if isinstance(value, dict):
+                candidates.append(value.get("version"))
+    for value in candidates:
+        if value:
+            return str(value).lstrip("v")
+    raise BuildError("Runtime sidecar version --json has no version")
+
+
+def verify_manifest_signature(manifest: dict[str, Any], record: dict[str, Any]) -> None:
+    public_key = str(manifest.get("signing_pubkey", "")).strip()
+    signature = str(record.get("signature", "")).strip()
+    digest = str(record.get("sha256", "")).strip().lower()
+    helper = ROOT / "scripts" / "verify_ed25519.py"
+    if not public_key or not helper.is_file():
+        raise BuildError("manifest signature verification helper/key is unavailable")
+    command_output(
+        [
+            sys.executable,
+            str(helper),
+            "--public-key",
+            public_key,
+            "--signature",
+            signature,
+            "--sha256",
+            digest,
+        ],
+        timeout=60,
+    )
+
+
+def resolve_runtime(path_arg: str | None, version: str, target_id: str, manifest: dict[str, Any], record: dict[str, Any]) -> tuple[Path, dict[str, Any]]:
+    candidate = Path(path_arg).expanduser() if path_arg else Path(
+        os.environ.get("SIMPLICIO_DESKTOP_RUNTIME", str(Path.home() / ".simplicio" / "bin" / SIDECAR_NAME))
+    )
+    if candidate.is_symlink():
+        raise BuildError("Runtime sidecar must be a regular file: " + str(candidate))
+    candidate = candidate.resolve()
+    if not candidate.is_file():
+        raise BuildError("Runtime sidecar must be a regular file: " + str(candidate))
+    if os.name != "nt" and not (candidate.stat().st_mode & stat.S_IXUSR):
+        raise BuildError("Runtime sidecar is not executable: " + str(candidate))
+    actual_version = runtime_version(candidate)
+    if actual_version != version:
+        raise BuildError(f"Runtime sidecar version {actual_version} does not match {version}")
+    actual_digest = sha256(candidate)
+    expected_digest = str(record["sha256"]).lower()
+    if actual_digest != expected_digest:
+        raise BuildError(
+            f"Runtime sidecar SHA-256 {actual_digest} does not match manifest {expected_digest} for {target_id}"
+        )
+    verify_manifest_signature(manifest, record)
+    return candidate, {
+        "source": str(candidate),
+        "version": actual_version,
+        "sha256": actual_digest,
+        "manifest_sha256": expected_digest,
+        "signature": {"algorithm": "ed25519", "status": "verified"},
+    }
+
+
+def stage_sidecar(source: Path, triple: str) -> Path:
+    directory = TAURI / "binaries"
+    directory.mkdir(parents=True, exist_ok=True)
+    destination = directory / f"{SIDECAR_NAME}-{triple}"
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(prefix=".simplicio-", dir=directory, delete=False) as stream:
+            temporary = Path(stream.name)
+            with source.open("rb") as input_stream:
+                shutil.copyfileobj(input_stream, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if os.name != "nt":
+            os.chmod(temporary, 0o755)
+        os.replace(temporary, destination)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+    if not destination.is_file() or sha256(destination) != sha256(source):
+        raise BuildError("staged Runtime sidecar does not match source bytes")
+    return destination
+
+
+def artifact_record(path: Path, bundle_root: Path) -> dict[str, Any]:
+    relative = path.relative_to(bundle_root)
+    return {"path": str(relative), "size": path.stat().st_size, "sha256": sha256(path)}
+
+
+def inspect_bundle(bundle_root: Path, triple: str, expected_sidecar_sha256: str) -> dict[str, Any]:
+    apps = sorted(path for path in bundle_root.rglob("*.app") if path.is_dir())
+    if not apps:
+        raise BuildError("Tauri build produced no .app bundle")
+    app = apps[0]
+    macos_dir = app / "Contents" / "MacOS"
+    sidecars = [macos_dir / SIDECAR_NAME, macos_dir / f"{SIDECAR_NAME}-{triple}"]
+    sidecar = next((path for path in sidecars if path.is_file()), None)
+    if sidecar is None:
+        raise BuildError("Tauri .app does not contain the target-specific Runtime sidecar")
+    if os.name != "nt" and not (sidecar.stat().st_mode & stat.S_IXUSR):
+        raise BuildError("bundled Runtime sidecar is not executable")
+    sidecar_digest = sha256(sidecar)
+    if sidecar_digest != expected_sidecar_sha256:
+        raise BuildError(
+            f"bundled Runtime sidecar SHA-256 {sidecar_digest} does not match verified source {expected_sidecar_sha256}"
+        )
+    signing: dict[str, Any] = {"status": "not_checked", "notarization": "not_performed"}
+    codesign = shutil.which("codesign")
+    if codesign:
+        result = subprocess.run([codesign, "--verify", "--strict", str(app)], capture_output=True, text=True)
+        signing["status"] = "verified" if result.returncode == 0 else "failed"
+        if result.returncode != 0:
+            signing["reason"] = (result.stderr or result.stdout)[-500:].strip()
+    else:
+        signing["status"] = "unavailable"
+        signing["reason"] = "codesign is unavailable on this host"
+    if shutil.which("xcrun"):
+        notarization = subprocess.run(
+            ["xcrun", "stapler", "validate", str(app)], capture_output=True, text=True
+        )
+        signing["notarization"] = "verified" if notarization.returncode == 0 else "not_performed"
+    return {
+        "app": artifact_record(app / "Contents" / "Info.plist", bundle_root) if (app / "Contents" / "Info.plist").is_file() else {"path": str(app.relative_to(bundle_root))},
+        "app_path": str(app.relative_to(bundle_root)),
+        "sidecar_path": str(sidecar.relative_to(bundle_root)),
+        "sidecar_sha256": sidecar_digest,
+        "signing": signing,
+    }
+
+
+def git_commit() -> str:
+    result = command_output(["git", "rev-parse", "HEAD"], cwd=ROOT, timeout=30)
+    return result.stdout.strip()
+
+
+def create_dmg(app: Path, bundle_root: Path, version: str, target_id: str) -> Path:
+    hdiutil = shutil.which("hdiutil")
+    if not hdiutil:
+        raise BuildError("hdiutil is unavailable; cannot create the macOS installer")
+    output = bundle_root / "macos" / f"Simplicio_{version}_{target_id}.dmg"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    command_output(
+        [
+            hdiutil,
+            "create",
+            "-ov",
+            "-format",
+            "UDZO",
+            "-volname",
+            f"Simplicio {version}",
+            "-srcfolder",
+            str(app),
+            str(output),
+        ],
+        cwd=ROOT,
+        timeout=300,
+    )
+    return output
+
+
+def sign_app_ad_hoc(app: Path) -> None:
+    codesign = shutil.which("codesign")
+    if not codesign:
+        return
+    # No Apple credentials are required for a local package. Re-sign the
+    # complete bundle after Tauri copies the external sidecar, then verify it.
+    command_output([codesign, "--force", "--sign", "-", str(app)], cwd=ROOT, timeout=120)
+
+
+def build_local(bundle_mode: str, version: str, target_id: str) -> Path:
+    npm = shutil.which("npm")
+    if not npm:
+        raise BuildError("npm is required for the Desktop package build")
+    # Build only the .app through Tauri. Its create-dmg helper requires a GUI
+    # Finder session and is not deterministic on a headless/locked Mac.
+    command_output(
+        [npm, "--prefix", str(DESKTOP), "run", "tauri", "--", "build", "--bundles", "app"],
+        cwd=ROOT,
+        timeout=1_800,
+    )
+    bundle_root = TAURI / "target" / "release" / "bundle"
+    if not bundle_root.is_dir():
+        raise BuildError("Tauri build did not create target/release/bundle")
+    apps = sorted(path for path in bundle_root.rglob("*.app") if path.is_dir())
+    if not apps:
+        raise BuildError("Tauri build produced no .app bundle")
+    sign_app_ad_hoc(apps[0])
+    if bundle_mode not in {"app", "dmg", "app,dmg"}:
+        raise BuildError("bundle mode must be app, dmg or app,dmg")
+    if "dmg" in bundle_mode:
+        create_dmg(apps[0], bundle_root, version, target_id)
+    return bundle_root
+
+
+def make_report(
+    version: str,
+    target_id: str,
+    triple: str,
+    runtime: dict[str, Any],
+    bundle_root: Path | None,
+    bundle_mode: str,
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "schema": "simplicio.desktop-build/v1",
+        "issue": 345,
+        "version": version,
+        "target": target_id,
+        "target_triple": triple,
+        "source_commit": git_commit(),
+        "runtime": runtime,
+        "build": {
+            "status": "staged",
+            "publication": "not_requested",
+            "bundles": bundle_mode,
+        },
+    }
+    if bundle_root is None:
+        return report
+    files = [
+        path
+        for path in bundle_root.rglob("*")
+        if path.is_file()
+        and not path.name.startswith(".")
+        and not path.name.startswith("rw.")
+        and (any(part.endswith(".app") for part in path.parts) or (("dmg" in bundle_mode) and path.suffix == ".dmg"))
+    ]
+    report["build"] = {
+        "status": "built",
+        "publication": "not_requested",
+        "bundles": bundle_mode,
+        "artifacts": [artifact_record(path, bundle_root) for path in sorted(files)],
+        "desktop": inspect_bundle(bundle_root, triple, str(runtime["sha256"])),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", help="verified Runtime executable (defaults to ~/.simplicio/bin/simplicio)")
+    parser.add_argument("--stage-only", action="store_true", help="verify and stage the sidecar without running Tauri")
+    parser.add_argument("--report", type=Path, help="write the JSON evidence report to this path")
+    parser.add_argument(
+        "--bundles",
+        choices=("app", "dmg", "app,dmg"),
+        default="app,dmg",
+        help="local package outputs (default: app,dmg; DMG uses hdiutil without Finder)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        version, _package, _tauri, _cargo = source_versions()
+        target_id, triple = native_target()
+        manifest, record = manifest_record(version, target_id)
+        source, runtime = resolve_runtime(args.runtime, version, target_id, manifest, record)
+        staged = stage_sidecar(source, triple)
+        report = make_report(
+            version,
+            target_id,
+            triple,
+            runtime,
+            None if args.stage_only else build_local(args.bundles, version, target_id),
+            args.bundles,
+        )
+        report["staged_sidecar"] = {
+            "path": str(staged.relative_to(ROOT)),
+            "sha256": sha256(staged),
+            "executable": bool(staged.stat().st_mode & stat.S_IXUSR),
+        }
+        report_path = args.report or ROOT / "reports" / f"desktop-build-{version}-{target_id}.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except BuildError as exc:
+        print(f"desktop build blocked: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a local-only macOS packaging command for issue #345
- stage the exact Runtime 3.8.46 sidecar only after version, SHA-256, and Ed25519 verification
- support deterministic native .app and hdiutil DMG output with a JSON build receipt
- prefer target-suffixed bundled sidecars while retaining the legacy base-name fixture path

## Verification

Native Apple Silicon (macos-arm64 / aarch64-apple-darwin) on the local Mac:

- `npm ci --prefix apps/desktop`
- `npm --prefix apps/desktop test` — 58 files, 375 tests passed
- `npm --prefix apps/desktop run build`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --locked -j 1` with incremental/debug info disabled — 156 passed, 0 failed, 3 ignored
- `python3 scripts/verify_distribution_consistency.py --json` — 8 OK
- `npm --prefix apps/desktop run package:stage`
- `npm --prefix apps/desktop run package:local`
- `codesign --verify --strict` — passed
- `hdiutil verify` — VALID
- packaged sidecar `version --json` — Runtime 3.8.46
- packaged sidecar MCP stdio smoke — initialize/tools-list passed (21 tools); clean HOME correctly returned login_required before map

Build receipt: `reports/desktop-build-3.8.46-macos-arm64.json` (local ignored artifact)
- DMG: `Simplicio_3.8.46_macos-arm64.dmg`
- DMG SHA-256: `4bb902bf4e5c8cabe647e63aaa532bf57fd83e849f74019b9b845a99809f78af`
- Runtime sidecar SHA-256: `4077bfc23ee1da030ed634d5fa8f176a4a8966934c2e679e6ee7d960855fe1a0`
- code signing: verified ad hoc
- notarization: not performed

This PR does not publish a release, upload artifacts, or use GitHub Actions. It is scoped to issue #345 and targets the repository's canonical `master` branch.