### PR TITLE
Desktop: harden provider quota telemetry and signed updates

### DIFF
--- a/apps/desktop/e2e/access-update-recovery.spec.ts
+++ b/apps/desktop/e2e/access-update-recovery.spec.ts
@@ -60,7 +60,10 @@ async function mockAccessUpdates(page: Page, state: "signed_out" | "unknown" | "
     body: JSON.stringify([{
       tag_name: "v3.8.40", draft: false, prerelease: false,
       html_url: `${DESKTOP_RELEASES_URL}/tag/v3.8.40`,
-      assets: [{ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` }],
+      assets: [
+        { name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` },
+        { name: `${name}.sig`, state: "uploaded", size: 92, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}.sig` },
+      ],
     }]),
   }));
 }

--- a/apps/desktop/e2e/desktop-updates.spec.ts
+++ b/apps/desktop/e2e/desktop-updates.spec.ts
@@ -81,7 +81,10 @@ async function mockUpdates(page: Page, options: { holdVersion?: boolean; version
     status: 200, headers: { "content-type": "application/json", "access-control-allow-origin": "*" },
     body: JSON.stringify([{ tag_name: "v3.8.40", draft: false, prerelease: false, html_url: `${DESKTOP_RELEASES_URL}/tag/v3.8.40`,
       published_at: "2026-08-31T01:34:29Z", body: options.notes ?? "Melhorias no login e nas integrações do Desktop.",
-      assets: [{ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` }],
+      assets: [
+        { name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}` },
+        { name: `${name}.sig`, state: "uploaded", size: 92, browser_download_url: `${DESKTOP_RELEASES_URL}/download/v3.8.40/${name}.sig` },
+      ],
     }]),
   }));
   await page.goto("/");

--- a/apps/desktop/e2e/native-observations.spec.ts
+++ b/apps/desktop/e2e/native-observations.spec.ts
@@ -14,7 +14,7 @@ test("reads native permissions and quotas and opens only the requested settings 
       if (command === "desktop_permissions") return { schema: "simplicio.desktop-permissions/v1", source: "operating_system", rows: ["microphone","camera","screen","accessibility","files","automation","network","devices"].map(id => ({id,status: id === "microphone" ? "granted" : id === "camera" ? "not_determined" : id === "accessibility" && accessibilityGranted ? "granted" : "unknown",canOpenSettings:true})) };
       if (command === "desktop_open_permission_settings") return;
       if (command === "desktop_request_media_permission") return { schema: "simplicio.desktop-permissions/v1", source: "operating_system", rows: ["microphone","camera","screen","accessibility","files","automation","network","devices"].map(id => ({id,status: id === "camera" ? "denied" : "unknown",canOpenSettings:true})) };
-      if (command === "desktop_provider_quotas") return {schema:"simplicio.provider-quotas/v1",status:"available",grok:{status:"available",windows:[{usedPercent:37,windowDurationMins:10080,resetsAt:1900000000}]},groups:[{id:"codex",windows:[{usedPercent:21,windowDurationMins:10080,resetsAt:1900000000}]}]};
+      if (command === "desktop_provider_quotas") return {schema:"simplicio.provider-quotas/v2",status:"available",observedAt:1900000000,providers:[{id:"codex",source:"codex_app_server",accountScope:"local_authenticated_account",observedAt:1900000000,redacted:true,status:"fresh",windows:[{usedPercent:21,windowDurationMins:10080,resetsAt:1900000000}]},{id:"grok",source:"grok_cli_billing",accountScope:"local_cli_session",observedAt:1900000000,redacted:true,status:"fresh",windows:[{usedPercent:37,windowDurationMins:10080,resetsAt:1900000000}]}]};
       if (command === "plugin:event|listen") return 1;
       throw "fixture_unavailable";
     } } });
@@ -34,10 +34,10 @@ test("reads native permissions and quotas and opens only the requested settings 
   await panel.getByRole("button", {name:"Compacto", exact:true}).click();
   await expect(panel.getByRole("button", {name:"Compacto", exact:true})).toHaveAttribute("aria-pressed", "true");
   await expect(panel.getByText("Renova em", {exact:false})).toHaveCount(0);
-  await expect(panel.getByRole("progressbar", {name:"Uso da janela de 10080 minutos"})).toHaveAttribute("value", "21");
+  await expect(panel.getByRole("progressbar", {name:"Uso da janela de 10080 minutos"}).first()).toHaveAttribute("value", "21");
   await panel.getByRole("button", {name:"Detalhado", exact:true}).click();
   await expect(panel.getByText("Renova em", {exact:false})).toHaveCount(2);
-  await expect(panel.getByRole("progressbar", {name:"Uso da conta Grok"})).toHaveAttribute("value", "37");
+  await expect(panel.getByRole("progressbar", {name:"Uso da janela de 10080 minutos"}).nth(1)).toHaveAttribute("value", "37");
   await page.getByRole("button",{name:"Fechar cotas"}).click();
   await expect(page.getByRole("region",{name:"Cotas dos agentes"})).toHaveCount(0);
   await page.evaluate(() => (window as unknown as {__grantAccessibility:()=>void}).__grantAccessibility());

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3246,10 +3246,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 name = "simplicio-desktop"
 version = "3.8.47"
 dependencies = [
+ "base64 0.22.1",
  "block2",
  "chrono",
  "objc2",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,8 @@ tauri-build = { version = "2.6.3", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+base64 = "0.22.1"
+ring = "0.17.14"
 chrono = "0.4.45"
 reqwest = { version = "0.13.4", features = ["blocking"] }
 tauri = { version = "2.11.5", features = [] }

--- a/apps/desktop/src-tauri/src/desktop_updater.rs
+++ b/apps/desktop/src-tauri/src/desktop_updater.rs
@@ -6,6 +6,8 @@
 //! to install anything that was not verified.  No authentication state is
 //! consulted: checking and installing a public Desktop release is anonymous.
 
+use base64::Engine as _;
+use ring::signature::{UnparsedPublicKey, ED25519};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
@@ -33,6 +35,9 @@ struct ReleaseArtifact {
     asset_bytes: u64,
     digest: String,
     url: String,
+    signature_url: String,
+    signature_bytes: u64,
+    signature: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -211,10 +216,31 @@ fn valid_digest(value: &str) -> bool {
         .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
+const SIGNING_PUBLIC_KEY: &str = "2RoVWAoqA/DtDkT5PZdzQYIP82zFskQqJx4S1w06Wok=";
+const SIGNATURE_DOMAIN: &str = "simplicio-release-v1:";
+const MAX_SIGNATURE_BYTES: u64 = 4096;
+
+fn valid_signature(value: &str) -> bool {
+    value.starts_with("ed25519:")
+        && value.len() <= MAX_SIGNATURE_BYTES as usize
+        && base64::engine::general_purpose::STANDARD
+            .decode(value.trim_start_matches("ed25519:"))
+            .is_ok_and(|signature| signature.len() == 64)
+}
+
+fn verify_signature(digest: &str, signature: &str) -> bool {
+    let Some(hex) = digest.strip_prefix("sha256:") else { return false; };
+    if !valid_digest(digest) || !valid_signature(signature) { return false; }
+    let Ok(public_key) = base64::engine::general_purpose::STANDARD.decode(SIGNING_PUBLIC_KEY) else { return false; };
+    let Ok(signature_bytes) = base64::engine::general_purpose::STANDARD.decode(signature.trim_start_matches("ed25519:")) else { return false; };
+    let payload = format!("{SIGNATURE_DOMAIN}{}", hex.to_ascii_lowercase());
+    UnparsedPublicKey::new(&ED25519, public_key).verify(payload.as_bytes(), &signature_bytes).is_ok()
+}
+
 fn fixed_asset_url(tag: &str, asset_name: &str) -> Result<String, String> {
     if !safe_component(tag, 80)
         || !tag.starts_with('v')
-        || !safe_component(asset_name, MAX_ASSET_NAME)
+        || !safe_component(asset_name, MAX_ASSET_NAME + 4)
     {
         return Err(error("update_identity_invalid"));
     }
@@ -272,6 +298,22 @@ fn parse_manifest(body: &[u8], tag: &str, asset_name: &str) -> Result<ReleaseArt
     {
         return Err(error("update_asset_invalid"));
     }
+    let signature_name = format!("{asset_name}.sig");
+    let signature_asset = assets
+        .iter()
+        .find(|candidate| candidate.get("name").and_then(Value::as_str) == Some(signature_name.as_str()))
+        .ok_or_else(|| error("update_signature_unavailable"))?;
+    let signature_bytes = signature_asset
+        .get("size")
+        .and_then(Value::as_u64)
+        .filter(|size| *size > 0 && *size <= MAX_SIGNATURE_BYTES)
+        .ok_or_else(|| error("update_signature_invalid"))?;
+    let signature_url = fixed_asset_url(tag, &signature_name)?;
+    if signature_asset.get("state").and_then(Value::as_str) != Some("uploaded")
+        || signature_asset.get("browser_download_url").and_then(Value::as_str) != Some(signature_url.as_str())
+    {
+        return Err(error("update_signature_invalid"));
+    }
     Ok(ReleaseArtifact {
         version: version.to_string(),
         tag: tag.to_string(),
@@ -279,6 +321,9 @@ fn parse_manifest(body: &[u8], tag: &str, asset_name: &str) -> Result<ReleaseArt
         asset_bytes: bytes,
         digest: digest.to_string(),
         url,
+        signature_url,
+        signature_bytes,
+        signature: None,
     })
 }
 
@@ -352,14 +397,17 @@ fn state_to_json(value: &UpdateState) -> Value {
         "asset_name": value.artifact.asset_name,
         "asset_bytes": value.artifact.asset_bytes,
         "asset_digest": value.artifact.digest,
+        "signature_url": value.artifact.signature_url,
+        "signature_bytes": value.artifact.signature_bytes,
+        "signature": value.artifact.signature,
         "received_bytes": value.received_bytes,
         "staged_path": value.staged_path.display().to_string(),
         "previous_path": value.previous_path.as_ref().map(|path| path.display().to_string()),
         "target": { "platform": expected_target().0, "arch": expected_target().1 },
         "restart_required": value.state == "relaunch_pending" || value.state == "awaiting_health",
         "anonymous": true,
-        "integrity": "sha256",
-        "provenance": "github-release-api",
+        "integrity": "sha256+ed25519",
+        "provenance": "github-release-api+ed25519-sidecar",
     })
 }
 
@@ -410,10 +458,28 @@ fn parse_state(value: &Value) -> Result<UpdateState, String> {
         .and_then(Value::as_str)
         .map(PathBuf::from)
         .ok_or_else(|| error("update_state_invalid"))?;
+    let signature_url = value
+        .get("signature_url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| error("update_state_invalid"))?;
+    let signature_bytes = value
+        .get("signature_bytes")
+        .and_then(Value::as_u64)
+        .filter(|size| *size > 0 && *size <= MAX_SIGNATURE_BYTES)
+        .ok_or_else(|| error("update_state_invalid"))?;
+    let signature = value
+        .get("signature")
+        .and_then(Value::as_str)
+        .filter(|signature| valid_signature(signature))
+        .map(str::to_string);
+    if state != "downloading" && signature.is_none() {
+        return Err(error("update_signature_unavailable"));
+    }
     if !version_valid(version)
         || !tag.starts_with('v')
         || !safe_component(asset_name, MAX_ASSET_NAME)
         || !asset_matches_target(asset_name)
+        || signature_url != fixed_asset_url(tag, &format!("{asset_name}.sig"))?
     {
         return Err(error("update_state_invalid"));
     }
@@ -431,6 +497,9 @@ fn parse_state(value: &Value) -> Result<UpdateState, String> {
             asset_bytes,
             digest: digest.to_string(),
             url: fixed_asset_url(tag, asset_name)?,
+            signature_url: signature_url.to_string(),
+            signature_bytes,
+            signature,
         },
         received_bytes: value
             .get("received_bytes")
@@ -498,7 +567,7 @@ pub fn download(
     }
     let _effect = UPDATE_EFFECT_LOCK.try_lock().map_err(|_| error("update_busy"))?;
     ensure_private_dir(&update_root(app_data))?;
-    let artifact = load_manifest(&update_root(app_data), tag, asset_name)?;
+    let mut artifact = load_manifest(&update_root(app_data), tag, asset_name)?;
     if artifact.version != version
         || (asset_bytes_hint != 0 && artifact.asset_bytes != asset_bytes_hint)
     {
@@ -545,6 +614,24 @@ pub fn download(
         write_state(app_data, &state)?;
         return Err(error("update_checksum_mismatch"));
     }
+    let signature_part = update_root(app_data).join(format!("{id}.sig.part"));
+    reject_symlink(&signature_part)?;
+    curl_to(&artifact.signature_url, &signature_part, false, 60)?;
+    let signature_body = fs::read(&signature_part).map_err(|_| error("update_signature_invalid"))?;
+    let _ = fs::remove_file(&signature_part);
+    if signature_body.len() as u64 != artifact.signature_bytes {
+        state.received_bytes = actual_bytes;
+        write_state(app_data, &state)?;
+        return Err(error("update_signature_invalid"));
+    }
+    let signature = std::str::from_utf8(&signature_body).map_err(|_| error("update_signature_invalid"))?.trim();
+    if !valid_signature(signature) || !verify_signature(&artifact.digest, signature) {
+        state.received_bytes = actual_bytes;
+        write_state(app_data, &state)?;
+        return Err(error("update_signature_mismatch"));
+    }
+    artifact.signature = Some(signature.to_string());
+    state.artifact = artifact.clone();
     let final_path = update_root(app_data).join(format!("{id}-{}", artifact.asset_name));
     reject_symlink(&final_path)?;
     fs::rename(&staged_path, &final_path).map_err(|_| error("update_stage_failed"))?;
@@ -835,6 +922,9 @@ pub fn install(
     if digest_file(&state.staged_path)? != state.artifact.digest {
         return Err(error("update_checksum_mismatch"));
     }
+    if !state.artifact.signature.as_deref().is_some_and(|signature| verify_signature(&state.artifact.digest, signature)) {
+        return Err(error("update_signature_mismatch"));
+    }
     install_bundle(app_data, current_executable, &mut state)
 }
 
@@ -922,11 +1012,22 @@ mod tests {
         ReleaseArtifact {
             version: version.to_string(),
             tag: format!("v{version}"),
-            asset_name: "Simplicio-3.8.99-arm64.zip".to_string(),
+            asset_name: "Simplicio_3.8.99_x64.AppImage".to_string(),
             asset_bytes: 10,
             digest: "sha256:".to_string() + &"a".repeat(64),
-            url: fixed_asset_url(&format!("v{version}"), "Simplicio-3.8.99-arm64.zip").unwrap(),
+            url: fixed_asset_url(&format!("v{version}"), "Simplicio_3.8.99_x64.AppImage").unwrap(),
+            signature_url: fixed_asset_url(&format!("v{version}"), "Simplicio_3.8.99_x64.AppImage.sig").unwrap(),
+            signature_bytes: 96,
+            signature: Some("ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".to_string()),
         }
+    }
+
+    #[test]
+    fn verifies_domain_separated_release_signature() {
+        let digest = "sha256:12681adb6fa49bc2a5d39f8feca42baabe5d97b61cfdf40a5d452d890a8be83a";
+        let signature = "ed25519:/Tt+wpY4VedOmsOJRPAaAz470OfD4QprLGnTed7QGkkWgyqLoeg2U/dr6PD3EWl4rvHLiok2UWALeDBvG9KmCQ==";
+        assert!(verify_signature(digest, signature));
+        assert!(!verify_signature(digest, "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="));
     }
 
     #[test]
@@ -989,24 +1090,48 @@ mod tests {
     }
 
     #[test]
+    fn rejects_manifest_without_signature_sidecar() {
+        let asset_name = "Simplicio_3.8.99_x64.AppImage";
+        let payload = json!([{
+            "tag_name": "v3.8.99", "draft": false, "prerelease": false,
+            "html_url": format!("{RELEASES_URL}/tag/v3.8.99"),
+            "assets": [{
+                "name": asset_name, "state": "uploaded", "size": 10,
+                "digest": "sha256:".to_string() + &"a".repeat(64),
+                "browser_download_url": format!("{RELEASES_URL}/download/v3.8.99/{asset_name}")
+            }]
+        }]);
+        assert_eq!(parse_manifest(payload.to_string().as_bytes(), "v3.8.99", asset_name).unwrap_err(), "update_signature_unavailable");
+    }
+
+    #[test]
     fn keeps_version_and_identity_bound_to_the_manifest() {
+        let asset_name = "Simplicio_3.8.99_x64.AppImage";
         let payload = json!([{
             "tag_name": "v3.8.99",
             "draft": false,
             "prerelease": false,
             "html_url": format!("{RELEASES_URL}/tag/v3.8.99"),
-            "assets": [{
-                "name": "Simplicio-3.8.99-arm64.zip",
-                "state": "uploaded",
-                "size": 10,
-                "digest": "sha256:".to_string() + &"a".repeat(64),
-                "browser_download_url": format!("{RELEASES_URL}/download/v3.8.99/Simplicio-3.8.99-arm64.zip")
-            }]
+            "assets": [
+                {
+                    "name": asset_name,
+                    "state": "uploaded",
+                    "size": 10,
+                    "digest": "sha256:".to_string() + &"a".repeat(64),
+                    "browser_download_url": format!("{RELEASES_URL}/download/v3.8.99/{asset_name}")
+                },
+                {
+                    "name": format!("{asset_name}.sig"),
+                    "state": "uploaded",
+                    "size": 92,
+                    "browser_download_url": format!("{RELEASES_URL}/download/v3.8.99/{asset_name}.sig")
+                }
+            ]
         }]);
         assert!(parse_manifest(
             payload.to_string().as_bytes(),
             "v3.8.99",
-            "Simplicio-3.8.99-arm64.zip"
+            asset_name
         )
         .is_ok());
         assert_eq!(

--- a/apps/desktop/src-tauri/src/grok_quotas.rs
+++ b/apps/desktop/src-tauri/src/grok_quotas.rs
@@ -89,10 +89,10 @@ fn query() -> Result<Value, &'static str> {
     }
     Err("quota_unavailable")
 }
-pub fn read() -> Value {
+pub fn read(observed_at: u64) -> Value {
     match query() {
-        Ok(window) => json!({"status":"available","source":"grok_cli_billing","windows":[window]}),
-        Err(reason) => json!({"status":"unavailable","source":"grok_cli_billing","reason":reason,"windows":[]}),
+        Ok(window) => json!({"id": "grok", "source": "grok_cli_billing", "observedAt": observed_at, "accountScope": "local_cli_session", "redacted": true, "status": "fresh", "windows": [window]}),
+        Err(reason) => json!({"id": "grok", "source": "grok_cli_billing", "observedAt": observed_at, "accountScope": "local_cli_session", "redacted": true, "status": "unavailable", "error": reason, "windows": []}),
     }
 }
 #[cfg(test)]
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     #[ignore = "explicit local acceptance: reads the signed-in Grok CLI session and calls billing"]
     fn local_billing_observation() {
-        let observation = read();
+        let observation = read(1900000000);
         assert_eq!(observation["source"], "grok_cli_billing");
         println!("{observation}");
     }

--- a/apps/desktop/src-tauri/src/provider_quotas.rs
+++ b/apps/desktop/src-tauri/src/provider_quotas.rs
@@ -1,30 +1,100 @@
 //! Provider quotas are independent from Runtime token ledgers.
 use serde_json::{json, Value};
 use std::{path::PathBuf, process::Command, sync::Mutex, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
+
+const SCHEMA: &str = "simplicio.provider-quotas/v2";
+const MAX_STALE_SECS: u64 = 15 * 60;
 static CACHE: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
+
+fn now_secs() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|value| value.as_secs()).unwrap_or(0)
+}
+
+fn safe_reason(value: &str) -> &'static str {
+    match value {
+        "cli_unavailable" | "login_required" | "refresh_in_grok" | "request_failed"
+        | "invalid_response" | "quota_unavailable" | "response_too_large" | "invalid_session"
+        | "read_failed" | "busy" => match value {
+            "cli_unavailable" => "cli_unavailable",
+            "login_required" => "login_required",
+            "refresh_in_grok" => "refresh_in_grok",
+            "request_failed" => "request_failed",
+            "invalid_response" => "invalid_response",
+            "quota_unavailable" => "quota_unavailable",
+            "response_too_large" => "response_too_large",
+            "invalid_session" => "invalid_session",
+            "read_failed" => "read_failed",
+            _ => "busy",
+        },
+        _ => "quota_unavailable",
+    }
+}
 
 fn window(value: &Value) -> Option<Value> {
     let used = value.get("usedPercent")?.as_f64()?;
     let minutes = value.get("windowDurationMins")?.as_u64()?;
     let resets = value.get("resetsAt")?.as_u64()?;
     if !used.is_finite() || !(0.0..=100.0).contains(&used) || minutes == 0 { return None; }
-    Some(json!({"usedPercent":used,"windowDurationMins":minutes,"resetsAt":resets}))
+    Some(json!({"usedPercent": used, "windowDurationMins": minutes, "resetsAt": resets}))
 }
+
 fn project(result: &Value) -> Vec<Value> {
     let mut groups = Vec::new();
     if let Some(by_id) = result.get("rateLimitsByLimitId").and_then(Value::as_object) {
         for (id, limits) in by_id.iter().take(16) { groups.push((id.as_str(), limits)); }
     }
     if groups.is_empty() {
-        if let Some(limits) = result.get("rateLimits").filter(|v| v.is_object()) {
+        if let Some(limits) = result.get("rateLimits").filter(|value| value.is_object()) {
             groups.push(("codex", limits));
         }
     }
     groups.into_iter().map(|(id, limits)| json!({
         "id": id.chars().take(80).collect::<String>(),
         "windows": (["primary", "secondary"].iter().filter_map(|name| window(&limits[*name])).collect::<Vec<_>>())
-    })).filter(|group| group["windows"].as_array().is_some_and(|v| !v.is_empty())).collect()
+    })).filter(|group| group["windows"].as_array().is_some_and(|value| !value.is_empty())).collect()
 }
+
+fn flatten_windows(groups: &[Value]) -> Vec<Value> {
+    groups.iter()
+        .filter_map(|group| group.get("windows").and_then(Value::as_array))
+        .flat_map(|windows| windows.iter().cloned())
+        .collect()
+}
+
+fn provider(id: &str, source: &str, account_scope: &str, observed_at: u64, status: &str, windows: Vec<Value>, reason: Option<&str>) -> Value {
+    let mut value = json!({
+        "id": id,
+        "source": source,
+        "observedAt": observed_at,
+        "accountScope": account_scope,
+        "redacted": true,
+        "status": status,
+        "windows": windows,
+    });
+    if let Some(reason) = reason { value["error"] = json!(safe_reason(reason)); }
+    value
+}
+
+fn root_status(providers: &[Value]) -> &'static str {
+    if providers.iter().any(|value| value["status"] == "fresh") { "available" }
+    else if providers.iter().any(|value| value["status"] == "stale") { "stale" }
+    else { "unavailable" }
+}
+
+fn mark_stale(value: &mut Value, now: u64) {
+    let status = if let Some(providers) = value.get_mut("providers").and_then(Value::as_array_mut) {
+        for provider in &mut *providers {
+            let observed = provider.get("observedAt").and_then(Value::as_u64).unwrap_or(0);
+            if provider["status"] == "fresh" && now.saturating_sub(observed) > MAX_STALE_SECS {
+                provider["status"] = json!("stale");
+                provider["error"] = json!("stale");
+            }
+        }
+        root_status(providers)
+    } else { return; };
+    value["status"] = json!(status);
+}
+
 fn codex_path() -> Option<PathBuf> {
     let mut paths = Vec::new();
     if let Some(home) = std::env::var_os("HOME") {
@@ -33,26 +103,42 @@ fn codex_path() -> Option<PathBuf> {
         paths.push(home.join(".cargo/bin/codex"));
     }
     paths.extend([PathBuf::from("/opt/homebrew/bin/codex"), PathBuf::from("/usr/local/bin/codex")]);
-    paths.into_iter().find(|p| p.is_file())
+    paths.into_iter().find(|path| path.is_file())
 }
+
 pub fn read() -> Value {
-    let Ok(mut cache) = CACHE.try_lock() else { return json!({"schema":"simplicio.provider-quotas/v1","status":"busy","groups":[]}); };
+    let observed = now_secs();
+    let Ok(mut cache) = CACHE.try_lock() else {
+        return json!({"schema": SCHEMA, "status": "busy", "observedAt": observed, "providers": []});
+    };
     if let Some((time, value)) = cache.as_ref() {
-        if time.elapsed() < Duration::from_secs(30) { return value.clone(); }
+        if time.elapsed() < Duration::from_secs(30) {
+            let mut cached = value.clone();
+            mark_stale(&mut cached, observed);
+            return cached;
+        }
     }
-    let observed = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
-    let result = match codex_path() {
-        Some(path) => crate::runtime_process::codex_account_limits(Command::new(path).arg("app-server")),
-        None => Err("cli_unavailable"),
+    let codex = match codex_path() {
+        Some(path) => match crate::runtime_process::codex_account_limits(Command::new(path).arg("app-server")) {
+            Ok(value) => {
+                let groups = project(&value);
+                let windows = flatten_windows(&groups);
+                let status = if windows.is_empty() { "unavailable" } else { "fresh" };
+                let reason = if windows.is_empty() { Some("quota_unavailable") } else { None };
+                provider("codex", "codex_app_server", "local_authenticated_account", observed,
+                    status, windows, reason)
+            }
+            Err(reason) => provider("codex", "codex_app_server", "local_authenticated_account", observed, "unavailable", vec![], Some(reason)),
+        },
+        None => provider("codex", "codex_app_server", "local_authenticated_account", observed, "unavailable", vec![], Some("cli_unavailable")),
     };
-    let mut response = match result {
-        Ok(value) => { let groups = project(&value); json!({"schema":"simplicio.provider-quotas/v1","status":if groups.is_empty() {"unavailable"} else {"available"},"source":"codex_app_server","observedAt":observed,"groups":groups}) },
-        Err(reason) => json!({"schema":"simplicio.provider-quotas/v1","status":"unavailable","source":"codex_app_server","observedAt":observed,"reason":reason,"groups":[]})
-    };
-    response["grok"] = crate::grok_quotas::read();
+    let grok = crate::grok_quotas::read(observed);
+    let providers = vec![codex, grok];
+    let response = json!({"schema": SCHEMA, "status": root_status(&providers), "observedAt": observed, "providers": providers});
     *cache = Some((Instant::now(), response.clone()));
     response
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,25 +158,32 @@ time.sleep(10)
         assert_eq!(project(&value)[0]["windows"][0]["usedPercent"], 21.0);
     }
     #[test] fn invalid_windows_are_not_zero_usage() {
-        assert!(window(&json!({"usedPercent":101,"windowDurationMins":10080,"resetsAt":1})).is_none());
-        assert!(project(&json!({"rateLimits":null})).is_empty());
+        assert!(window(&json!({"usedPercent": 101, "windowDurationMins": 10080, "resetsAt": 1})).is_none());
+        assert!(project(&json!({"rateLimits": null})).is_empty());
     }
-
     #[test]
     fn falls_back_to_legacy_limits_when_limit_id_map_is_empty() {
-        let result = project(&json!({
-            "rateLimitsByLimitId": {},
-            "rateLimits": {
-                "primary": {"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": 1900000000}
-            }
-        }));
+        let result = project(&json!({"rateLimitsByLimitId": {}, "rateLimits": {"primary": {"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": 1900000000}}}));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0]["id"], "codex");
         assert_eq!(result[0]["windows"][0]["usedPercent"], 21.0);
     }
-    #[test] fn preserves_quota_window_identity_and_omits_secrets() {
-        let result = project(&json!({"rateLimits":{"primary":{"usedPercent":21,"windowDurationMins":10080,"resetsAt":1900000000},"token":"secret"}}));
-        assert_eq!(result[0]["windows"][0]["usedPercent"],21.0);
-        assert!(!serde_json::to_string(&result).unwrap().contains("secret"));
+    #[test]
+    fn contract_has_source_scope_timestamp_and_redaction_without_secrets() {
+        let groups = project(&json!({"rateLimits": {"primary": {"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": 1900000000}, "token": "secret"}}));
+        let value = provider("codex", "codex_app_server", "local_authenticated_account", 1900000000, "fresh", flatten_windows(&groups), None);
+        assert_eq!(value["source"], "codex_app_server");
+        assert_eq!(value["accountScope"], "local_authenticated_account");
+        assert_eq!(value["observedAt"], 1900000000);
+        assert_eq!(value["redacted"], true);
+        assert_eq!(value["windows"][0]["usedPercent"], 21.0);
+        assert!(!value.to_string().contains("secret"));
+    }
+    #[test]
+    fn stale_cache_is_not_presented_as_fresh() {
+        let mut value = json!({"providers": [provider("codex", "codex_app_server", "local_authenticated_account", 1, "fresh", vec![json!({"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": 1900000000})], None)]});
+        mark_stale(&mut value, MAX_STALE_SECS + 2);
+        assert_eq!(value["providers"][0]["status"], "stale");
+        assert_eq!(value["providers"][0]["error"], "stale");
     }
 }

--- a/apps/desktop/src/components/DesktopUpdates.tsx
+++ b/apps/desktop/src/components/DesktopUpdates.tsx
@@ -71,6 +71,9 @@ function nativeFailureMessage(code: string): string {
     update_identity_invalid: "A identidade do pacote mudou. A atualização foi interrompida por segurança.",
     update_manifest_changed: "A release mudou desde a consulta. Verifique novamente antes de baixar.",
     update_digest_unavailable: "A distribuição não publicou um SHA-256 verificável para este pacote.",
+    update_signature_unavailable: "A distribuição não publicou a assinatura Ed25519 deste pacote.",
+    update_signature_invalid: "A assinatura publicada não atende ao contrato Ed25519.",
+    update_signature_mismatch: "A assinatura Ed25519 não corresponde ao pacote. O pacote não será instalado.",
     update_asset_invalid: "O pacote publicado não atende ao alvo ou ao contrato de distribuição.",
     update_download_failed: "O download falhou. O arquivo parcial foi preservado para retomar com segurança.",
     update_download_incomplete: "O download não terminou com o tamanho publicado. Tente novamente.",
@@ -385,7 +388,7 @@ export function DesktopUpdates() {
     status.state === "up_to_date" ? "Simplicio está atualizado" :
     status.state === "newer_local" ? "Versão local mais recente" : "Atualização não confirmada";
   const description = action.error || (action.stage === "downloading" ? "Baixando e verificando o pacote em armazenamento privado…" :
-    action.stage === "ready" ? "O pacote foi baixado e conferido por SHA-256. Está pronto para instalar." :
+    action.stage === "ready" ? "O pacote foi baixado e conferido por SHA-256 e Ed25519. Está pronto para instalar." :
     action.stage === "installing" ? "Preparando a troca do aplicativo e o reinício." :
     action.stage === "awaiting_health" ? "O aplicativo será reiniciado e validará a versão antes de confirmar a troca." :
     action.stage === "rollback" ? "Restaurando a cópia anterior do aplicativo." :
@@ -419,7 +422,7 @@ export function DesktopUpdates() {
       <div className="desktop-update-progress-label"><span role="status" aria-live="polite">{action.stage === "downloading" ? "Baixando e verificando instalador" : action.stage === "installing" ? "Instalando e preparando reinício" : "Restaurando versão anterior"}</span>
         <span>{progressBytes > 0 && result ? formatBytes(progressBytes) + " de " + formatBytes(result.release.assetBytes) : "Aguarde…"}</span></div>
       <progress aria-label="Progresso do download" value={progressRatio} max="100" />
-      <p>O arquivo é armazenado em área privada e só é instalado após a verificação de tamanho e SHA-256.</p>
+      <p>O arquivo é armazenado em área privada e só é instalado após a verificação de tamanho, SHA-256 e assinatura Ed25519.</p>
     </div>}
     {status.currentVersion && <p className="desktop-update-installed">Versão deste aplicativo: <strong>{status.currentVersion}</strong></p>}
     {result && available && <>
@@ -439,7 +442,7 @@ export function DesktopUpdates() {
     {status.state === "available" && action.stage === "idle" && <div className="desktop-update-manual"><Glyph name="external" size={17} /><div><strong>Atualização verificada pela distribuição</strong>
       <p>Baixe a release oficial para preparar uma instalação segura. O login do Simplicio não é necessário.</p></div></div>}
     {action.stage === "ready" && <div className="desktop-update-manual"><Glyph name="check" size={17} /><div><strong>Pacote pronto</strong>
-      <p>O tamanho publicado e o SHA-256 foram conferidos. Você pode instalar e reiniciar quando quiser.</p></div></div>}
+      <p>O tamanho publicado, o SHA-256 e a assinatura Ed25519 foram conferidos. Você pode instalar e reiniciar quando quiser.</p></div></div>}
     {action.stage === "awaiting_health" && <div className="desktop-update-manual"><Glyph name="refresh" size={17} /><div><strong>Reinício em validação</strong>
       <p>Se a nova versão não iniciar corretamente, use rollback para voltar à cópia anterior.</p></div></div>}
     {action.error && <p className="inline-error" role="alert">{action.error}</p>}

--- a/apps/desktop/src/components/ProviderUsage.tsx
+++ b/apps/desktop/src/components/ProviderUsage.tsx
@@ -3,29 +3,118 @@ import { invoke } from "@tauri-apps/api/core";
 import "./provider_usage.css";
 
 type WindowUsage = { usedPercent: number; windowDurationMins: number; resetsAt: number };
-type GrokQuota = { status: "available" | "unavailable"; reason?: string; windows: WindowUsage[] };
-type Quotas = { grok?: GrokQuota; status: "available" | "unavailable" | "busy"; observedAt?: number; groups: Array<{ id: string; windows: WindowUsage[] }> };
-export function parseQuotas(value: unknown): Quotas {
-  const data = value as Quotas & { schema?: string };
-  if (!data || data.schema !== "simplicio.provider-quotas/v1" || !["available","unavailable","busy"].includes(data.status) || !Array.isArray(data.groups) || data.groups.length > 16) throw new Error("quota_invalid");
-  for (const group of data.groups) {
-    if (!group || typeof group.id !== "string" || !Array.isArray(group.windows) || group.windows.length > 2) throw new Error("quota_invalid");
-    for (const w of group.windows) if (!w || !Number.isFinite(w.usedPercent) || w.usedPercent < 0 || w.usedPercent > 100 || !Number.isSafeInteger(w.windowDurationMins) || w.windowDurationMins <= 0 || !Number.isSafeInteger(w.resetsAt) || w.resetsAt < 0) throw new Error("quota_invalid");
-  }
-  let grok: GrokQuota | undefined;
-  if (data.grok) {
-    const projected = parseQuotas({schema: "simplicio.provider-quotas/v1", status: data.grok.status, groups: [{id: "grok", windows: data.grok.windows}]});
-    if (projected.status === "busy") throw new Error("quota_invalid");
-    grok = {status: projected.status, windows: projected.groups[0].windows, reason: typeof data.grok.reason === "string" ? data.grok.reason : undefined};
-  }
-  return { grok, status: data.status, observedAt: typeof data.observedAt === "number" ? data.observedAt : undefined, groups: data.groups };
+type ProviderQuota = {
+  id: "codex" | "grok";
+  source: "codex_app_server" | "grok_cli_billing";
+  observedAt: number;
+  accountScope: "local_authenticated_account" | "local_cli_session";
+  redacted: true;
+  status: "fresh" | "stale" | "unavailable";
+  error?: string;
+  windows: WindowUsage[];
+};
+type Quotas = {
+  schema: "simplicio.provider-quotas/v2";
+  status: "available" | "stale" | "unavailable" | "busy";
+  observedAt: number;
+  providers: ProviderQuota[];
+};
+
+const providerIds = ["codex", "grok"] as const;
+const sources = ["codex_app_server", "grok_cli_billing"] as const;
+const scopes = ["local_authenticated_account", "local_cli_session"] as const;
+const statuses = ["fresh", "stale", "unavailable"] as const;
+const maxProviderWindows = 32;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+function parseWindow(value: unknown): WindowUsage {
+  if (!record(value)) throw new Error("quota_invalid");
+  const used = value.usedPercent;
+  const minutes = value.windowDurationMins;
+  const resets = value.resetsAt;
+  if (typeof used !== "number" || !Number.isFinite(used) || used < 0 || used > 100
+    || typeof minutes !== "number" || !Number.isSafeInteger(minutes) || minutes <= 0
+    || typeof resets !== "number" || !Number.isSafeInteger(resets) || resets < 0) {
+    throw new Error("quota_invalid");
+  }
+  return { usedPercent: used, windowDurationMins: minutes, resetsAt: resets };
+}
+
+export function parseQuotas(value: unknown): Quotas {
+  if (!record(value)
+    || value.schema !== "simplicio.provider-quotas/v2"
+    || !["available", "stale", "unavailable", "busy"].includes(String(value.status))
+    || !Number.isSafeInteger(value.observedAt) || Number(value.observedAt) < 0
+    || !Array.isArray(value.providers) || value.providers.length > 2) {
+    throw new Error("quota_invalid");
+  }
+  const seen = new Set<string>();
+  const providers = value.providers.map((raw): ProviderQuota => {
+    if (!record(raw)
+      || !providerIds.includes(raw.id as typeof providerIds[number])
+      || seen.has(String(raw.id))
+      || !sources.includes(raw.source as typeof sources[number])
+      || !scopes.includes(raw.accountScope as typeof scopes[number])
+      || raw.redacted !== true
+      || !Number.isSafeInteger(raw.observedAt) || Number(raw.observedAt) < 0
+      || !statuses.includes(raw.status as typeof statuses[number])
+      || !Array.isArray(raw.windows) || raw.windows.length > maxProviderWindows
+      || (raw.status === "unavailable" && raw.windows.length !== 0)
+      || (raw.status !== "unavailable" && raw.windows.length === 0)) {
+      throw new Error("quota_invalid");
+    }
+    seen.add(String(raw.id));
+    const windows = raw.windows.map(parseWindow);
+    const error = raw.error === undefined
+      ? undefined
+      : typeof raw.error === "string" && /^[a-z_]{1,64}$/.test(raw.error) ? raw.error : null;
+    if (error === null) throw new Error("quota_invalid");
+    return {
+      id: raw.id as ProviderQuota["id"],
+      source: raw.source as ProviderQuota["source"],
+      observedAt: raw.observedAt as number,
+      accountScope: raw.accountScope as ProviderQuota["accountScope"],
+      redacted: true,
+      status: raw.status as ProviderQuota["status"],
+      error,
+      windows,
+    };
+  });
+  if (value.status === "busy" && providers.length !== 0) throw new Error("quota_invalid");
+  return {
+    schema: "simplicio.provider-quotas/v2",
+    status: value.status as Quotas["status"],
+    observedAt: value.observedAt as number,
+    providers,
+  };
+}
+
 export async function readProviderQuotas(): Promise<Quotas> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    return parseQuotas(await Promise.race([invoke("desktop_provider_quotas"), new Promise((_, reject) => { timer = setTimeout(() => reject(new Error("quota_timeout")), 40_000); })]));
-  } finally { clearTimeout(timer); }
+    return parseQuotas(await Promise.race([
+      invoke("desktop_provider_quotas"),
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error("quota_timeout")), 40_000); }),
+    ]));
+  } finally {
+    clearTimeout(timer);
+  }
 }
+
+function providerLabel(provider: ProviderQuota | undefined): string {
+  if (provider?.status === "stale") return "Dados anteriores; atualize para uma leitura atual.";
+  if (provider?.error === "refresh_in_grok") return "Abra o Grok neste computador para renovar a sessão e consulte novamente.";
+  if (provider?.error === "login_required") return "Entre no cliente neste computador para consultar sua cota.";
+  return "Cota indisponível. Nenhum percentual presumido.";
+}
+
+function sourceLabel(provider: ProviderQuota): string {
+  return provider.source === "codex_app_server" ? "Codex app-server" : "Grok CLI billing";
+}
+
 export function ProviderUsage({ onAccounts, onHistory }: { onAccounts: () => void; onHistory: () => void }) {
   const [open, setOpen] = useState(false);
   const [compact, setCompact] = useState(false);
@@ -35,57 +124,68 @@ export function ProviderUsage({ onAccounts, onHistory }: { onAccounts: () => voi
   const lock = useRef(false);
   const alive = useRef(false);
   const root = useRef<HTMLDivElement>(null);
+
   async function refresh() {
     if (lock.current || !("__TAURI_INTERNALS__" in window)) return;
-    lock.current = true; setBusy(true);
+    lock.current = true;
+    setBusy(true);
     try {
       const next = await readProviderQuotas();
       if (alive.current) { setData(next); setError(false); }
-    } catch { if (alive.current) setError(true); }
-    finally { lock.current = false; if (alive.current) setBusy(false); }
+    } catch {
+      if (alive.current) setError(true);
+    } finally {
+      lock.current = false;
+      if (alive.current) setBusy(false);
+    }
   }
+
   useEffect(() => {
-    alive.current = true; void refresh();
+    alive.current = true;
+    void refresh();
     const timer = setInterval(() => { if (!document.hidden) void refresh(); }, 60_000);
     return () => { alive.current = false; clearInterval(timer); };
   }, []);
+
   useEffect(() => {
     if (!open) return;
-    const outside = (e: PointerEvent) => { if (!root.current?.contains(e.target as Node)) setOpen(false); };
-    const key = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
-    document.addEventListener("pointerdown", outside); document.addEventListener("keydown", key);
+    const outside = (event: PointerEvent) => { if (!root.current?.contains(event.target as Node)) setOpen(false); };
+    const key = (event: KeyboardEvent) => { if (event.key === "Escape") setOpen(false); };
+    document.addEventListener("pointerdown", outside);
+    document.addEventListener("keydown", key);
     return () => { document.removeEventListener("pointerdown", outside); document.removeEventListener("keydown", key); };
   }, [open]);
-  const windows = data?.groups.flatMap(g => g.windows) ?? [];
-  const summary = windows.find(w => w.windowDurationMins === 10080) ?? windows[0];
+
+  const codex = data?.providers.find(provider => provider.id === "codex");
+  const grok = data?.providers.find(provider => provider.id === "grok");
+  const summary = codex?.windows.find(window => window.windowDurationMins === 10080) ?? codex?.windows[0];
+  const renderWindows = (provider: ProviderQuota | undefined, label: string) => <>
+    <h3>{label}</h3>
+    {provider?.windows.map((window, index) => <div className={"quota-window" + (compact ? " quota-window-compact" : "")} key={window.windowDurationMins + "-" + window.resetsAt + "-" + index}>
+      <span>{window.windowDurationMins === 10080 ? "Semanal" : window.windowDurationMins === 300 ? "5 horas" : window.windowDurationMins + " min"} · {window.usedPercent}% usado</span>
+      <progress max={100} value={window.usedPercent} aria-label={"Uso da janela de " + window.windowDurationMins + " minutos"} />
+      {!compact && <small>Renova em {new Date(window.resetsAt * 1000).toLocaleString("pt-BR")}</small>}
+    </div>)}
+    {(!provider || !provider.windows.length) && <p>{providerLabel(provider)}</p>}
+    {provider && <small>Fonte: {sourceLabel(provider)} · consulta {new Date(provider.observedAt * 1000).toLocaleTimeString("pt-BR")}{provider.status === "stale" ? " · desatualizada" : ""}</small>}
+  </>;
+
   return <div className="provider-usage" ref={root}>
-    <button type="button" aria-expanded={open} aria-controls="provider-usage-panel" onClick={() => setOpen(!open)}>{summary && !error ? "Codex " + summary.usedPercent + "% usado" : busy ? "Consultando cotas…" : "Cotas dos agentes"}</button>
+    <button type="button" aria-expanded={open} aria-controls="provider-usage-panel" onClick={() => setOpen(!open)}>
+      {summary && !error ? "Codex " + summary.usedPercent + "% usado" + (codex?.status === "stale" ? " · desatualizado" : "") : busy ? "Consultando cotas…" : "Cotas dos agentes"}
+    </button>
     {open && <section id="provider-usage-panel" className="provider-usage-panel" aria-label="Cotas dos agentes">
       <header><strong>Uso das contas</strong><button type="button" disabled={busy} onClick={() => void refresh()}>{busy ? "Consultando…" : "Atualizar cotas"}</button><button type="button" aria-label="Fechar cotas" onClick={() => setOpen(false)}>×</button></header>
       <div className="quota-display-mode" role="group" aria-label="Modo de exibição das cotas">
         <button type="button" aria-pressed={!compact} onClick={() => setCompact(false)}>Detalhado</button>
         <button type="button" aria-pressed={compact} onClick={() => setCompact(true)}>Compacto</button>
       </div>
-      <h3>Codex</h3>
       {error && <p role="status">Consulta falhou. Dados anteriores não são uma leitura atual.</p>}
-      {!summary && <p>{busy ? "Consultando o cliente Codex…" : "Cota não disponível. Verifique o login no cliente Codex."}</p>}
-      {data?.groups.map(group => <div key={group.id}>{data.groups.length > 1 && <strong>{group.id}</strong>}{group.windows.map(w => <div className={"quota-window" + (compact ? " quota-window-compact" : "")} key={w.windowDurationMins}>
-        <span>{w.windowDurationMins === 10080 ? "Semanal" : w.windowDurationMins === 300 ? "5 horas" : w.windowDurationMins + " min"} · {w.usedPercent}% usado</span>
-        <progress max={100} value={w.usedPercent} aria-label={"Uso da janela de " + w.windowDurationMins + " minutos"} />
-        {!compact && <small>Renova em {new Date(w.resetsAt * 1000).toLocaleString("pt-BR")}</small>}
-      </div>)}</div>)}
-      {data?.observedAt && <small>Fonte: Codex app-server · consulta {new Date(data.observedAt * 1000).toLocaleTimeString("pt-BR")}</small>}
-      <h3>Grok</h3>
-      {data?.grok?.windows.map(w => <div className={"quota-window" + (compact ? " quota-window-compact" : "")} key={w.windowDurationMins}>
-        <span>{w.windowDurationMins === 10080 ? "Semanal" : w.windowDurationMins + " min"} · {w.usedPercent}% usado</span>
-        <progress max={100} value={w.usedPercent} aria-label="Uso da conta Grok" />
-        {!compact && <small>Renova em {new Date(w.resetsAt * 1000).toLocaleString("pt-BR")}</small>}
-      </div>)}
-      {!data?.grok?.windows.length && <p>{data?.grok?.reason === "refresh_in_grok" ? "Abra o Grok neste computador para renovar a sessão e consulte novamente." : data?.grok?.reason === "login_required" ? "Entre no cliente Grok neste computador para consultar sua cota." : "Cota Grok indisponível. Nenhum percentual presumido."}</p>}
-      {data?.grok?.windows.length ? <small>Fonte: Grok CLI billing</small> : null}
+      {renderWindows(codex, "Codex")}
+      {renderWindows(grok, "Grok")}
       <button type="button" onClick={() => { setOpen(false); onHistory(); }}>Histórico de uso do Runtime</button>
       <button type="button" onClick={() => { setOpen(false); onAccounts(); }}>Contas de IA</button>
-      <p className="quota-note">Cotas de assinatura não são tokens faturados nem economia do Runtime. Atualizações respeitam cache de 30 segundos.</p>
+      <p className="quota-note">Cotas de assinatura não são tokens faturados nem economia do Runtime. Atualizações respeitam cache de 30 segundos; estados desatualizados não são tratados como leituras atuais.</p>
     </section>}
   </div>;
 }

--- a/apps/desktop/src/desktop_updates.test.ts
+++ b/apps/desktop/src/desktop_updates.test.ts
@@ -9,7 +9,10 @@ function release(version: string, names = [`Simplicio-${version}-arm64.dmg`]) {
   const tag = `v${version}`;
   return {
     tag_name: tag, draft: false, prerelease: false, html_url: `${DESKTOP_RELEASES_URL}/tag/${tag}`,
-    assets: names.map((name) => ({ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/${tag}/${encodeURIComponent(name)}` })),
+    assets: [
+      ...names.map((name) => ({ name, state: "uploaded", size: 100_000, browser_download_url: `${DESKTOP_RELEASES_URL}/download/${tag}/${encodeURIComponent(name)}` })),
+      ...names.filter((name) => !name.endsWith(".sig")).map((name) => ({ name: `${name}.sig`, state: "uploaded", size: 92, browser_download_url: `${DESKTOP_RELEASES_URL}/download/${tag}/${encodeURIComponent(name + ".sig")}` })),
+    ],
   };
 }
 
@@ -86,6 +89,14 @@ describe("published Desktop asset selection", () => {
     for (const name of ["simplicio-windows-x64.exe", "simplicio-3.8.39-windows-x64.exe", "simplicio_3.8.39_x64.exe", "simplicio_3.8.39_x64.zip"]) {
       expect(() => selectDesktopRelease([release("3.8.39", [name])], windows)).toThrow("no_compatible_release");
     }
+  });
+
+  it("requires a matching uploaded Ed25519 sidecar", () => {
+    const fixture = release("3.8.39");
+    expect(() => selectDesktopRelease([{ ...fixture, assets: fixture.assets.filter((asset) => !asset.name.endsWith(".sig")) }], mac)).toThrow("no_compatible_release");
+    const signature = fixture.assets.find((asset) => asset.name.endsWith(".sig"));
+    expect(() => selectDesktopRelease([{ ...fixture, assets: [{ ...signature!, browser_download_url: "https://evil.invalid/signature" }, fixture.assets[0]] }], mac)).toThrow("no_compatible_release");
+    expect(selectDesktopRelease([fixture], mac).assetName).toBe("Simplicio-3.8.39-arm64.dmg");
   });
 
   it("requires exact official release and download URLs", () => {

--- a/apps/desktop/src/desktop_updates.ts
+++ b/apps/desktop/src/desktop_updates.ts
@@ -156,6 +156,13 @@ export function selectDesktopRelease(payload: unknown, target: DesktopUpdateTarg
       if (rank === null || asset.browser_download_url !== `${DESKTOP_RELEASES_URL}/download/${entry.tag_name}/${encodeURIComponent(asset.name)}`) continue;
       if (selected === null || rank < selected.rank) selected = { name: asset.name, bytes: asset.size, rank };
     }
+    if (selected) {
+      const signatureName = `${selected.name}.sig`;
+      const signature = entry.assets.find((asset) => record(asset) && asset.state === "uploaded" && asset.name === signatureName &&
+        typeof asset.size === "number" && Number.isSafeInteger(asset.size) && asset.size > 0 && asset.size <= 4096 &&
+        asset.browser_download_url === `${DESKTOP_RELEASES_URL}/download/${entry.tag_name}/${encodeURIComponent(signatureName)}`);
+      if (!signature) selected = null;
+    }
     if (selected && (latest === null || compareVersions(version, latest.version) > 0)) {
       latest = { version, tag: entry.tag_name, releaseUrl, assetName: selected.name, assetBytes: selected.bytes,
         publishedAt: publicationDate(entry.published_at), notes: releaseNotes(entry.body) };

--- a/apps/desktop/src/native_observations.test.ts
+++ b/apps/desktop/src/native_observations.test.ts
@@ -7,10 +7,18 @@ describe("native permission and quota projections", () => {
     expect(parsePermissions({ schema: "simplicio.desktop-permissions/v1", source: "operating_system", rows })[0].status).toBe("unknown");
     expect(() => parsePermissions({ schema: "simplicio.desktop-permissions/v1", source: "operating_system", rows: [...rows.slice(1), rows[1]] })).toThrow();
   });
-  it("rejects quota percentages outside the contract", () => {
-    const quota = { schema: "simplicio.provider-quotas/v1", status: "available", groups: [{ id: "codex", windows: [{ usedPercent: 21, windowDurationMins: 10080, resetsAt: 1900000000 }] }] };
-    expect(parseQuotas(quota).groups[0].windows[0].usedPercent).toBe(21);
-    quota.groups[0].windows[0].usedPercent = 101;
+  it("requires a redacted provider record with source, scope, timestamp and windows", () => {
+    const quota = { schema: "simplicio.provider-quotas/v2", status: "available", observedAt: 1900000000, providers: [{ id: "codex", source: "codex_app_server", accountScope: "local_authenticated_account", observedAt: 1900000000, redacted: true, status: "fresh", windows: [{ usedPercent: 21, windowDurationMins: 10080, resetsAt: 1900000000 }] }] };
+    expect(parseQuotas(quota).providers[0].windows[0].usedPercent).toBe(21);
+    quota.providers[0].windows[0].usedPercent = 101;
     expect(() => parseQuotas(quota)).toThrow();
+    quota.providers[0].windows[0].usedPercent = 21;
+    quota.providers[0].redacted = false;
+    expect(() => parseQuotas(quota)).toThrow();
+  });
+  it("keeps stale and unavailable states explicit", () => {
+    const stale = { schema: "simplicio.provider-quotas/v2", status: "stale", observedAt: 1900000000, providers: [{ id: "grok", source: "grok_cli_billing", accountScope: "local_cli_session", observedAt: 1899990000, redacted: true, status: "stale", error: "stale", windows: [{ usedPercent: 10, windowDurationMins: 43200, resetsAt: 1900000000 }] }] };
+    expect(parseQuotas(stale).providers[0].status).toBe("stale");
+    expect(parseQuotas({ ...stale, status: "unavailable", providers: [{ ...stale.providers[0], status: "unavailable", windows: [], error: "login_required" }] }).providers[0].windows).toHaveLength(0);
   });
 });

--- a/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
+++ b/apps/desktop/src/screens/ReferenceSettingsScreen.tsx
@@ -178,8 +178,9 @@ function AccountConnection({ provider }: { provider: "codex" | "grok" }) {
     lock.current = true; setBusy(true);
     try {
       const data = await readProviderQuotas();
-      const windows = provider === "codex" ? data.groups.flatMap(group => group.windows) : data.grok?.windows ?? [];
-      const reason = data.grok?.reason;
+      const providerData = data.providers.find(item => item.id === provider);
+      const windows = providerData?.windows ?? [];
+      const reason = providerData?.error;
       const next = windows.length ? "Consulta de cota confirmada. A identidade da conta não foi consultada."
         : provider === "grok" && reason === "refresh_in_grok" ? "Sessão expirada. Abra o Grok neste computador para renovar e consulte novamente."
         : data.status === "busy" ? "Outra consulta está em andamento. Tente novamente quando terminar."

--- a/docs/desktop/PROVIDER-CONTRACT.md
+++ b/docs/desktop/PROVIDER-CONTRACT.md
@@ -35,6 +35,22 @@ The snapshot returns redacted state and account labels only. Secrets, complete
 configuration files, raw command output and provider transcripts never cross
 the Desktop bridge.
 
+## Provider quota telemetry
+
+The read-only quota command returns `simplicio.provider-quotas/v2` with one
+bounded record per provider. Each record carries `source`, `observedAt`,
+`accountScope`, `redacted: true`, `status` (`fresh`, `stale` or `unavailable`),
+an optional bounded error and reset windows with `usedPercent`,
+`windowDurationMins` and `resetsAt`.
+
+Codex is read through the supported `account/rateLimits/read` app-server RPC;
+Grok is read through its fixed CLI billing endpoint using the existing local
+session. Credentials and raw provider payloads stay in native code. Missing
+percentages are unavailable, never zero; stale values remain explicitly stale.
+This telemetry is separate from Runtime token ledgers and never enables account
+creation, logout, login or account selection. Those controls remain unavailable
+until a real provider account contract exists.
+
 ## Host-path caveat
 
 Packaged apps do not inherit the same `PATH` as an interactive shell. Detection

--- a/docs/desktop/RELEASE-CONTRACT.md
+++ b/docs/desktop/RELEASE-CONTRACT.md
@@ -8,10 +8,12 @@ same descriptor.
 This remains the publishing contract for a release that claims verified
 provenance. The native `Check for Updates...` menu now opens the GitHub
 metadata dialog, and the dialog can download/install only an exact target asset
-whose GitHub release entry supplies a SHA-256 digest. The updater deliberately
-does not elevate that digest into `desktop.release/v1` provenance, Developer ID
-signing or notarization; those publication gates remain mandatory. See
-[manual delivery and the updater gate](RELEASE.md).
+whose GitHub release entry supplies a SHA-256 digest and matching `<asset>.sig`
+sidecar. The sidecar is Ed25519 over the canonical
+`simplicio-release-v1:<sha256>` payload using the pinned update-signature key.
+The anonymous updater verifies size, digest and sidecar before staging; missing
+or invalid signatures fail closed. Apple Developer ID signing and notarization
+remain separate publication gates. See [manual delivery and the updater gate](RELEASE.md).
 
 The Desktop never treats a version string as proof that an update is safe. In
 standalone/preview mode, update and rollback remain unavailable with a reason

--- a/docs/desktop/RELEASE.md
+++ b/docs/desktop/RELEASE.md
@@ -10,11 +10,14 @@ Desktop source revision, target, installer digest and bundled Runtime identity
 separately. Never replace already-published bytes under an immutable version. This document is the normative source for the Desktop release and updater requirements; the former `distribution/desktop-release.json` duplicate specification is not consumed by the application.
 
 `Check for Updates...` checks public GitHub release metadata and, for a
-compatible Desktop package with a published SHA-256 digest, offers the bounded
-download, verification and install flow. The download is anonymous, resumable,
-stored in a private directory and never starts an install before size and digest
-verification. A missing digest, stale manifest, wrong target, interrupted
-download or failed verification fails closed and leaves the current app intact.
+compatible Desktop package with a published SHA-256 digest and matching
+`<asset>.sig` sidecar, offers the bounded download, verification and install
+flow. The sidecar is Ed25519 over the canonical `simplicio-release-v1:<sha256>`
+payload using the pinned update-signature key. The download is anonymous,
+resumable, stored in a private directory and never starts an install before
+size, digest and signature verification. A missing digest or signature, stale
+manifest, wrong target, interrupted download or failed verification fails closed
+and leaves the current app intact.
 
 ## Public v3.8.47 companion evidence
 
@@ -42,6 +45,7 @@ native Desktop status probe remain unexecuted here.
 | Gate | Status | Boundary |
 | --- | --- | --- |
 | Desktop package digest and Runtime sidecar identity | **verified** | Downloaded DMG hash and extracted sidecar match the public release assets |
+| Desktop package Ed25519 sidecar | **blocked** | v3.8.47 publishes no `Simplicio-3.8.47-arm64.dmg.sig`; the updater must fail closed with `update_signature_unavailable` |
 | Runtime closed-world manifest | **verified** | `SHA256SUMS` and `simplicio-update-manifest.json` remain Runtime-only and unchanged |
 | Apple Developer ID signing and notarization | **blocked** | No Apple credentials are available; the package is ad-hoc and Gatekeeper acceptance is not claimed |
 | Authentication-only native probe and Google acceptance | **unexecuted** | Requires a native macOS executor and a separately authorized account run; no Google flow was initiated |
@@ -54,16 +58,19 @@ the blocked or unexecuted gates as passed.
 
 The updater transaction is implemented in `src-tauri::desktop_updater`:
 
-1. re-read the official release API and bind the requested version/tag/asset;
-2. resume into a private `.part` file and atomically stage the verified package;
+1. re-read the official release API and bind the requested version/tag/asset and signature sidecar;
+2. resume into a private `.part` file, verify SHA-256 and Ed25519, and atomically stage the verified package;
 3. retain the current macOS app bundle as one rollback candidate;
 4. replace the bundle, relaunch it, and persist `awaiting_health`;
 5. reconcile the running bundle version at startup, or restore the candidate.
 
 The Desktop UI never reports completion until startup reconciliation confirms the
-expected bundle version. A public GitHub digest is integrity evidence, not a
-Developer ID/notarization or independent release signature; publication still
-requires the signing, provenance and artifact gates below.
+expected bundle version. A public GitHub digest is integrity evidence; the
+updater additionally requires the independent Ed25519 sidecar before staging.
+This does not replace Apple Developer ID signing or notarization; publication
+still requires the signing, provenance and artifact gates below. The current
+public v3.8.47 Desktop package remains outside the installed updater trust gate
+until its matching sidecar is published in a new immutable release.
 
 ## Native bundle identity
 


### PR DESCRIPTION
## Development

Continuation of #375 on `codex/issue-375-provider-quotas-acceptance`, committed as `6356b49e025e762261142434880a181cfd09de4c`. This PR addresses the code/documentation portion of the issue and intentionally does not claim full #375 closure.

- Provider quotas now use `simplicio.provider-quotas/v2`, with bounded source, timestamp, account scope, redaction, reset windows, and explicit fresh/stale/unavailable states.
- Codex remains read-only through the supported `account/rateLimits/read` app-server lifecycle; Grok uses the fixed local CLI billing source. No credentials or raw provider payloads cross the renderer, and account login/logout/selection controls remain unavailable without a real provider contract.
- The anonymous Desktop updater now requires a matching uploaded `<asset>.sig`, verifies its size, SHA-256 digest, and Ed25519 signature over `simplicio-release-v1:<sha256>`, and fails closed before staging/installing when the signature is missing or invalid.
- Fixtures, UI messaging, native state handling, and Desktop provider/release contract docs were updated with regression coverage.

## Validation

| Check | Result |
| --- | --- |
| `git diff --check` | Passed |
| `cd apps/desktop && npm test -- --reporter=dot` | 63 files / 408 tests passed |
| `cd apps/desktop && npm run build` | Passed; existing Vite chunk-size warning |
| `cd apps/desktop && npm run test:e2e` | 117 passed |
| `cd apps/desktop && cargo test --manifest-path src-tauri/Cargo.toml --offline -j 1` | Not runnable: `rustc 1.85.0`; resolved dependencies require `rustc 1.88.0` |
| `cd apps/desktop && cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` | Not runnable: `cargo-fmt` is not installed |

## Tests

Frontend unit, production-build, and full Playwright validation passed locally. Native Rust validation is explicitly unexecuted because the Linux box has the incompatible Rust toolchain above. Earlier local acceptance evidence also recorded publisher contract tests passing (18) and three unrelated generic Python contract failures; those failures are not reclassified by this PR.

Playwright uses preview/mocked IPC and does not establish real provider authentication, signed distribution, or installed-app updater behavior.

## Item-by-item review

- Provider quota contract: implemented as bounded, redacted, source-labelled telemetry; missing data remains unknown rather than zero.
- Codex lifecycle: read-only app-server account/rate-limits request with bounded native handling; no renderer credential import.
- Grok: fixed billing source with explicit unavailable/refresh-required states; no fabricated quota values.
- Account management: remains correctly unavailable because quota telemetry is not provider login.
- Release updater: signature, digest, target, size, resumable download, and state gates are covered in source/tests; release installation remains separately platform-dependent.
- Full #375 closure is blocked by real evidence gaps:
  1. The published v3.8.47 Desktop DMG has no `Simplicio-3.8.47-arm64.dmg.sig`; the updater therefore intentionally fails closed with `update_signature_unavailable` for that release.
  2. This is a Linux execution environment, so there is no native macOS signed install/relaunch/rollback evidence from this box.
  3. Full Tauri native validation is blocked by `rustc 1.85.0` versus dependencies requiring `rustc 1.88.0`.
- No macOS signing, notarization, provider authentication, or updater install/relaunch/rollback result is claimed here.