### PR TITLE
fix(hosts): keep Claude MCP registration Mapper-only

### DIFF
--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -41,7 +41,9 @@ supported configuration locations are `~/.claude/settings.json` and
 `~/.claude/.mcp.json`; the public installer does not copy Codex-only hooks into
 those files. Verification is the Runtime registration receipt produced by
 `simplicio mcp register --binary <absolute-path> --json`, and the Runtime is
-responsible for the atomic merge and rollback of the host configuration.
+responsible for the atomic merge and rollback of the host configuration. The
+managed Claude MCP entry carries `SIMPLICIO_RUNTIME_MODE=mapper-only` so the
+direct registration path cannot silently select the full Runtime surface.
 
 Cursor is detected only through the exact `cursor` executable. The registry
 declares both user (`~/.cursor/mcp.json`) and workspace (`.cursor/mcp.json`)

--- a/docs/hosts/claude-code.md
+++ b/docs/hosts/claude-code.md
@@ -10,6 +10,12 @@ documented path available). Existing keys are preserved, writes are atomic,
 and a `.simplicio.bak` copy is kept before a replacement. Re-running the
 installer is a no-op after the entry is already correct.
 
+The installer-scoped MCP entry sets `SIMPLICIO_RUNTIME_MODE=mapper-only`. This
+keeps direct host registration aligned with the native Claude plugin: Mapper
+discovery and read-only context are available, while edit, run, loop, and
+execution surfaces are not advertised. Claude still owns its native editing
+and terminal tools; a registration receipt is not a live handshake.
+
 Live MCP registration and handshake evidence remain Runtime-owned. A dry run
 reports the planned path without creating or changing files; set
 `SIMPLICIO_SKIP_CLAUDE_CODE=1` to opt out.

--- a/pypi/simplicio/simplicio/host_adapters.py
+++ b/pypi/simplicio/simplicio/host_adapters.py
@@ -49,11 +49,14 @@ def _safe_binary(binary: str | os.PathLike[str]) -> str:
     return str(path)
 
 
-def _entry(binary: str) -> dict[str, Any]:
-    return {
+def _entry(binary: str, mcp_environment: Mapping[str, str] | None = None) -> dict[str, Any]:
+    entry: dict[str, Any] = {
         "command": binary,
         "args": ["serve", "--mcp", "--stdio"],
     }
+    if mcp_environment:
+        entry["env"] = dict(mcp_environment)
+    return entry
 
 
 def portable_cli_plan(spec: HostSpec, executable: str) -> dict[str, Any]:
@@ -113,7 +116,11 @@ def _load_json(path: Path) -> tuple[dict[str, Any], bytes, str | None]:
     return value, raw, None
 
 
-def _merge_mcp(document: dict[str, Any], binary: str) -> tuple[dict[str, Any], str]:
+def _merge_mcp(
+    document: dict[str, Any],
+    binary: str,
+    mcp_environment: Mapping[str, str] | None = None,
+) -> tuple[dict[str, Any], str]:
     result = json.loads(json.dumps(document, ensure_ascii=False))
     if isinstance(result.get("mcpServers"), dict):
         key = "mcpServers"
@@ -124,7 +131,7 @@ def _merge_mcp(document: dict[str, Any], binary: str) -> tuple[dict[str, Any], s
     servers = result.setdefault(key, {})
     if not isinstance(servers, dict):
         raise ValueError("MCP server collection must be an object")
-    servers[MANAGED_SERVER] = _entry(binary)
+    servers[MANAGED_SERVER] = _entry(binary, mcp_environment)
     return result, key
 
 
@@ -148,7 +155,8 @@ def _write_one(spec: HostSpec, path: Path, binary: str, *, dry_run: bool) -> Int
     if error:
         return IntegrationResult(spec.host_id, "failed", "", str(path), spec.capability, "none", error)
     try:
-        merged, _ = _merge_mcp(document, binary)
+        environment = dict(spec.mcp_environment)
+        merged, _ = _merge_mcp(document, binary, environment)
         encoded = (json.dumps(merged, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
     except (TypeError, ValueError):
         return IntegrationResult(spec.host_id, "failed", "", str(path), spec.capability, "none", "invalid_mcp_document")
@@ -163,7 +171,7 @@ def _write_one(spec: HostSpec, path: Path, binary: str, *, dry_run: bool) -> Int
             _atomic_write(path, encoded)
             round_trip, _, round_trip_error = _load_json(path)
             servers = round_trip.get("mcpServers", round_trip.get("servers", {}))
-            if round_trip_error or not isinstance(servers, dict) or servers.get(MANAGED_SERVER) != _entry(binary):
+            if round_trip_error or not isinstance(servers, dict) or servers.get(MANAGED_SERVER) != _entry(binary, environment):
                 raise OSError("managed entry did not survive the atomic write")
         except (OSError, ValueError):
             if backup and Path(backup).exists():

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -37,6 +37,7 @@ class HostSpec:
     verification_command: Tuple[str, ...] = ()
     scopes: Tuple[str, ...] = ("user",)
     default_scope: str = "user"
+    mcp_environment: Tuple[Tuple[str, str], ...] = ()
     documentation: str = ""
     reason: str = ""
 
@@ -50,6 +51,7 @@ def _runtime_mcp(
     minimum_version: str = "not-pinned",
     scopes: Sequence[str] = ("user",),
     default_scope: str = "user",
+    mcp_environment: Sequence[Tuple[str, str]] = (),
 ) -> HostSpec:
     return HostSpec(
         host_id=host_id,
@@ -69,6 +71,7 @@ def _runtime_mcp(
         ),
         scopes=tuple(scopes),
         default_scope=default_scope,
+        mcp_environment=tuple(mcp_environment),
         documentation=documentation,
         reason="The Runtime owns the atomic MCP/native-hook registration.",
     )
@@ -96,6 +99,7 @@ HOSTS: Tuple[HostSpec, ...] = (
         ("claude",),
         ("~/.claude/settings.json", "~/.claude/.mcp.json"),
         "https://docs.anthropic.com/claude/docs/claude-code",
+        mcp_environment=(("SIMPLICIO_RUNTIME_MODE", "mapper-only"),),
     ),
     _runtime_mcp(
         "cursor",

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -115,6 +115,9 @@ def test_claude_code_contract_uses_exact_probe_and_user_scope(tmp_path: Path) ->
     assert result["results"][0]["status"] == "registered"
     document = json.loads(config.read_text(encoding="utf-8"))
     assert document["mcpServers"]["simplicio"]["command"] == "/opt/simplicio/bin/simplicio"
+    assert document["mcpServers"]["simplicio"]["env"] == {
+        "SIMPLICIO_RUNTIME_MODE": "mapper-only",
+    }
     assert not (home / ".claude" / "settings.json.simplicio.bak").is_symlink()
 
 
@@ -191,6 +194,7 @@ def test_opencode_contract_registers_documented_user_config(tmp_path: Path) -> N
     document = json.loads(config.read_text(encoding="utf-8"))
     assert document["provider"] == "local"
     assert document["mcpServers"]["simplicio"]["args"] == ["serve", "--mcp", "--stdio"]
+    assert "env" not in document["mcpServers"]["simplicio"]
 
 
 def test_vscode_contract_supports_user_workspace_and_remote_scopes(tmp_path: Path) -> None:

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -65,6 +65,7 @@ def test_claude_code_has_runtime_verification_contract() -> None:
     assert claude.capability == "runtime-mcp"
     assert claude.verification_command[-1] == "--json"
     assert "<absolute-path>" in claude.verification_command
+    assert claude.mcp_environment == (("SIMPLICIO_RUNTIME_MODE", "mapper-only"),)
 
 
 def test_cursor_declares_user_and_workspace_scopes() -> None:


### PR DESCRIPTION
Related to #373.

## Development

The public Claude host adapter wrote a bare `simplicio serve --mcp --stdio` entry, while the native Claude plugin already scopes its process to `SIMPLICIO_RUNTIME_MODE=mapper-only`. Add a host-spec environment contract and persist that environment only for Claude. This prevents the direct registration path from silently advertising the full Runtime surface. Cursor, OpenCode, and other Runtime-MCP hosts keep their existing entries.

## Validation

- `uv run --isolated --with pytest pytest -q tests/test_host_adapters.py tests/test_host_integrations.py`
- `python3 -m compileall -q pypi/simplicio/simplicio tests scripts`
- `git diff --cached --check`

## Tests

- 30 focused host adapter/integration tests passed.
- Native Claude/Hermes Mapper-only source remains separately tested; live host reconnect and Runtime conformance still require the installed Runtime/host matrix.

## Item-by-item review

- Host contract: Claude declares `SIMPLICIO_RUNTIME_MODE=mapper-only`.
- Persistence: the managed Claude MCP JSON entry writes and round-trip-verifies the environment.
- Isolation: non-Claude Runtime-MCP entries do not receive the environment.
- Documentation: direct registration and native plugin boundaries are explicit.
- Remaining: this does not prove an installed Claude/Hermes live handshake or Runtime release evidence.