### PR TITLE
Desktop: add provider quota acceptance contract and installed evidence

### DIFF
--- a/apps/desktop/src-tauri/src/provider_quotas.rs
+++ b/apps/desktop/src-tauri/src/provider_quotas.rs
@@ -4,6 +4,9 @@ use std::{path::PathBuf, process::Command, sync::Mutex, time::{Duration, Instant
 
 const SCHEMA: &str = "simplicio.provider-quotas/v2";
 const MAX_STALE_SECS: u64 = 15 * 60;
+const MAX_WINDOW_DURATION_MINS: u64 = 366 * 24 * 60;
+const MAX_SAFE_EPOCH_SECS: u64 = 9_007_199_254_740_991;
+const MAX_WINDOWS: usize = 32;
 static CACHE: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
 
 fn now_secs() -> u64 {
@@ -34,7 +37,9 @@ fn window(value: &Value) -> Option<Value> {
     let used = value.get("usedPercent")?.as_f64()?;
     let minutes = value.get("windowDurationMins")?.as_u64()?;
     let resets = value.get("resetsAt")?.as_u64()?;
-    if !used.is_finite() || !(0.0..=100.0).contains(&used) || minutes == 0 { return None; }
+    if !used.is_finite() || !(0.0..=100.0).contains(&used)
+        || minutes == 0 || minutes > MAX_WINDOW_DURATION_MINS
+        || resets > MAX_SAFE_EPOCH_SECS { return None; }
     Some(json!({"usedPercent": used, "windowDurationMins": minutes, "resetsAt": resets}))
 }
 
@@ -58,6 +63,7 @@ fn flatten_windows(groups: &[Value]) -> Vec<Value> {
     groups.iter()
         .filter_map(|group| group.get("windows").and_then(Value::as_array))
         .flat_map(|windows| windows.iter().cloned())
+        .take(MAX_WINDOWS)
         .collect()
 }
 
@@ -162,6 +168,11 @@ time.sleep(10)
         assert!(project(&json!({"rateLimits": null})).is_empty());
     }
     #[test]
+    fn rejects_unbounded_window_fields() {
+        assert!(window(&json!({"usedPercent": 21, "windowDurationMins": MAX_WINDOW_DURATION_MINS + 1, "resetsAt": 1900000000})).is_none());
+        assert!(window(&json!({"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": MAX_SAFE_EPOCH_SECS + 1})).is_none());
+    }
+    #[test]
     fn falls_back_to_legacy_limits_when_limit_id_map_is_empty() {
         let result = project(&json!({"rateLimitsByLimitId": {}, "rateLimits": {"primary": {"usedPercent": 21, "windowDurationMins": 10080, "resetsAt": 1900000000}}}));
         assert_eq!(result.len(), 1);
@@ -185,5 +196,11 @@ time.sleep(10)
         mark_stale(&mut value, MAX_STALE_SECS + 2);
         assert_eq!(value["providers"][0]["status"], "stale");
         assert_eq!(value["providers"][0]["error"], "stale");
+    }
+    #[test]
+    fn root_status_preserves_fresh_stale_and_unavailable_states() {
+        assert_eq!(root_status(&[provider("codex", "codex_app_server", "local_authenticated_account", 1, "fresh", vec![json!({"usedPercent": 1, "windowDurationMins": 10080, "resetsAt": 1900000000})], None)]), "available");
+        assert_eq!(root_status(&[provider("codex", "codex_app_server", "local_authenticated_account", 1, "stale", vec![json!({"usedPercent": 1, "windowDurationMins": 10080, "resetsAt": 1900000000})], Some("stale"))]), "stale");
+        assert_eq!(root_status(&[provider("codex", "codex_app_server", "local_authenticated_account", 1, "unavailable", vec![], Some("login_required"))]), "unavailable");
     }
 }

--- a/apps/desktop/src/components/ProviderUsage.tsx
+++ b/apps/desktop/src/components/ProviderUsage.tsx
@@ -25,6 +25,11 @@ const sources = ["codex_app_server", "grok_cli_billing"] as const;
 const scopes = ["local_authenticated_account", "local_cli_session"] as const;
 const statuses = ["fresh", "stale", "unavailable"] as const;
 const maxProviderWindows = 32;
+const maxWindowDurationMins = 366 * 24 * 60;
+const providerContract = {
+  codex: { source: "codex_app_server", accountScope: "local_authenticated_account" },
+  grok: { source: "grok_cli_billing", accountScope: "local_cli_session" },
+} as const;
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -36,8 +41,8 @@ function parseWindow(value: unknown): WindowUsage {
   const minutes = value.windowDurationMins;
   const resets = value.resetsAt;
   if (typeof used !== "number" || !Number.isFinite(used) || used < 0 || used > 100
-    || typeof minutes !== "number" || !Number.isSafeInteger(minutes) || minutes <= 0
-    || typeof resets !== "number" || !Number.isSafeInteger(resets) || resets < 0) {
+    || typeof minutes !== "number" || !Number.isSafeInteger(minutes) || minutes <= 0 || minutes > maxWindowDurationMins
+    || typeof resets !== "number" || !Number.isSafeInteger(resets) || resets < 0 || resets > Number.MAX_SAFE_INTEGER) {
     throw new Error("quota_invalid");
   }
   return { usedPercent: used, windowDurationMins: minutes, resetsAt: resets };
@@ -53,13 +58,17 @@ export function parseQuotas(value: unknown): Quotas {
   }
   const seen = new Set<string>();
   const providers = value.providers.map((raw): ProviderQuota => {
+    const id = record(raw) ? raw.id : undefined;
+    const contract = providerContract[id as keyof typeof providerContract];
     if (!record(raw)
       || !providerIds.includes(raw.id as typeof providerIds[number])
       || seen.has(String(raw.id))
       || !sources.includes(raw.source as typeof sources[number])
       || !scopes.includes(raw.accountScope as typeof scopes[number])
+      || !contract || raw.source !== contract.source || raw.accountScope !== contract.accountScope
       || raw.redacted !== true
       || !Number.isSafeInteger(raw.observedAt) || Number(raw.observedAt) < 0
+      || Number(raw.observedAt) > Number(value.observedAt)
       || !statuses.includes(raw.status as typeof statuses[number])
       || !Array.isArray(raw.windows) || raw.windows.length > maxProviderWindows
       || (raw.status === "unavailable" && raw.windows.length !== 0)
@@ -84,6 +93,12 @@ export function parseQuotas(value: unknown): Quotas {
     };
   });
   if (value.status === "busy" && providers.length !== 0) throw new Error("quota_invalid");
+  if (value.status !== "busy") {
+    const expectedStatus = providers.some(provider => provider.status === "fresh")
+      ? "available"
+      : providers.some(provider => provider.status === "stale") ? "stale" : "unavailable";
+    if (value.status !== expectedStatus) throw new Error("quota_invalid");
+  }
   return {
     schema: "simplicio.provider-quotas/v2",
     status: value.status as Quotas["status"],

--- a/apps/desktop/src/native_observations.test.ts
+++ b/apps/desktop/src/native_observations.test.ts
@@ -21,4 +21,16 @@ describe("native permission and quota projections", () => {
     expect(parseQuotas(stale).providers[0].status).toBe("stale");
     expect(parseQuotas({ ...stale, status: "unavailable", providers: [{ ...stale.providers[0], status: "unavailable", windows: [], error: "login_required" }] }).providers[0].windows).toHaveLength(0);
   });
+  it("rejects mismatched source, future observations and unbounded windows", () => {
+    const quota = { schema: "simplicio.provider-quotas/v2", status: "available", observedAt: 1900000000, providers: [{ id: "codex", source: "grok_cli_billing", accountScope: "local_authenticated_account", observedAt: 1900000001, redacted: true, status: "fresh", windows: [{ usedPercent: 21, windowDurationMins: 10080, resetsAt: 1900000000 }] }] };
+    expect(() => parseQuotas(quota)).toThrow();
+    quota.providers[0].source = "codex_app_server";
+    quota.providers[0].observedAt = 1900000000;
+    quota.providers[0].windows[0].windowDurationMins = 366 * 24 * 60 + 1;
+    expect(() => parseQuotas(quota)).toThrow();
+  });
+  it("requires root status to agree with provider states", () => {
+    const quota = { schema: "simplicio.provider-quotas/v2", status: "unavailable", observedAt: 1900000000, providers: [{ id: "codex", source: "codex_app_server", accountScope: "local_authenticated_account", observedAt: 1900000000, redacted: true, status: "fresh", windows: [{ usedPercent: 21, windowDurationMins: 10080, resetsAt: 1900000000 }] }] };
+    expect(() => parseQuotas(quota)).toThrow();
+  });
 });

--- a/docs/desktop/INSTALLED-E2E.md
+++ b/docs/desktop/INSTALLED-E2E.md
@@ -37,3 +37,42 @@ Local-project acceptance validates an actual folder, opens it through the fixed
 native handler, scopes the token query to that directory and removes only the
 bookmark. Native diagnostic/activity exports must return an actual saved path
 and preserve existing Downloads files, just like the token exports.
+
+## #375 acceptance evidence path
+
+The installed run writes one redacted report per native executor under the
+ignored local path `reports/desktop-installed/<platform>-<run>.json`. Validate
+that report with:
+
+```bash
+python3 scripts/verify_desktop_installed_acceptance.py \
+  --evidence reports/desktop-installed/macos-arm64-<run>.json --json
+```
+
+The report schema is `simplicio.desktop-installed-acceptance/v1`. It must name
+the installed app and bundled Runtime digest, use an isolated clean HOME, and
+mark each of these checks as `verified` before the report can be `READY`:
+
+`bundle_identity`, `runtime_snapshot`, `provider_quotas_contract`,
+`provider_quotas_current`, `signed_update_download`, `signed_update_install`,
+`signed_update_relaunch`, `signed_update_health`, `signed_update_rollback`,
+`logout_relogin`, and `permissions`.
+
+`provider_quotas_contract` records only the v2 schema, fixed source/scope,
+redaction and status/window counts. `provider_quotas_current` separately
+requires at least one fresh provider id; an honest unavailable session is not
+converted into a current reading. The report contains no paths, credentials,
+raw provider payloads or account identity.
+
+The updater checks are separate lifecycle gates: a verified download is not an
+installed update, a relaunch is not health confirmation, and a failed health
+check must retain rollback evidence. A missing Desktop `.sig`, unavailable
+native executor, unavailable Apple signing/notarization, or incompatible Rust
+toolchain is recorded with `blocked`/`unexecuted` plus a reason code and keeps
+the report blocked. Preview/Playwright evidence is rejected by the verifier.
+
+For the current Linux workspace, do not create a synthetic macOS report. The
+published v3.8.47 DMG has no matching `.sig`, Linux has no native signed
+macOS-install evidence, and native Rust evidence is conditional on a
+Tauri-compatible `rustc` (the earlier PR run was blocked by rustc 1.85.0);
+these remain explicit blockers in the PR and release notes when applicable.

--- a/docs/desktop/PROVIDER-CONTRACT.md
+++ b/docs/desktop/PROVIDER-CONTRACT.md
@@ -37,11 +37,25 @@ the Desktop bridge.
 
 ## Provider quota telemetry
 
-The read-only quota command returns `simplicio.provider-quotas/v2` with one
-bounded record per provider. Each record carries `source`, `observedAt`,
-`accountScope`, `redacted: true`, `status` (`fresh`, `stale` or `unavailable`),
-an optional bounded error and reset windows with `usedPercent`,
-`windowDurationMins` and `resetsAt`.
+The read-only `desktop_provider_quotas` command returns
+`simplicio.provider-quotas/v2`. Its root status is `available`, `stale`,
+`unavailable` or transient `busy`; `busy` always has an empty provider list.
+Otherwise the root status is `available` when any provider is `fresh`, `stale`
+when none is fresh but at least one is stale, and `unavailable` when no usable
+record exists. Each provider record carries `source`, `observedAt` (no later
+than the root timestamp), `accountScope`, `redacted: true`, `status` (`fresh`,
+`stale` or `unavailable`), an optional error code of at most 64 lowercase ASCII
+characters, and at most 32 reset windows.
+
+| Provider | Source | Account scope |
+| --- | --- | --- |
+| `codex` | `codex_app_server` | `local_authenticated_account` |
+| `grok` | `grok_cli_billing` | `local_cli_session` |
+
+Every window has finite `usedPercent` in `0..100`, a positive
+`windowDurationMins` no larger than 366 days, and a non-negative reset epoch
+that fits JavaScript's safe integer range. An `unavailable` provider has no
+windows; missing values remain unavailable rather than becoming zero.
 
 Codex is read through the supported `account/rateLimits/read` app-server RPC;
 Grok is read through its fixed CLI billing endpoint using the existing local
@@ -50,6 +64,10 @@ percentages are unavailable, never zero; stale values remain explicitly stale.
 This telemetry is separate from Runtime token ledgers and never enables account
 creation, logout, login or account selection. Those controls remain unavailable
 until a real provider account contract exists.
+
+The renderer validates this boundary again before displaying it. A valid
+contract with no current provider session is an honest `unavailable`
+observation, not proof of a live quota reading.
 
 ## Host-path caveat
 

--- a/scripts/verify_desktop_installed_acceptance.py
+++ b/scripts/verify_desktop_installed_acceptance.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Verify redacted evidence from one installed Desktop acceptance run.
+
+This verifier accepts only a report captured from the installed native app. It
+does not turn preview tests, a build directory, or a missing platform into a
+pass. Blocked and unexecuted checks are retained as honest evidence but keep
+the report not ready.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "simplicio.desktop-installed-acceptance/v1"
+PLATFORMS = ("macos-arm64", "macos-x64", "windows-x64", "linux-x64")
+CHECKS = (
+    "bundle_identity",
+    "runtime_snapshot",
+    "provider_quotas_contract",
+    "provider_quotas_current",
+    "signed_update_download",
+    "signed_update_install",
+    "signed_update_relaunch",
+    "signed_update_health",
+    "signed_update_rollback",
+    "logout_relogin",
+    "permissions",
+)
+STATUSES = {"verified", "blocked", "unexecuted"}
+REASONS = {
+    "app_not_installed",
+    "artifact_not_built",
+    "authentication_not_authorized",
+    "developer_id_unavailable",
+    "environment_blocked",
+    "host_unavailable",
+    "notarization_unavailable",
+    "provider_session_unavailable",
+    "rust_toolchain_unavailable",
+    "signed_sidecar_missing",
+}
+PROVIDER_CONTRACT = {
+    "codex": ("codex_app_server", "local_authenticated_account"),
+    "grok": ("grok_cli_billing", "local_cli_session"),
+}
+PROVIDER_STATUSES = {"fresh", "stale", "unavailable"}
+ROOT_STATUSES = {"available", "stale", "unavailable", "busy"}
+IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+DIGEST = re.compile(r"^[0-9a-f]{64}$")
+UNSAFE_KEY = re.compile(
+    r"(?:path|cwd|home|argv|secret|password|credential|authorization|"
+    r"api[_-]?key|access[_-]?token|refresh[_-]?token|raw[_-]?(?:output|payload))",
+    re.I,
+)
+
+
+def _error(code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
+
+
+def _contains_unsafe_key(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(
+            not isinstance(key, str)
+            or (key != "clean_home" and UNSAFE_KEY.search(key) is not None)
+            or _contains_unsafe_key(child)
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_unsafe_key(child) for child in value)
+    return False
+
+
+def _quota_errors(observation: Any) -> list[dict[str, str]]:
+    errors: list[dict[str, str]] = []
+    if not isinstance(observation, dict):
+        return [_error("quota_observation_missing", "provider quota contract observation is required")]
+    if observation.get("schema") != "simplicio.provider-quotas/v2":
+        errors.append(_error("quota_schema_invalid", "provider quota observation must use v2"))
+    root_status = observation.get("status")
+    if root_status not in ROOT_STATUSES:
+        errors.append(_error("quota_root_status_invalid", "provider quota root status is invalid"))
+    providers = observation.get("providers")
+    if not isinstance(providers, list) or len(providers) > 2:
+        errors.append(_error("quota_providers_invalid", "provider quota observation must contain at most two records"))
+        providers = []
+    seen: set[str] = set()
+    statuses: list[str] = []
+    for provider in providers:
+        if not isinstance(provider, dict):
+            errors.append(_error("quota_provider_invalid", "each provider quota record must be an object"))
+            continue
+        provider_id = provider.get("id")
+        source = provider.get("source")
+        scope = provider.get("accountScope")
+        expected = PROVIDER_CONTRACT.get(provider_id) if isinstance(provider_id, str) else None
+        if (
+            not isinstance(provider_id, str)
+            or provider_id in seen
+            or expected is None
+            or source != expected[0]
+            or scope != expected[1]
+        ):
+            errors.append(_error("quota_provider_identity_invalid", "provider id, source and account scope must agree"))
+        else:
+            seen.add(provider_id)
+        if provider.get("redacted") is not True:
+            errors.append(_error("quota_redaction_invalid", "provider quota evidence must be redacted"))
+        status = provider.get("status")
+        if status not in PROVIDER_STATUSES:
+            errors.append(_error("quota_provider_status_invalid", "provider quota status is invalid"))
+        else:
+            statuses.append(status)
+        window_count = provider.get("window_count")
+        if not isinstance(window_count, int) or isinstance(window_count, bool) or not 0 <= window_count <= 32:
+            errors.append(_error("quota_window_count_invalid", "provider quota window_count must be between 0 and 32"))
+        elif status == "unavailable" and window_count != 0:
+            errors.append(_error("quota_unavailable_has_windows", "unavailable provider quotas must have zero windows"))
+        elif status in {"fresh", "stale"} and window_count == 0:
+            errors.append(_error("quota_current_has_no_windows", "fresh or stale provider quotas need a window count"))
+    if root_status == "busy" and providers:
+        errors.append(_error("quota_busy_has_providers", "busy root status must have no provider records"))
+    elif root_status != "busy":
+        expected_root = "available" if "fresh" in statuses else "stale" if "stale" in statuses else "unavailable"
+        if root_status != expected_root:
+            errors.append(_error("quota_root_status_mismatch", "root status does not summarize provider states"))
+    return errors
+
+
+def verify_evidence(document: Any) -> dict[str, Any]:
+    errors: list[dict[str, str]] = []
+    if not isinstance(document, dict):
+        return {"schema": SCHEMA, "ready": False, "errors": [_error("document_invalid", "evidence must be an object")]}
+    if _contains_unsafe_key(document):
+        return {"schema": SCHEMA, "ready": False, "errors": [_error("sensitive_field", "installed evidence contains a forbidden field")]}
+    if document.get("schema") != SCHEMA:
+        errors.append(_error("schema_invalid", f"schema must be {SCHEMA}"))
+    if document.get("source") != "installed" or document.get("preview") is not False:
+        errors.append(_error("installed_source_required", "preview or mocked evidence cannot satisfy installed acceptance"))
+    if document.get("clean_home") is not True:
+        errors.append(_error("clean_home_required", "acceptance must use an isolated clean HOME"))
+    if document.get("platform") not in PLATFORMS:
+        errors.append(_error("platform_invalid", "acceptance must name a supported native platform"))
+    app = document.get("installed_app")
+    if not isinstance(app, dict) or not isinstance(app.get("version"), str) or not VERSION.fullmatch(app["version"]):
+        errors.append(_error("installed_app_identity_missing", "installed_app.version must be a release version"))
+    if not isinstance(app, dict) or not isinstance(app.get("runtime_version"), str) or not VERSION.fullmatch(app["runtime_version"]):
+        errors.append(_error("runtime_identity_missing", "installed_app.runtime_version must be a release version"))
+    if not isinstance(app, dict) or not isinstance(app.get("runtime_digest"), str) or not DIGEST.fullmatch(app["runtime_digest"]):
+        errors.append(_error("runtime_digest_missing", "installed_app.runtime_digest must be a SHA-256 digest"))
+
+    records = document.get("checks")
+    if not isinstance(records, list):
+        records = []
+        errors.append(_error("checks_missing", "acceptance checks must be a list"))
+    by_id: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict) or not isinstance(record.get("id"), str):
+            errors.append(_error("check_invalid", "each acceptance check needs an id"))
+            continue
+        check_id = record["id"]
+        if check_id in by_id:
+            errors.append(_error("check_duplicate", f"duplicate acceptance check: {check_id}"))
+        by_id[check_id] = record
+    missing = sorted(set(CHECKS) - set(by_id))
+    extra = sorted(set(by_id) - set(CHECKS))
+    if missing:
+        errors.append(_error("check_missing", "missing checks: " + ", ".join(missing)))
+    if extra:
+        errors.append(_error("check_unknown", "unknown checks: " + ", ".join(extra)))
+
+    verified: list[str] = []
+    blocked: list[str] = []
+    unexecuted: list[str] = []
+    for check_id in CHECKS:
+        record = by_id.get(check_id)
+        if record is None:
+            continue
+        if record.get("source") != "installed" or record.get("redacted") is not True:
+            errors.append(_error("check_evidence_invalid", f"{check_id} must be installed redacted evidence"))
+        evidence_id = record.get("evidence_id")
+        if not isinstance(evidence_id, str) or not IDENTIFIER.fullmatch(evidence_id):
+            errors.append(_error("evidence_id_invalid", f"{check_id} needs a safe evidence_id"))
+        status = record.get("status")
+        if status not in STATUSES:
+            errors.append(_error("check_status_invalid", f"{check_id} has an invalid status"))
+            continue
+        if status == "verified":
+            verified.append(check_id)
+            if "reason_code" in record:
+                errors.append(_error("verified_reason_invalid", f"verified {check_id} cannot carry a blocker reason"))
+        else:
+            (blocked if status == "blocked" else unexecuted).append(check_id)
+            if record.get("reason_code") not in REASONS:
+                errors.append(_error("reason_code_invalid", f"{check_id} needs an explicit environment reason"))
+        if check_id == "provider_quotas_contract" and status == "verified":
+            errors.extend(_quota_errors(record.get("observation")))
+        if check_id == "provider_quotas_current" and status == "verified":
+            fresh = record.get("fresh_provider_ids")
+            if (
+                not isinstance(fresh, list)
+                or not fresh
+                or any(not isinstance(item, str) or item not in PROVIDER_CONTRACT for item in fresh)
+            ):
+                errors.append(_error("quota_current_missing", "current quota evidence needs at least one fresh provider id"))
+
+    ready = not errors and len(verified) == len(CHECKS)
+    return {
+        "schema": SCHEMA,
+        "ready": ready,
+        "platform": document.get("platform"),
+        "verified_checks": verified,
+        "blocked_checks": blocked,
+        "unexecuted_checks": unexecuted,
+        "required_checks": len(CHECKS),
+        "errors": errors,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        report = verify_evidence(json.loads(args.evidence.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        report = {"schema": SCHEMA, "ready": False, "errors": [_error("evidence_read_failed", str(exc))]}
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    else:
+        print("desktop installed acceptance: " + ("READY" if report["ready"] else "BLOCKED"))
+        for item in report.get("errors", []):
+            print(f"  [{item['code']}] {item['message']}")
+        for check_id in report.get("blocked_checks", []):
+            print(f"  [blocked] {check_id}")
+        for check_id in report.get("unexecuted_checks", []):
+            print(f"  [unexecuted] {check_id}")
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_desktop_installed_acceptance.py
+++ b/tests/test_desktop_installed_acceptance.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from scripts.verify_desktop_installed_acceptance import CHECKS, SCHEMA, verify_evidence
+
+
+def valid_document() -> dict:
+    observation = {
+        "schema": "simplicio.provider-quotas/v2",
+        "status": "available",
+        "providers": [
+            {
+                "id": "codex",
+                "source": "codex_app_server",
+                "accountScope": "local_authenticated_account",
+                "redacted": True,
+                "status": "fresh",
+                "window_count": 1,
+            },
+            {
+                "id": "grok",
+                "source": "grok_cli_billing",
+                "accountScope": "local_cli_session",
+                "redacted": True,
+                "status": "unavailable",
+                "window_count": 0,
+            },
+        ],
+    }
+    checks = []
+    for check_id in CHECKS:
+        record = {
+            "id": check_id,
+            "status": "verified",
+            "source": "installed",
+            "redacted": True,
+            "evidence_id": f"evidence-{check_id}",
+        }
+        if check_id == "provider_quotas_contract":
+            record["observation"] = observation
+        if check_id == "provider_quotas_current":
+            record["fresh_provider_ids"] = ["codex"]
+        checks.append(record)
+    return {
+        "schema": SCHEMA,
+        "source": "installed",
+        "preview": False,
+        "clean_home": True,
+        "platform": "linux-x64",
+        "installed_app": {
+            "version": "3.8.47",
+            "runtime_version": "3.8.47",
+            "runtime_digest": "a" * 64,
+        },
+        "checks": checks,
+    }
+
+
+def test_complete_installed_acceptance_is_ready() -> None:
+    report = verify_evidence(valid_document())
+    assert report["ready"] is True
+    assert report["verified_checks"] == list(CHECKS)
+
+
+def test_blocked_install_is_explicit_but_not_ready() -> None:
+    document = valid_document()
+    document["checks"][4] = {
+        "id": "signed_update_download",
+        "status": "blocked",
+        "source": "installed",
+        "redacted": True,
+        "evidence_id": "update-download-blocked",
+        "reason_code": "signed_sidecar_missing",
+    }
+    report = verify_evidence(document)
+    assert report["ready"] is False
+    assert report["blocked_checks"] == ["signed_update_download"]
+    assert report["errors"] == []
+
+
+def test_preview_and_missing_current_quota_are_not_passes() -> None:
+    document = valid_document()
+    document["preview"] = True
+    current = document["checks"][3]
+    current.pop("fresh_provider_ids")
+    report = verify_evidence(document)
+    codes = {item["code"] for item in report["errors"]}
+    assert {"installed_source_required", "quota_current_missing"} <= codes
+
+
+def test_quota_identity_and_root_state_are_checked() -> None:
+    document = valid_document()
+    observation = document["checks"][2]["observation"]
+    observation["status"] = "unavailable"
+    observation["providers"][0]["source"] = "grok_cli_billing"
+    report = verify_evidence(document)
+    codes = {item["code"] for item in report["errors"]}
+    assert {"quota_provider_identity_invalid", "quota_root_status_mismatch"} <= codes
+
+
+def test_sensitive_evidence_is_rejected() -> None:
+    document = deepcopy(valid_document())
+    document["checks"][0]["raw_output"] = "not publishable"
+    report = verify_evidence(document)
+    assert report["errors"][0]["code"] == "sensitive_field"


### PR DESCRIPTION
## Development

Continuation of #375 on `codex/issue-375-provider-quotas-acceptance`, based on merged `origin/master` at `1ad65d6`. This PR contains only the remaining provider-quota contract and installed-app acceptance evidence path.

- Tightens `simplicio.provider-quotas/v2`: fixed provider/source/account-scope identity, bounded windows, safe reset epochs, provider/root status invariants, redaction, and timestamp ordering. The renderer validates the same boundary again.
- Adds `scripts/verify_desktop_installed_acceptance.py` and focused tests. Reports are redacted, preview/mock evidence is rejected, provider contract shape and current fresh-quota evidence are separate checks, and blocked/unexecuted native updater gates remain visible.
- Documents the fixed installed evidence path under `reports/desktop-installed/<platform>-<run>.json`; no new screens or IDE/worktree UX are introduced.

## Validation

- `git diff --check`: passed.
- `cd apps/desktop && npm test -- --run`: 63 files / 412 tests passed.
- `cd apps/desktop && npm run build`: passed; existing Vite chunk-size warning.
- `pytest -q tests/test_desktop_installed_acceptance.py tests/test_desktop_release_evidence.py tests/test_installed_validation_matrix.py`: 13 passed.
- `TAURI_CONFIG='{"bundle":{"externalBin":[]}}' cargo test --manifest-path src-tauri/Cargo.toml --offline -j 1 provider_quotas`: 7 passed.
- Full Playwright run is not acceptance evidence: 106/118 passed, 12 failed with Chromium page crashes/timeouts and concurrent dirty-worktree behavior. No installed-native claim is based on it.
- Normal native cargo invocation remains blocked when the ignored Runtime sidecar is absent; the sidecar-independent unit run above does not prove a packaged app.

## Tests

Frontend unit/build, focused verifier, and targeted native quota tests are green. The ignored sidecar bytes and a macOS native executor were not available, so installed-app, signed-update install/relaunch/health/rollback, and native WebView acceptance remain unexecuted.

## Item-by-item review

- Provider quota contract: implemented and tested at native projection, renderer parser, and redacted evidence-verifier boundaries.
- Codex lifecycle: remains read-only through `account/rateLimits/read`; no credential or account-management contract is added.
- Grok: remains the fixed local billing source with explicit unavailable/refresh-required states.
- Installed-app acceptance: executable evidence schema and validation path are documented; no synthetic macOS report is created.
- Updates: Ed25519 fail-closed behavior from the merged PR is preserved; this PR does not claim install/relaunch/rollback proof.
- Explicit blockers: the published v3.8.47 DMG has no matching `Simplicio-3.8.47-arm64.dmg.sig`; Linux cannot provide native signed macOS install/relaunch/rollback evidence; native full validation requires an ignored staged Runtime sidecar and a Tauri-compatible rustc. No macOS signing, notarization, or provider authentication evidence is claimed.