### PR TITLE
fix(claude): enforce mapper-only MCP bootstrap

### DIFF
--- a/plugins/simplicio/.mcp.json
+++ b/plugins/simplicio/.mcp.json
@@ -3,7 +3,7 @@
     "simplicio-runtime": {
       "command": "node",
       "args": [
-        "./bin/simplicio-mcp-bootstrap.js"
+        "./bin/simplicio-claude-mcp-bootstrap.js"
       ],
       "cwd": ".",
       "env_vars": [

--- a/plugins/simplicio/README.md
+++ b/plugins/simplicio/README.md
@@ -4,8 +4,10 @@
 
 This multi-host package preserves the native Codex plugin and adds official
 portable Agent Plugins v1, Claude Code, and Gemini CLI manifests. Every package
-starts the same verified Simplicio Runtime bootstrap, exposes its live MCP
-surface, and ships the same governed Simplicio skills.
+uses the verified Simplicio Runtime bootstrap, exposes its live MCP surface,
+and ships the same governed Simplicio skills. Claude Code has a host-specific
+launcher so its MCP process is authoritative Mapper-only while the portable,
+Codex, and Gemini launchers retain their host-selected Runtime mode.
 
 ## Host packages
 
@@ -42,7 +44,10 @@ first activates the package:
 3. Install the pinned Runtime release through its fail-closed SHA-256 and
    Ed25519 release checks.
 4. Start `simplicio serve --mcp --stdio --no-facade-mode` with stdout reserved
-   exclusively for MCP JSON-RPC.
+   exclusively for MCP JSON-RPC. Claude Code uses the adjacent
+   `simplicio-claude-mcp-bootstrap.js`, which sets `SIMPLICIO_RUNTIME_MODE` to
+   `mapper-only` in that process only; the shared launcher is unchanged for
+   other hosts.
 
 The managed binary is installed at `~/.simplicio/bin/simplicio`. Existing valid
 installs at `~/.local/bin/simplicio` are reused. Concurrent starts share an

--- a/plugins/simplicio/bin/simplicio-claude-mcp-bootstrap.js
+++ b/plugins/simplicio/bin/simplicio-claude-mcp-bootstrap.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+"use strict";
+
+const bootstrap = require("./simplicio-mcp-bootstrap.js");
+
+// Claude Code owns native editing and terminal tools. Keep this selection
+// process-local so an ambient full Runtime configuration is not changed for
+// the user's other hosts.
+process.env.SIMPLICIO_RUNTIME_MODE = "mapper-only";
+
+bootstrap.main().catch((error) => {
+  process.stderr.write(`[simplicio-plugin] ${error.message}. See ~/.simplicio/logs/codex-plugin-bootstrap.log\n`);
+  process.exitCode = 1;
+});

--- a/plugins/simplicio/bin/simplicio-mcp-bootstrap.js
+++ b/plugins/simplicio/bin/simplicio-mcp-bootstrap.js
@@ -319,10 +319,10 @@ async function installRuntime(env = process.env, home = resolveHome(env)) {
   }
 }
 
-function launchRuntime(runtime) {
+function launchRuntime(runtime, environment = process.env) {
   const args = ["serve", "--mcp", "--stdio", "--no-facade-mode"];
   const child = spawn(runtime.binary, args, {
-    env: process.env,
+    env: environment,
     stdio: "inherit",
     windowsHide: true
   });
@@ -340,10 +340,10 @@ function launchRuntime(runtime) {
   });
 }
 
-async function main() {
-  const home = resolveHome();
-  const runtime = findRuntime(process.env, home) || await installRuntime(process.env, home);
-  launchRuntime(runtime);
+async function main(environment = process.env) {
+  const home = resolveHome(environment);
+  const runtime = findRuntime(environment, home) || await installRuntime(environment, home);
+  launchRuntime(runtime, environment);
 }
 
 if (require.main === module) {
@@ -360,6 +360,8 @@ module.exports = {
   executableName,
   findRuntime,
   installRuntime,
+  launchRuntime,
+  main,
   parseVersion,
   resolveHome,
   runtimeCandidates,

--- a/plugins/simplicio/tests/bootstrap.test.js
+++ b/plugins/simplicio/tests/bootstrap.test.js
@@ -10,6 +10,7 @@ const { spawn, spawnSync } = require("node:child_process");
 const test = require("node:test");
 
 const bootstrapPath = path.resolve(__dirname, "..", "bin", "simplicio-mcp-bootstrap.js");
+const claudeBootstrapPath = path.resolve(__dirname, "..", "bin", "simplicio-claude-mcp-bootstrap.js");
 const bootstrap = require(bootstrapPath);
 
 test("version comparison is semantic and bounded", () => {
@@ -263,6 +264,42 @@ printf '%s' "$*" > "$SIMPLICIO_TEST_ARGS_FILE"
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, "");
     assert.equal(fs.readFileSync(argsFile, "utf8"), "serve --mcp --stdio --no-facade-mode");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("Claude bootstrap forces Mapper-only without changing the parent environment", { skip: process.platform === "win32" }, () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "simplicio-claude-bootstrap-test-"));
+  const fakeRuntime = path.join(tempDir, ".simplicio", "bin", "simplicio");
+  const launchFile = path.join(tempDir, "launch.json");
+  fs.mkdirSync(path.dirname(fakeRuntime), { recursive: true });
+  fs.writeFileSync(fakeRuntime, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  printf '{"schema":"simplicio.release-manifest/v1","product":"simplicio-runtime","runtime":{"name":"simplicio-runtime","version":"${bootstrap.POLICY.runtimeVersion}","executable":{"path":"%s","version":"${bootstrap.POLICY.runtimeVersion}"}},"auto_update":{"distribution":{"source_code_distributed":true}},"identity":{"enabled":true,"login_enabled":true},"security":{"signature_required":true,"public_key_configured":true,"refuse_unsigned":true,"refuse_invalid_signature":true}}' "$0"
+  exit 0
+fi
+printf '{"argv":"%s","mode":"%s"}' "$*" "$SIMPLICIO_RUNTIME_MODE" > "$SIMPLICIO_CLAUDE_LAUNCH_FILE"
+`, { mode: 0o700 });
+
+  try {
+    const result = spawnSync(process.execPath, [claudeBootstrapPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        SIMPLICIO_RUNTIME_MODE: "full",
+        SIMPLICIO_CLAUDE_LAUNCH_FILE: launchFile
+      },
+      timeout: 15000
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.deepEqual(JSON.parse(fs.readFileSync(launchFile, "utf8")), {
+      argv: "serve --mcp --stdio --no-facade-mode",
+      mode: "mapper-only"
+    });
+    assert.notEqual(process.env.SIMPLICIO_RUNTIME_MODE, "mapper-only");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/unit/test_plugin_marketplace.py
+++ b/tests/unit/test_plugin_marketplace.py
@@ -81,12 +81,16 @@ def test_portable_agent_plugin_contract() -> None:
     assert (source / server["args"][0].removeprefix("./")).is_file()
 
 
-def test_native_claude_and_gemini_manifests_reuse_the_bootstrap() -> None:
+def test_native_claude_and_gemini_manifests_use_their_host_bootstrap() -> None:
     claude = _load_json("plugins/simplicio/.claude-plugin/plugin.json")
     gemini = _load_json("plugins/simplicio/gemini-extension.json")
 
     assert claude["name"] == gemini["name"] == "simplicio"
     assert claude["mcpServers"] == "./.mcp.json"
+    claude_mcp = _load_json("plugins/simplicio/.mcp.json")
+    assert claude_mcp["mcpServers"]["simplicio-runtime"]["args"] == [
+        "./bin/simplicio-claude-mcp-bootstrap.js"
+    ]
     args = gemini["mcpServers"]["simplicio-runtime"]["args"]
     assert args == ["${extensionPath}/bin/simplicio-mcp-bootstrap.js"]
 


### PR DESCRIPTION
## Summary
- add a Claude-only MCP launcher that forces `SIMPLICIO_RUNTIME_MODE=mapper-only` in the child process
- keep the shared bootstrap and other host launchers unchanged
- add a launch-contract regression test covering ambient `full`, exact argv, and parent-environment isolation
- update the Claude manifest contract and plugin documentation

Closes #372

## Changed paths
- `plugins/simplicio/.mcp.json`
- `plugins/simplicio/bin/simplicio-claude-mcp-bootstrap.js`
- `plugins/simplicio/bin/simplicio-mcp-bootstrap.js`
- `plugins/simplicio/tests/bootstrap.test.js`
- `tests/unit/test_plugin_marketplace.py`
- `plugins/simplicio/README.md`

## Validation
Executed locally from commit `6ef1d87006e18203f5379b3a24590651e5e036ff`:
- `node --test plugins/simplicio/tests/bootstrap.test.js` — 12 passed, 1 skipped (live Runtime unavailable), exit 0
- manual invocation of the six tests in `tests/test_claude_mapper_only_hooks.py` — 6 passed, exit 0
- `node --check plugins/simplicio/bin/simplicio-mcp-bootstrap.js` — exit 0
- `node --check plugins/simplicio/bin/simplicio-claude-mcp-bootstrap.js` — exit 0
- `git diff --check` — exit 0

Not executed:
- pytest command could not start because the available Python environment has no pytest and shell package installation was blocked by network approval
- real installed Runtime/Claude handshake is unverified because no compatible Runtime is installed in this environment
- `python3 scripts/repository_policy.py` reports five pre-existing absolute-path findings in untouched files; no changed path is among them
- GitHub Actions are not present and were not triggered

The Claude launcher is process-local: it does not rewrite the user's ambient Runtime configuration or alter Codex, portable Agent Plugin, or Gemini launch behavior.