### PR TITLE
docs(desktop): publish macOS companion channel

### DIFF
--- a/DESKTOP-SHA256SUMS
+++ b/DESKTOP-SHA256SUMS
@@ -1,0 +1,1 @@
+9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779 *Simplicio-3.8.47-arm64.dmg

--- a/README.md
+++ b/README.md
@@ -56,25 +56,31 @@ optional, not required.**
 
 ## 🖥️ Desktop-first setup
 
-The public Desktop shell is the preferred product journey, but a signed
-downloadable Desktop package is not part of the current release yet. Until that
-package is published, use the verified CLI bootstrap below; it is the supported
-way to install the Runtime today.
+The public Desktop channel currently provides one macOS Apple Silicon companion
+package from the immutable Runtime `v3.8.47` release:
+[`Simplicio-3.8.47-arm64.dmg`](https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.47/Simplicio-3.8.47-arm64.dmg).
+Its SHA-256 is recorded in [`DESKTOP-SHA256SUMS`](DESKTOP-SHA256SUMS). This is
+an integrity-verified, ad-hoc macOS package: Apple Developer ID signing and
+notarization are unavailable, so Gatekeeper acceptance is not claimed.
 
-When a signed Desktop package is available, the first-run order is:
+Windows Desktop is not published. On Windows, use the verified CLI bootstrap
+below until a Windows Desktop installer has its own public digest, native
+install evidence, and platform-signing evidence.
 
-1. Open Desktop and let it install its bundled, verified Runtime before login.
-2. Complete Google login and confirm active identity and entitlement in the app.
-3. Review and consent to the exact host-integration plan before any client files
+For the public macOS arm64 package, the first-run order is:
+
+1. Download the immutable DMG and verify its SHA-256 before opening it.
+2. Open Desktop and let it install its bundled, verified Runtime before login.
+3. Complete Google login and confirm active identity and entitlement in the app.
+4. Review and consent to the exact host-integration plan before any client files
    are changed.
-4. Restart open MCP clients so they reload the registered command and hooks.
-5. Make one harmless tools/list or simplicio_map call and confirm the live
-   schema/receipt before starting project work.
+5. Restart open MCP clients, then make one harmless tools/list or simplicio_map
+   call and confirm the live schema/receipt before starting project work.
 
 Login is never a substitute for installation, and a successful process exit is
-not proof that a host is configured. If the Desktop package is unavailable, the
-CLI path below follows the same Runtime, authentication, consent, reload, and
-first-call contract.
+not proof that a host is configured. The CLI path below remains the supported
+cross-platform fallback and follows the same Runtime, authentication, consent,
+reload, and first-call contract.
 
 ## 🚀 Installation
 
@@ -82,11 +88,11 @@ first-call contract.
 
 The native Simplicio Desktop is being built publicly in
 [`apps/desktop`](apps/desktop). It uses Tauri 2 as a thin, capability-scoped
-shell around the separately supervised Simplicio Runtime. The first public
-Desktop download will replace the existing Desktop channel only after signed
-macOS and Windows artifacts pass the clean-machine, entitlement, provider,
-update and rollback gates. Until that cutover, the current download entrypoint
-remains unchanged.
+shell around the separately supervised Simplicio Runtime. The current public
+channel is macOS arm64 only; Windows Desktop remains explicitly blocked until
+the required installer and native release gates are met. See the
+[Desktop release evidence](docs/desktop/RELEASE.md) for the exact digest,
+sidecar identity, and unexecuted platform gates.
 
 See the [Desktop architecture decision](docs/desktop/ADR-0001-public-tauri-shell.md),
 [product states](docs/desktop/PRODUCT-STATES.md), and

--- a/distribution/bootstrap-profiles.json
+++ b/distribution/bootstrap-profiles.json
@@ -6,7 +6,7 @@
       "label": "Desktop",
       "recommended": true,
       "channel": "desktop",
-      "entrypoint": "https://github.com/wesleysimplicio/simplicio-agent/releases/latest",
+      "entrypoint": "https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.47/Simplicio-3.8.47-arm64.dmg",
       "source_repository": "https://github.com/wesleysimplicio/simplicio",
       "target_release_repository": "https://github.com/wesleysimplicio/simplicio/releases",
       "channel_migration": "public-foundation-before-atomic-cutover",

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -66,6 +66,26 @@ are not part of the signed Runtime update manifest because they are consumed
 by the Desktop distribution path. The release record must include their exact
 filename, SHA-256, size, and platform signing/notarization status.
 
+### Current Desktop v3.8.47 companion
+
+The public `v3.8.47` release contains the macOS Apple Silicon DMG below. Its
+checksum is published separately in `DESKTOP-SHA256SUMS`; do not add it to the
+Runtime `SHA256SUMS` or signed update manifest, and do not overwrite the existing
+immutable Runtime metadata asset.
+
+| Asset | Bytes | SHA-256 | Platform status |
+| --- | ---: | --- | --- |
+| `Simplicio-3.8.47-arm64.dmg` | 41,242,676 | `9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779` | ad-hoc; Developer ID/notarization unavailable |
+
+The downloaded DMG's `Contents/MacOS/simplicio` matches the public
+`simplicio-macos-arm64` Runtime asset at SHA-256
+`529ab8130222b93953485d5fe7c49cddfa29767c6a7db60cdd4f5db88a1ac053`, and the
+Runtime Ed25519 signature is verified. The release metadata does not carry the
+Desktop source revision, so none is inferred. Windows Desktop is not published
+for this release; its CLI installer remains the supported Windows path. Full
+gate status and unexecuted native checks are recorded in
+[`docs/desktop/RELEASE.md`](desktop/RELEASE.md).
+
 ### Published Desktop v3.8.39
 
 The Desktop assets were added manually to the existing public `v3.8.39`

--- a/docs/desktop/RELEASE.md
+++ b/docs/desktop/RELEASE.md
@@ -16,6 +16,42 @@ stored in a private directory and never starts an install before size and digest
 verification. A missing digest, stale manifest, wrong target, interrupted
 download or failed verification fails closed and leaves the current app intact.
 
+## Public v3.8.47 companion evidence
+
+The public Desktop channel currently contains one macOS Apple Silicon companion
+asset. Its digest is kept in [`DESKTOP-SHA256SUMS`](../../DESKTOP-SHA256SUMS),
+separate from the Runtime-only `SHA256SUMS` and
+`simplicio-update-manifest.json`; the Runtime closed-world manifest is not
+expanded with Desktop packages.
+
+| Item | Measured evidence |
+| --- | --- |
+| DMG | `Simplicio-3.8.47-arm64.dmg`, 41,242,676 bytes, SHA-256 `9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779` |
+| Bundled Runtime sidecar | `Contents/MacOS/simplicio`, 50,974,800 bytes, SHA-256 `529ab8130222b93953485d5fe7c49cddfa29767c6a7db60cdd4f5db88a1ac053` |
+| Runtime authenticity | Ed25519 signature for the public `simplicio-macos-arm64` asset verified with `scripts/verify_ed25519.py`; the sidecar extracted from the DMG matches that asset byte-for-byte |
+| Public release metadata | GitHub API reports the DMG as `uploaded`, with the same size and `sha256:9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779` |
+| Desktop source revision | Not present in the v3.8.47 release metadata; no source commit is inferred |
+
+The DMG and sidecar were downloaded again from the immutable release and the
+sidecar was extracted from its APFS image before comparison. The arm64 Runtime
+cannot execute on the available x86_64 verifier, so `version --json` and the
+native Desktop status probe remain unexecuted here.
+
+### Gate status for this public channel
+
+| Gate | Status | Boundary |
+| --- | --- | --- |
+| Desktop package digest and Runtime sidecar identity | **verified** | Downloaded DMG hash and extracted sidecar match the public release assets |
+| Runtime closed-world manifest | **verified** | `SHA256SUMS` and `simplicio-update-manifest.json` remain Runtime-only and unchanged |
+| Apple Developer ID signing and notarization | **blocked** | No Apple credentials are available; the package is ad-hoc and Gatekeeper acceptance is not claimed |
+| Authentication-only native probe and Google acceptance | **unexecuted** | Requires a native macOS executor and a separately authorized account run; no Google flow was initiated |
+| Windows Desktop | **blocked** | No Windows Desktop `.exe`/`.msi` installer is attached to v3.8.47; the CLI remains the Windows path |
+| CI | **absent** | This repository documents and runs local gates; no GitHub Actions result is invented |
+
+This evidence establishes a public macOS arm64 integrity channel, not a fully
+notarized Apple release or a published Windows Desktop channel. Do not describe
+the blocked or unexecuted gates as passed.
+
 The updater transaction is implemented in `src-tauri::desktop_updater`:
 
 1. re-read the official release API and bind the requested version/tag/asset;

--- a/landing.html
+++ b/landing.html
@@ -92,7 +92,7 @@ footer a{color:#0066cc;text-decoration:none}
 <h2>Get Simplicio.</h2>
 <p>Escolha seu canal antes de instalar. Depois do login, ele configura tudo.</p>
 <div style="margin:20px 0">
-<a href="https://github.com/wesleysimplicio/simplicio-agent/releases/latest" class="btn-pill blue" data-bootstrap-profile="recommended-desktop">⬇ Desktop · recomendado</a>
+<a href="https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.47/Simplicio-3.8.47-arm64.dmg" class="btn-pill blue" data-bootstrap-profile="recommended-desktop">⬇ Desktop · recomendado</a>
 <a href="https://pypi.org/project/simplicio/" class="btn-pill outline" data-bootstrap-profile="recommended-cli">⬇ CLI only</a>
 </div>
 <div style="font-size:12px;color:rgba(255,255,255,0.3)">Um perfil, um Runtime, um estado compartilhado</div>

--- a/tests/test_desktop_channel_contract.py
+++ b/tests/test_desktop_channel_contract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+DMG_NAME = "Simplicio-3.8.47-arm64.dmg"
+DMG_URL = "https://github.com/wesleysimplicio/simplicio/releases/download/v3.8.47/Simplicio-3.8.47-arm64.dmg"
+DMG_SHA256 = "9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779"
+
+
+def test_desktop_digest_is_separate_from_runtime_closed_world() -> None:
+    desktop_sums = (ROOT / "DESKTOP-SHA256SUMS").read_text(encoding="ascii").splitlines()
+    assert desktop_sums == [f"{DMG_SHA256} *{DMG_NAME}"]
+    assert DMG_NAME not in (ROOT / "SHA256SUMS").read_text(encoding="ascii")
+    manifest = json.loads((ROOT / "simplicio-update-manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["artifacts"]) == 4
+    assert all(record["artifact"] != DMG_NAME for record in manifest["artifacts"])
+
+
+def test_public_desktop_links_and_windows_boundary_are_consistent() -> None:
+    landing = (ROOT / "landing.html").read_text(encoding="utf-8")
+    profile = json.loads((ROOT / "distribution" / "bootstrap-profiles.json").read_text(encoding="utf-8"))
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    release = (ROOT / "docs" / "desktop" / "RELEASE.md").read_text(encoding="utf-8")
+    assert DMG_URL in landing
+    assert profile["download_options"][0]["entrypoint"] == DMG_URL
+    assert "Windows Desktop is not published." in readme
+    assert DMG_URL in readme
+    assert "Apple Developer ID signing" in readme
+    assert "Gatekeeper acceptance is not claimed" in readme
+    assert "Windows Desktop" in release
+    assert "no GitHub Actions result is invented" in release


### PR DESCRIPTION
## Development

- Added `DESKTOP-SHA256SUMS` for the public `Simplicio-3.8.47-arm64.dmg` companion asset.
- Updated `README.md`, `distribution/bootstrap-profiles.json`, and `landing.html` to use the public `simplicio` DMG channel.
- Documented the v3.8.47 digest, extracted Runtime sidecar identity, Runtime closed-world boundary, and gate states in `docs/desktop/RELEASE.md` and `docs/RELEASE_RUNBOOK.md`.
- Added `tests/test_desktop_channel_contract.py` for the digest/manifest/link/Windows boundary contract.
- Runtime `SHA256SUMS` and `simplicio-update-manifest.json` were not changed.

## Validation

- `sha256sum` of downloaded DMG: PASS; `9c8b02e8b804ddcf992c26f5d156ab0261fe498bee30237727d74abbbc38d779`.
- APFS extraction of the downloaded DMG: bundled `Contents/MacOS/simplicio` matches the public Runtime asset byte-for-byte; SHA-256 `529ab8130222b93953485d5fe7c49cddfa29767c6a7db60cdd4f5db88a1ac053`.
- Runtime Ed25519 verification with `scripts/verify_ed25519.py`: PASS.
- GitHub API: v3.8.47 DMG is uploaded, 41,242,676 bytes, with the same public digest.
- `git diff --check`: PASS; Runtime closed-world diff is empty.
- `python3 scripts/verify_distribution_consistency.py`: PASS, 0 errors and 0 warnings.
- `python3 scripts/repository_policy.py`: BLOCKED by pre-existing personal absolute-path findings in unchanged files; no new finding is introduced by this PR.
- No GitHub Actions workflow exists in this repository; no CI result is claimed.

## Tests

- Focused contract set: `48 passed, 1 deselected, 27 subtests passed`.
- `simplicio-dev-cli` verify-only: `verification_passed`, 4 contract tests passed.
- Coverage measurement of the existing evidence verifier: 64%; this PR changes static metadata/docs and the contract test, not executable release logic.
- One unrelated release test was deselected because `pwsh` is unavailable on this Linux executor; Windows Desktop remains explicitly blocked and this is recorded in the release evidence.

## Item-by-item review

- Public Desktop digest: measured locally and represented in `DESKTOP-SHA256SUMS`; the companion checksum asset is uploaded separately after merge without overwriting immutable Runtime metadata.
- README/first-run: macOS arm64 package is described as public integrity-verified/ad-hoc; Windows Desktop is explicitly not published and CLI fallback is stated.
- Windows: no Desktop installer is attached to v3.8.47; blocked status is documented.
- Release gates: sidecar/Runtime authenticity are measured; Apple Developer ID/notarization and native authentication/OAuth gates are blocked or unexecuted, never invented.
- Landing/bootstrap: both point to the immutable `wesleysimplicio/simplicio` v3.8.47 DMG.
- Runtime closed-world: the signed manifest and Runtime `SHA256SUMS` remain unchanged.
- Scope: #375, #373, and #376 are out of scope.
