### PR TITLE
feat(desktop): refine settings, activity, and usage UX

### DIFF
--- a/apps/desktop/e2e/desktop.spec.ts
+++ b/apps/desktop/e2e/desktop.spec.ts
@@ -29,6 +29,10 @@ test("all navigation, provider, receipt, and account controls work", async ({ pa
 
   await page.getByRole("button", { name: "Atividade", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();
+  await page.getByRole("searchbox", { name: "Buscar recibos", exact: true }).fill("contexto");
+  await expect(page.locator(".activity-page-row")).toHaveCount(1);
+  await expect(page.locator(".activity-page-row")).toContainText("Contexto reutilizado");
+  await page.getByRole("searchbox", { name: "Buscar recibos", exact: true }).fill("");
   await page.getByRole("button", { name: "atenção" }).click();
   await page.locator(".activity-provider-filter select").selectOption("all");
   const activityDownload = page.waitForEvent("download");
@@ -61,6 +65,25 @@ test("all navigation, provider, receipt, and account controls work", async ({ pa
   await expect(page.getByRole("heading", { name: "Conta Simplicio" })).toBeVisible();
   await page.getByRole("button", { name: "Sair da conta" }).click();
   await expect(page.getByRole("button", { name: "Começar", exact: true })).toBeVisible();
+});
+
+test("Desktop settings persist language and launch preferences and keep uninstall bounded", async ({ page }) => {
+  await page.goto("/?state=active&view=settings");
+  await expect(page.getByRole("heading", { name: "Conta Simplicio" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Idioma da interface", exact: true })).toHaveValue("pt-BR");
+  await page.getByRole("combobox", { name: "Comportamento ao iniciar", exact: true }).selectOption("last_view");
+  await expect(page.getByRole("combobox", { name: "Comportamento ao iniciar", exact: true })).toHaveValue("last_view");
+  await page.reload();
+  await expect(page.getByRole("combobox", { name: "Comportamento ao iniciar", exact: true })).toHaveValue("last_view");
+  await page.goto("/?state=active&view=activity");
+  await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();
+  await page.goto("/?state=active");
+  await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();
+  await page.goto("/?state=active&view=settings");
+  await expect(page.getByRole("button", { name: "Abrir localização do app", exact: true })).toBeEnabled();
+  await page.getByRole("button", { name: "Abrir localização do app", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("Nenhum arquivo foi removido");
+  await expect(page.getByText("Projetos, relatórios e o Runtime gerenciado não são removidos", { exact: false })).toBeVisible();
 });
 
 test("Bot Center exposes the canonical roster, timeline, rooms, and honest computer state", async ({ page }) => {

--- a/apps/desktop/e2e/runtime-integration.spec.ts
+++ b/apps/desktop/e2e/runtime-integration.spec.ts
@@ -273,5 +273,5 @@ test("diagnostic and activity exports go through native commands with no fronten
   await page.getByRole("button", { name: "atenção", exact: true }).click();
   await page.getByRole("button", { name: "Exportar recibos" }).click();
   await expect(page.getByRole("status")).toContainText("/Downloads/simplicio-activity.json");
-  expect((await calls(page, "desktop_export_snapshot")).at(-1)?.args).toEqual({ kind: "activity", filters: { status: "attention", provider: "all" } });
+  expect((await calls(page, "desktop_export_snapshot")).at(-1)?.args).toEqual({ kind: "activity", filters: { status: "attention", provider: "all", search: "" } });
 });

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -834,6 +834,54 @@ async fn desktop_open_releases() -> Result<(), String> {
         .map_err(|_| "release_page_unavailable".to_string())?
 }
 
+fn open_uninstall_location() -> Result<(), String> {
+    let executable = std::env::current_exe().map_err(|_| "uninstall_location_unavailable")?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let bundle = executable
+            .ancestors()
+            .find(|path| path.extension().is_some_and(|extension| extension == "app"))
+            .ok_or("uninstall_location_unavailable")?
+            .to_path_buf();
+        let status = Command::new("/usr/bin/open")
+            .args(["-R"])
+            .arg(bundle)
+            .status()
+            .map_err(|_| "uninstall_location_unavailable")?;
+        return if status.success() { Ok(()) } else { Err("uninstall_location_unavailable".into()) };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let status = Command::new("explorer.exe")
+            .arg(format!("/select,{}", executable.display()))
+            .status()
+            .map_err(|_| "uninstall_location_unavailable")?;
+        return if status.success() { Ok(()) } else { Err("uninstall_location_unavailable".into()) };
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let parent = executable.parent().ok_or("uninstall_location_unavailable")?;
+        let status = Command::new("xdg-open")
+            .arg(parent)
+            .status()
+            .map_err(|_| "uninstall_location_unavailable")?;
+        return if status.success() { Ok(()) } else { Err("uninstall_location_unavailable".into()) };
+    }
+
+    #[allow(unreachable_code)]
+    Err("uninstall_location_unsupported".into())
+}
+
+#[tauri::command]
+async fn desktop_open_uninstall_location() -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(open_uninstall_location)
+        .await
+        .map_err(|_| "uninstall_location_unavailable".to_string())?
+}
+
 fn validate_snapshot(value: Value) -> Result<Value, String> {
     let encoded = serde_json::to_vec(&value)
         .map_err(|_| "Contrato de snapshot do Runtime incompatível".to_string())?;
@@ -1238,6 +1286,7 @@ pub fn run() {
             desktop_update_install,
             desktop_update_rollback,
             desktop_open_releases,
+            desktop_open_uninstall_location,
             desktop_bot_action,
             runtime_status
         ])

--- a/apps/desktop/src-tauri/src/snapshot_exports.rs
+++ b/apps/desktop/src-tauri/src/snapshot_exports.rs
@@ -23,14 +23,18 @@ fn projection(snapshot: &Value, kind: &str, filters: &Value) -> Result<Value, St
         "activity" => {
             let status = filters["status"].as_str().unwrap_or("all");
             let provider = filters["provider"].as_str().unwrap_or("all");
+            let search = filters["search"].as_str().unwrap_or("");
             if !matches!(status, "all" | "verified" | "running" | "attention")
                 || provider.len() > 256
+                || search.len() > 120
             {
                 return Err("snapshot_export_invalid".into());
             }
+            let search = search.to_lowercase();
             let items = snapshot["activity"].as_array().map(|items| items.iter().take(5)
                 .filter(|item| status == "all" || item["status"].as_str() == Some(status))
                 .filter(|item| provider == "all" || item["provider"].as_str() == Some(provider))
+                .filter(|item| search.is_empty() || ["id", "title", "detail", "provider", "status"].iter().any(|field| item[*field].as_str().unwrap_or("").to_lowercase().contains(&search)))
                 .map(|item| json!({
                     "id": item["id"], "title": item["title"], "provider": item["provider"],
                     "savedTokens": item["savedTokens"], "occurredAt": item["occurredAt"], "status": item["status"],
@@ -120,6 +124,14 @@ mod tests {
         .unwrap();
         assert_eq!(activity["items"].as_array().unwrap().len(), 1);
         assert!(activity["items"][0].get("detail").is_none());
+        let searched = projection(
+            &snapshot(),
+            "activity",
+            &json!({"status":"all","provider":"all","search":"private prompt"}),
+        )
+        .unwrap();
+        assert_eq!(searched["items"].as_array().unwrap().len(), 1);
+        assert_eq!(searched["items"][0]["id"], "1");
         assert!(projection(&snapshot(), "../arbitrary", &Value::Null).is_err());
         assert!(projection(&snapshot(), "activity", &json!({"status":"invalid"})).is_err());
     }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -147,6 +147,9 @@ describe("Simplicio Desktop product states", () => {
     expect(html).toContain("Exportar diagnóstico");
     expect(html).toContain("Atualizar estado");
     expect(html).toContain("Sair da conta");
+    expect(html).toContain("Idioma da interface");
+    expect(html).toContain("Comportamento ao iniciar");
+    expect(html).toContain("Desinstalar Simplicio");
     expect(html).toContain("tenta revogar a sessão remota");
     expect(html).not.toContain("O Runtime revoga a sessão");
     expect(JSON.stringify(diagnostic)).not.toContain("voce@example.com");
@@ -158,6 +161,7 @@ describe("Simplicio Desktop product states", () => {
     const html = renderToStaticMarkup(<ActivityScreen snapshot={snapshot} />);
     expect(html).toContain("Exportar recibos");
     expect(html).toContain("Todos");
+    expect(html).toContain("Buscar recibos");
     expect(html).toContain("máximo 5");
     expect(redactedActivity(snapshot.activity)[0]).not.toHaveProperty("detail");
   });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import {
   loadDesktopPreparationStatus,
   loadDesktopSnapshot,
   logoutDesktop,
+  openDesktopUninstallLocation,
   openDesktopSubscription,
   refreshDesktopSnapshot,
   reconcileDesktopRuntimeInstall,
@@ -30,7 +31,7 @@ import { ProjectDialog } from "./components/ProjectDialog";
 import { DesktopUpdates } from "./components/DesktopUpdates";
 import { installFailureMessage, installFailureRecovery, type InstallFailureRecovery } from "./install_failures";
 import { runtimeFailureMessage } from "./runtime_failures";
-import { isView, loadWorkbench, MAX_PROJECTS, moveHistory, navigate, WORKBENCH_KEY, type LocalProject, type NavigationEntry, type NavigationState, type WorkbenchState } from "./workbench";
+import { isSettingsView, isView, loadWorkbench, MAX_PROJECTS, moveHistory, navigate, WORKBENCH_KEY, type LocalProject, type NavigationEntry, type NavigationState, type WorkbenchState } from "./workbench";
 import { viewNavigationEntry } from "./settings_navigation";
 import { ProvidersScreen } from "./screens/ProvidersScreen";
 import { MemoryScreen } from "./screens/MemoryScreen";
@@ -48,10 +49,15 @@ import type { PreparationResult } from "./runtime_preparation_result";
 import { runtimeIsValid } from "./setup_flow";
 import { createDesktopUsageStore, createUsageChangefeedSupervisor } from "./usage_store";
 
-function initialView(fallback: View): View {
+function initialView(fallback: View, preferences: WorkbenchState["preferences"], hasSelectedProject: boolean): View {
   if (typeof window === "undefined") return "home";
   const requested = new URLSearchParams(window.location.search).get("view");
-  return isView(requested) ? requested : fallback;
+  if (isView(requested)) return requested;
+  if (preferences.launchBehavior === "last_view"
+    && (preferences.lastView !== "project" || hasSelectedProject)) {
+    return preferences.lastView;
+  }
+  return fallback;
 }
 
 export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSnapshot }) {
@@ -69,7 +75,11 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
   const [applicationRecovery, setApplicationRecovery] = useState<InstallFailureRecovery | undefined>();
   const [workbench, setWorkbench] = useState(loadWorkbench);
   const [history, setHistory] = useState<NavigationState>(() => ({ entries: [{
-    view: initialView(workbench.selectedProjectId ? "project" : "home"),
+    view: initialView(
+      workbench.selectedProjectId ? "project" : "home",
+      workbench.preferences,
+      Boolean(workbench.selectedProjectId),
+    ),
     projectId: workbench.selectedProjectId,
     tokenRepo: "",
   }], index: 0 }));
@@ -160,6 +170,13 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
 
   function setView(next: View, restoreRoute?: NavigationEntry) {
     setHistory((current) => navigate(current, viewNavigationEntry(current.entries[current.index], next, restoreRoute)));
+    if (!isSettingsView(next) && next !== "setup" && workbench.preferences.lastView !== next) {
+      saveWorkbench({ ...workbench, preferences: { ...workbench.preferences, lastView: next } });
+    }
+  }
+
+  async function openUninstallLocation() {
+    await openDesktopUninstallLocation();
   }
 
   function moveNavigation(direction: -1 | 1) {
@@ -539,7 +556,10 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
       {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} projectPaths={workbench.projects.map(project => project.path)} usage={usage} />}
       {(view === "settings" || view === "diagnostics") && (
-        <SettingsScreen section={view === "diagnostics" ? "diagnostics" : "account"} snapshot={snapshot} busy={action !== null} onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"} />
+        <SettingsScreen section={view === "diagnostics" ? "diagnostics" : "account"} snapshot={snapshot} busy={action !== null}
+          onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"}
+          preferences={workbench.preferences} onPreferences={(preferences) => saveWorkbench({ ...workbench, preferences })}
+          onUninstall={openUninstallLocation} />
       )}
       {(view === "general" || view === "shortcuts" || view === "models") && <PreferencesScreen view={view} snapshot={snapshot} preferences={workbench.preferences} onPreferences={(preferences) => saveWorkbench({ ...workbench, preferences })} onProviders={() => setView("agents")} />}
       {view === "activity" && <ActivityScreen snapshot={snapshot} usage={usage} />}

--- a/apps/desktop/src/activity_screen.test.ts
+++ b/apps/desktop/src/activity_screen.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { redactedActivity } from "./screens/ActivityScreen";
+import { activityMatchesSearch, redactedActivity } from "./screens/ActivityScreen";
 import type { ActivityItem } from "./contracts";
 
 const item: ActivityItem = {
@@ -22,5 +22,11 @@ describe("Activity savings proof", () => {
 
   it("keeps the value only when the caller has a Runtime proof class", () => {
     expect(redactedActivity([item], true)[0].savedTokens).toBe(42);
+  });
+
+  it("searches receipt title, detail and provider without accent sensitivity", () => {
+    expect(activityMatchesSearch({ ...item, title: "Validação determinística" }, "validacao")).toBe(true);
+    expect(activityMatchesSearch({ ...item, detail: "Recibo do Runtime" }, "runtime")).toBe(true);
+    expect(activityMatchesSearch(item, "grok")).toBe(false);
   });
 });

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -168,7 +168,7 @@ export async function openDesktopProject(path: string): Promise<void> {
   await invoke("desktop_open_project", { path });
 }
 
-export async function exportDesktopSnapshot(kind: "diagnostic" | "activity", filters: { status?: string; provider?: string } = {}): Promise<string | null> {
+export async function exportDesktopSnapshot(kind: "diagnostic" | "activity", filters: { status?: string; provider?: string; search?: string } = {}): Promise<string | null> {
   if (!isTauri()) return null;
   const receipt = await invoke<{ schema: string; path: string; bytes: number }>("desktop_export_snapshot", { kind, filters });
   if (receipt.schema !== "simplicio.desktop-snapshot-export/v1" || typeof receipt.path !== "string" || receipt.bytes <= 0) throw new Error("snapshot_export_invalid");
@@ -352,6 +352,12 @@ export async function openDesktopSubscription(): Promise<void> {
     return;
   }
   await invoke("desktop_open_subscription");
+}
+
+/** Opens the installed app location so the user can remove only the Desktop bundle. */
+export async function openDesktopUninstallLocation(): Promise<void> {
+  if (!isTauri()) throw new Error("preview_no_runtime");
+  await invoke("desktop_open_uninstall_location");
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/apps/desktop/src/components/DesktopUpdates.tsx
+++ b/apps/desktop/src/components/DesktopUpdates.tsx
@@ -419,10 +419,10 @@ export function DesktopUpdates() {
       <p>{checking.progress.receivedBytes > 0 ? formatBytes(checking.progress.receivedBytes) + " de metadados recebidos. " : ""}O instalador não está sendo baixado.</p>
     </div>}
     {(action.stage === "downloading" || action.stage === "installing" || action.stage === "rollback") && <div className="desktop-update-progress" data-update-stage={action.stage}>
-      <div className="desktop-update-progress-label"><span role="status" aria-live="polite">{action.stage === "downloading" ? "Baixando e verificando instalador" : action.stage === "installing" ? "Instalando e preparando reinício" : "Restaurando versão anterior"}</span>
+      <div className="desktop-update-progress-label"><span role="status" aria-live="polite">{action.stage === "downloading" ? "Baixando pacote Desktop" : action.stage === "installing" ? "Aplicando pacote e preparando reinício" : "Restaurando versão anterior"}</span>
         <span>{progressBytes > 0 && result ? formatBytes(progressBytes) + " de " + formatBytes(result.release.assetBytes) : "Aguarde…"}</span></div>
-      <progress aria-label="Progresso do download" value={progressRatio} max="100" />
-      <p>O arquivo é armazenado em área privada e só é instalado após a verificação de tamanho, SHA-256 e assinatura Ed25519.</p>
+      <progress aria-label={action.stage === "downloading" ? "Progresso do download" : action.stage === "installing" ? "Progresso da instalação" : "Progresso da recuperação"} value={progressRatio} max="100" />
+      <p>{action.stage === "downloading" ? "O pacote é recebido em área privada; a verificação de tamanho, SHA-256 e assinatura Ed25519 acontece antes de preparar a instalação." : action.stage === "installing" ? "A versão atual é preservada como recuperação enquanto o Desktop prepara o reinício." : "A versão anterior está sendo restaurada; o estado só será concluído após a validação do aplicativo."}</p>
     </div>}
     {status.currentVersion && <p className="desktop-update-installed">Versão deste aplicativo: <strong>{status.currentVersion}</strong></p>}
     {result && available && <>
@@ -459,4 +459,3 @@ export function DesktopUpdates() {
     </div>
   </dialog>;
 }
-

--- a/apps/desktop/src/components/ProviderUsage.tsx
+++ b/apps/desktop/src/components/ProviderUsage.tsx
@@ -126,6 +126,14 @@ function providerLabel(provider: ProviderQuota | undefined): string {
   return "Cota indisponível. Nenhum percentual presumido.";
 }
 
+function providerStatusLabel(provider: ProviderQuota | undefined): string {
+  if (provider?.status === "fresh") return "Atual";
+  if (provider?.status === "stale") return "Desatualizado";
+  if (provider?.error === "refresh_in_grok") return "Atualize no Grok";
+  if (provider?.error === "login_required") return "Login necessário";
+  return "Indisponível";
+}
+
 function sourceLabel(provider: ProviderQuota): string {
   return provider.source === "codex_app_server" ? "Codex app-server" : "Grok CLI billing";
 }
@@ -173,9 +181,11 @@ export function ProviderUsage({ onAccounts, onHistory }: { onAccounts: () => voi
 
   const codex = data?.providers.find(provider => provider.id === "codex");
   const grok = data?.providers.find(provider => provider.id === "grok");
-  const summary = codex?.windows.find(window => window.windowDurationMins === 10080) ?? codex?.windows[0];
-  const renderWindows = (provider: ProviderQuota | undefined, label: string) => <>
-    <h3>{label}</h3>
+  const summaryProvider = [codex, grok].find(provider => provider?.status === "fresh" && provider.windows.length)
+    ?? [codex, grok].find(provider => provider?.windows.length);
+  const summary = summaryProvider?.windows.find(window => window.windowDurationMins === 10080) ?? summaryProvider?.windows[0];
+  const renderWindows = (provider: ProviderQuota | undefined, label: string) => <section className={`quota-provider quota-provider-${provider?.id ?? label.toLowerCase()}`} data-provider={provider?.id ?? label.toLowerCase()}>
+    <div className="quota-provider-heading"><h3>{label}</h3><span className={`quota-status quota-status-${provider?.status ?? "unavailable"}`}>{providerStatusLabel(provider)}</span></div>
     {provider?.windows.map((window, index) => <div className={"quota-window" + (compact ? " quota-window-compact" : "")} key={window.windowDurationMins + "-" + window.resetsAt + "-" + index}>
       <span>{window.windowDurationMins === 10080 ? "Semanal" : window.windowDurationMins === 300 ? "5 horas" : window.windowDurationMins + " min"} · {window.usedPercent}% usado</span>
       <progress max={100} value={window.usedPercent} aria-label={"Uso da janela de " + window.windowDurationMins + " minutos"} />
@@ -183,11 +193,11 @@ export function ProviderUsage({ onAccounts, onHistory }: { onAccounts: () => voi
     </div>)}
     {(!provider || !provider.windows.length) && <p>{providerLabel(provider)}</p>}
     {provider && <small>Fonte: {sourceLabel(provider)} · consulta {new Date(provider.observedAt * 1000).toLocaleTimeString("pt-BR")}{provider.status === "stale" ? " · desatualizada" : ""}</small>}
-  </>;
+  </section>;
 
   return <div className="provider-usage" ref={root}>
     <button type="button" aria-expanded={open} aria-controls="provider-usage-panel" onClick={() => setOpen(!open)}>
-      {summary && !error ? "Codex " + summary.usedPercent + "% usado" + (codex?.status === "stale" ? " · desatualizado" : "") : busy ? "Consultando cotas…" : "Cotas dos agentes"}
+      {summary && !error ? (summaryProvider?.id === "grok" ? "Grok " : "Codex ") + summary.usedPercent + "% usado" + (summaryProvider?.status === "stale" ? " · desatualizado" : "") : busy ? "Consultando cotas…" : "Cotas dos agentes"}
     </button>
     {open && <section id="provider-usage-panel" className="provider-usage-panel" aria-label="Cotas dos agentes">
       <header><strong>Uso das contas</strong><button type="button" disabled={busy} onClick={() => void refresh()}>{busy ? "Consultando…" : "Atualizar cotas"}</button><button type="button" aria-label="Fechar cotas" onClick={() => setOpen(false)}>×</button></header>

--- a/apps/desktop/src/components/provider_usage.css
+++ b/apps/desktop/src/components/provider_usage.css
@@ -2,9 +2,18 @@
 .provider-usage-panel { position: fixed; bottom: 44px; left: 20px; width: min(430px, calc(100vw - 40px)); max-height: calc(100vh - 100px); overflow-y: auto; background: #fff; color: #29342e; border: 1px solid #dce4df; box-shadow: 0 12px 48px #14251d33; border-radius: 16px; padding: 20px; z-index: 80; font-size: 14px; }
 .provider-usage-panel header { display: flex; gap: 12px; align-items: center; justify-content: space-between; }
 .provider-usage-panel h3 { margin: 16px 0 8px; }
+.quota-provider { margin-top: 16px; padding-top: 1px; border-top: 1px solid #edf1ee; }
+.quota-provider:first-of-type { margin-top: 12px; }
+.quota-provider-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.quota-provider-heading h3 { margin: 0; }
+.quota-status { padding: 4px 7px; border-radius: 999px; font-size: 11px; font-weight: 600; }
+.quota-status-fresh { color: #245d49; background: #e9f2ed; }
+.quota-status-stale { color: #815d25; background: #fbf1dc; }
+.quota-status-unavailable { color: #6f6256; background: #f2efeb; }
 .provider-usage-panel > button { display: block; margin-top: 14px; }
 .quota-window { display: grid; gap: 8px; padding: 10px 0; }
 .quota-window progress { width: 100%; accent-color: #287259; }
+.quota-provider-grok .quota-window progress { accent-color: #a56b3e; }
 .quota-display-mode { display: flex; gap: 4px; margin-top: 14px; padding: 4px; border: 1px solid #dce4df; border-radius: 10px; }
 .quota-display-mode button { flex: 1; padding: 6px 10px; border-radius: 6px; }
 .quota-display-mode button[aria-pressed="true"] { background: #e9f2ed; color: #245d49; font-weight: 600; }

--- a/apps/desktop/src/screens/ActivityScreen.tsx
+++ b/apps/desktop/src/screens/ActivityScreen.tsx
@@ -4,6 +4,7 @@ import type { ActivityItem, DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { createActivityProjection } from "../activity_projection";
 import type { DesktopUsageState } from "../usage_store";
+import { searchMatches } from "../workbench";
 
 type StatusFilter = "all" | ActivityItem["status"];
 
@@ -28,11 +29,16 @@ function statusLabel(status: ActivityItem["status"]): string {
   return status === "verified" ? "verificado" : status === "running" ? "em execução" : "atenção";
 }
 
+export function activityMatchesSearch(item: ActivityItem, query: string): boolean {
+  return searchMatches([item.id, item.title, item.detail, item.provider, item.status].join(" "), query);
+}
+
 export function ActivityScreen({ snapshot, usage }: { snapshot: DesktopSnapshot; usage?: DesktopUsageState }) {
   const projection = createActivityProjection(snapshot);
   const savingsProven = snapshot.savings.proofKind === "measured" || snapshot.savings.proofKind === "replayed" || snapshot.savings.proofKind === "mixed";
   const [status, setStatus] = useState<StatusFilter>("all");
   const [provider, setProvider] = useState("all");
+  const [query, setQuery] = useState("");
   const [page, setPage] = useState(0);
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<string | null>(null);
@@ -40,7 +46,9 @@ export function ActivityScreen({ snapshot, usage }: { snapshot: DesktopSnapshot;
   const exportLock = useRef(false);
   const pageSize = Math.max(1, Math.min(snapshot.limits.maxActivity, 5));
   const providers = useMemo(() => Array.from(new Set(projection.items.map((item) => item.provider))).sort(), [projection.items]);
-  const filtered = projection.items.filter((item) => (status === "all" || item.status === status) && (provider === "all" || item.provider === provider));
+  const filtered = projection.items.filter((item) => (status === "all" || item.status === status)
+    && (provider === "all" || item.provider === provider)
+    && activityMatchesSearch(item, query));
   const visible = filtered.slice(page * pageSize, (page + 1) * pageSize);
   const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, pageCount - 1);
@@ -50,7 +58,7 @@ export function ActivityScreen({ snapshot, usage }: { snapshot: DesktopSnapshot;
     if (exportLock.current) return;
     exportLock.current = true; setExporting(true); setExported(null); setExportError(null);
     try {
-      const path = await exportDesktopSnapshot("activity", { status, provider });
+      const path = await exportDesktopSnapshot("activity", { status, provider, search: query });
       if (path) setExported(path);
       else downloadActivity(filtered, savingsProven);
     } catch { setExportError("Não foi possível salvar os recibos em Downloads. Verifique as permissões e o espaço em disco."); }
@@ -72,6 +80,7 @@ export function ActivityScreen({ snapshot, usage }: { snapshot: DesktopSnapshot;
       {exportError && <p className="inline-error" role="alert">{exportError}</p>}
       <section className="panel activity-page-panel">
         <div className="activity-toolbar">
+          <label className="activity-search"><Glyph name="search" size={16} /><input type="search" aria-label="Buscar recibos" placeholder="Buscar recibos" value={query} maxLength={120} onChange={(event) => { setQuery(event.target.value); setPage(0); }} /></label>
           <div className="segmented-control" aria-label="Filtrar por estado">
             {(["all", "verified", "running", "attention"] as const).map((item) => (
               <button key={item} className={status === item ? "active" : ""} type="button" onClick={() => { setStatus(item); setPage(0); }}>

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -3,6 +3,7 @@ import type { DesktopSnapshot } from "../contracts";
 import { Glyph } from "../components/Brand";
 import { exportDesktopSnapshot } from "../bridge";
 import { runtimeSummary } from "../workbench";
+import { DEFAULT_PREFERENCES, type WorkbenchPreferences } from "../workbench";
 import { formatRuntimeTimestamp } from "../runtime_timestamp";
 
 export function redactedDiagnostic(snapshot: DesktopSnapshot) {
@@ -25,11 +26,14 @@ function previewDownload(snapshot: DesktopSnapshot) {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-export function SettingsScreen({ snapshot, busy, onRefresh, onSubscribe, onLogout, logoutBusy, section = "all" }:
-  { snapshot: DesktopSnapshot; busy: boolean; onRefresh: () => void; onSubscribe: () => void; onLogout: () => void; logoutBusy: boolean; section?: "account" | "diagnostics" | "all" }) {
+export function SettingsScreen({ snapshot, busy, onRefresh, onSubscribe, onLogout, logoutBusy, section = "all", preferences = DEFAULT_PREFERENCES, onPreferences = () => undefined, onUninstall }:
+  { snapshot: DesktopSnapshot; busy: boolean; onRefresh: () => void; onSubscribe: () => void; onLogout: () => void; logoutBusy: boolean; section?: "account" | "diagnostics" | "all"; preferences?: WorkbenchPreferences; onPreferences?: (preferences: WorkbenchPreferences) => void; onUninstall?: () => Promise<void> }) {
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [uninstalling, setUninstalling] = useState(false);
+  const [uninstallError, setUninstallError] = useState<string | null>(null);
+  const [uninstallOpened, setUninstallOpened] = useState(false);
   const exportLock = useRef(false);
   const runtime = runtimeSummary(snapshot);
   async function download() {
@@ -42,6 +46,21 @@ export function SettingsScreen({ snapshot, busy, onRefresh, onSubscribe, onLogou
     } catch { setExportError("Não foi possível salvar o diagnóstico em Downloads. Verifique as permissões e o espaço em disco."); }
     finally { exportLock.current = false; setExporting(false); }
   }
+  async function openUninstallLocation() {
+    if (!onUninstall || uninstalling) return;
+    setUninstalling(true); setUninstallError(null); setUninstallOpened(false);
+    try {
+      await onUninstall();
+      setUninstallOpened(true);
+    } catch {
+      setUninstallError("Não foi possível abrir a localização do aplicativo. Nenhum arquivo foi removido.");
+    } finally {
+      setUninstalling(false);
+    }
+  }
+  function updatePreferences(patch: Partial<WorkbenchPreferences>) {
+    onPreferences({ ...preferences, ...patch });
+  }
   return <div className="page preferences-page account-page">
     <section className="page-heading"><div><h1>{section === "diagnostics" ? "Runtime e diagnóstico" : "Conta Simplicio"}</h1><p>{section === "diagnostics" ? "Estado local verificado pelo Runtime. Diagnósticos sem dados sensíveis." : "Sua identidade e assinatura, verificadas pelo Simplicio Runtime."}</p></div></section>
     {section !== "diagnostics" && <section className="settings-section"><h2>Minha conta</h2><div className="settings-slab">
@@ -51,6 +70,11 @@ export function SettingsScreen({ snapshot, busy, onRefresh, onSubscribe, onLogou
       <div className="preference-row"><div><strong>Gerenciar assinatura</strong><p>Abre sua conta no site do Simplicio.</p></div><button className="button button-secondary" type="button" onClick={onSubscribe} disabled={busy}>Gerenciar plano<Glyph name="external" size={15} /></button></div>
       <div className="preference-row"><div><strong>Sair deste computador</strong><p>O Runtime remove o login local e tenta revogar a sessão remota. Seus projetos não são apagados.</p></div><button className="button button-secondary" type="button" onClick={onLogout} disabled={busy || logoutBusy}>{logoutBusy ? "Saindo…" : "Sair da conta"}</button></div>
     </div></section>}
+    {section !== "diagnostics" && <section className="settings-section"><h2>Preferências do Desktop</h2><div className="settings-slab">
+      <div className="preference-row"><div><strong>Idioma da interface</strong><p>O idioma fica salvo somente neste computador. Este build oferece Português (Brasil).</p></div><select className="preference-select" aria-label="Idioma da interface" value={preferences.language} onChange={(event) => { if (event.target.value === "pt-BR") updatePreferences({ language: "pt-BR" }); }}><option value="pt-BR">Português (Brasil)</option></select></div>
+      <div className="preference-row"><div><strong>Comportamento ao iniciar</strong><p>Escolha se o Desktop abre no Início ou retoma a última tela de trabalho.</p></div><select className="preference-select" aria-label="Comportamento ao iniciar" value={preferences.launchBehavior} onChange={(event) => updatePreferences({ launchBehavior: event.target.value === "last_view" ? "last_view" : "home" })}><option value="home">Abrir no Início</option><option value="last_view">Retomar última tela</option></select></div>
+      <div className="preference-row"><div><strong>Desinstalar Simplicio</strong><p>Abre a localização do aplicativo para você movê-lo para o Lixo. Projetos, relatórios e o Runtime gerenciado não são removidos por esta ação.</p></div><button className="button button-secondary" type="button" onClick={() => void openUninstallLocation()} disabled={!onUninstall || uninstalling}>{uninstalling ? "Abrindo…" : "Abrir localização do app"}</button></div>
+    </div>{uninstallOpened && <p className="export-feedback" role="status">Localização do aplicativo aberta. A remoção é manual no Finder ou gerenciador de arquivos.</p>}{uninstallError && <p className="inline-error" role="alert">{uninstallError}</p>}</section>}
     {section !== "account" && <>
       <section className="settings-section"><h2>Runtime local</h2><div className="settings-slab">
         <div className="preference-row"><div><strong>{runtime.label}</strong><p>Versão {snapshot.runtime.version || "não informada"} · transporte {snapshot.runtime.transport}</p></div><button className="button button-secondary" type="button" onClick={onRefresh} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Atualizar estado"}</button></div>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1510,7 +1510,11 @@ p { margin-top: 0; }
 .settings-safety p { margin: 4px 0 0; color: #7f897b; font-size: 9px; line-height: 1.4; }
 
 .activity-page-panel { padding: 18px; }
-.activity-toolbar { min-width: 0; margin-bottom: 13px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.activity-toolbar { min-width: 0; margin-bottom: 13px; display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.activity-search { min-width: min(260px, 100%); flex: 1 1 220px; min-height: 30px; box-sizing: border-box; padding: 0 9px; border: 1px solid var(--line); border-radius: 7px; display: flex; align-items: center; gap: 7px; color: var(--muted-soft); background: var(--surface-strong); }
+.activity-search:focus-within { border-color: #a7b8ab; box-shadow: 0 0 0 2px #dce9df; }
+.activity-search input { min-width: 0; width: 100%; border: 0; outline: 0; color: var(--ink); background: transparent; font: 10px/1 var(--mono); }
+.activity-search input::placeholder { color: var(--muted-soft); }
 .activity-provider-filter { display: inline-flex; align-items: center; gap: 7px; color: #969184; font: 8px/1 var(--mono); }
 .activity-provider-filter select { min-height: 28px; padding: 0 25px 0 8px; border: 1px solid var(--line); border-radius: 7px; color: #66675f; background: var(--surface-strong); font: 9px/1 var(--mono); }
 .activity-page-list { border-top: 1px solid var(--line-soft); }

--- a/apps/desktop/src/workbench.css
+++ b/apps/desktop/src/workbench.css
@@ -160,6 +160,7 @@
 .preference-row strong { display: block; font-size: 13px; font-weight: 550; line-height: 1.5; }
 .preference-row p { font-size: 12px; color: var(--muted); line-height: 1.7; margin: 4px 0 0; overflow-wrap: anywhere; }
 .preference-row > .button, .preference-row > .segmented-control, .preference-row > kbd { flex-shrink: 0; }
+.preference-select { min-height: 32px; max-width: 240px; padding: 0 28px 0 10px; border: 1px solid var(--line); border-radius: 7px; color: var(--ink); background: var(--surface-strong); font: 10px/1 var(--mono); flex: 0 0 auto; }
 .preference-switch { width: 36px; height: 22px; flex: 0 0 auto; border: 1px solid #ccd2d7; background: #d9dfe3; padding: 2px; border-radius: 20px; cursor: pointer; }
 .preference-switch span { display: block; height: 16px; width: 16px; background: #fff; box-shadow: 0 1px 3px #0000001a; border-radius: 50%; transition: transform 120ms ease; }
 .preference-switch.checked { background: var(--green-dark); border-color: var(--green-dark); }

--- a/apps/desktop/src/workbench.test.ts
+++ b/apps/desktop/src/workbench.test.ts
@@ -23,7 +23,7 @@ describe("local workbench state", () => {
       selectedProjectId: project(1).id, preferences: { density: "compact", showProjectPaths: true, rememberProject: true, dangerousMode: true } }));
     expect(state.projects).toEqual([project(), project(1)]);
     expect(state.selectedProjectId).toBe(project(1).id);
-    expect(state.preferences).toEqual({ density: "compact", showProjectPaths: true, rememberProject: true });
+    expect(state.preferences).toEqual({ ...emptyWorkbench().preferences, density: "compact", showProjectPaths: true, rememberProject: true });
     expect(JSON.stringify(state)).not.toContain("dangerousMode");
     expect(parseWorkbench(JSON.stringify({ ...state, projects: Array.from({ length: 100 }, (_, index) => project(index)) })).projects).toHaveLength(MAX_PROJECTS);
   });
@@ -35,6 +35,18 @@ describe("local workbench state", () => {
     }
     expect(parseWorkbench(JSON.stringify({ ...emptyWorkbench(), projects: [project()], selectedProjectId: project().id,
       preferences: { rememberProject: false } })).selectedProjectId).toBeNull();
+  });
+
+  it("keeps the launch preference bounded and restores only a workbench view", () => {
+    const state = parseWorkbench(JSON.stringify({ ...emptyWorkbench(), preferences: {
+      ...emptyWorkbench().preferences, launchBehavior: "last_view", lastView: "activity",
+    } }));
+    expect(state.preferences.launchBehavior).toBe("last_view");
+    expect(state.preferences.lastView).toBe("activity");
+    const unsafe = parseWorkbench(JSON.stringify({ ...emptyWorkbench(), preferences: {
+      ...emptyWorkbench().preferences, launchBehavior: "last_view", lastView: "settings",
+    } }));
+    expect(unsafe.preferences.lastView).toBe("home");
   });
 
   it("rejects untrusted project identifiers, remote paths and control characters", () => {

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -65,6 +65,9 @@ export interface WorkbenchPreferences {
   density: "comfortable" | "compact";
   showProjectPaths: boolean;
   rememberProject: boolean;
+  language: "pt-BR";
+  launchBehavior: "home" | "last_view";
+  lastView: View;
 }
 export interface WorkbenchState {
   schema: "simplicio.desktop-workbench/v1";
@@ -74,7 +77,14 @@ export interface WorkbenchState {
 }
 
 export const WORKBENCH_KEY = "simplicio.desktop.workbench.v1";
-export const DEFAULT_PREFERENCES: WorkbenchPreferences = { density: "comfortable", showProjectPaths: false, rememberProject: true };
+export const DEFAULT_PREFERENCES: WorkbenchPreferences = {
+  density: "comfortable",
+  showProjectPaths: false,
+  rememberProject: true,
+  language: "pt-BR",
+  launchBehavior: "home",
+  lastView: "home",
+};
 export const MAX_PROJECTS = 32;
 
 export function emptyWorkbench(): WorkbenchState {
@@ -108,6 +118,12 @@ export function parseWorkbench(raw: string | null): WorkbenchState {
     if (preferences?.density === "compact") state.preferences.density = "compact";
     if (typeof preferences?.showProjectPaths === "boolean") state.preferences.showProjectPaths = preferences.showProjectPaths;
     if (typeof preferences?.rememberProject === "boolean") state.preferences.rememberProject = preferences.rememberProject;
+    if (preferences?.language === "pt-BR") state.preferences.language = "pt-BR";
+    if (preferences?.launchBehavior === "last_view") state.preferences.launchBehavior = "last_view";
+    if (typeof preferences?.lastView === "string" && isView(preferences.lastView)
+      && !isSettingsView(preferences.lastView) && preferences.lastView !== "setup") {
+      state.preferences.lastView = preferences.lastView;
+    }
     if (state.preferences.rememberProject && state.projects.some((item) => item.id === value.selectedProjectId)) {
       state.selectedProjectId = value.selectedProjectId;
     }


### PR DESCRIPTION
## Development

- Added persisted Desktop preferences for the current Portuguese (Brazil) locale and launch behavior (Home or last workbench view).
- Added a bounded uninstall handoff that opens the installed app location; it does not delete projects, reports, or the managed Runtime.
- Added free-text receipt search in Activity, including accent-insensitive local filtering and the matching native export filter.
- Polished provider usage with provider-specific freshness/repair states and Codex/Grok-aware summary text.
- Clarified update progress copy and progress semantics for download, install, and recovery stages.
- No new screens or renderer credentials.

## Validation

- Runtime mapper-only map completed with Simplicio Runtime 3.8.47; generated map artifact was fresh and the tracked tree remained unchanged.
- `git diff --check` passed.
- Production TypeScript/Vite build passed; existing warning remains for the 537 kB main bundle.
- Native code compiled with the documented no-sidecar test configuration.

## Tests

- Vitest: 63 test files, 412 tests passed.
- Playwright Desktop + runtime-integration: 18/18 passed.
- Native snapshot export tests: 4 passed.
- Full native Cargo suite was previously run with the no-sidecar configuration: 194 passed, 3 existing Linux updater tests failed because `update_target_unavailable` is unavailable in this Linux environment, and 4 were ignored. No macOS signed-install evidence is claimed.

## Item-by-item review

- Settings item 9: language display is honest about the only shipped locale; launch preference persists and restores a workbench view; uninstall is a safe, user-confirmed Finder/file-manager handoff.
- Activity item 7: search covers receipt id, title, detail, provider, and status, and native exports receive the same bounded query.
- Providers/updates: usage state and source remain explicit for Codex vs Grok; refresh/repair copy and update-stage messaging are clearer without adding credentials or screens.
- PR #383 remains the source of the quota/signed-update contract. Issue #375 acceptance blockers remain unchanged: matching macOS `.sig` and native macOS install/relaunch/rollback evidence are unavailable here.