### PR TITLE
test: neutralize fixture paths blocked by repository policy

### DIFF
--- a/apps/desktop/e2e/entry-state-machine.spec.ts
+++ b/apps/desktop/e2e/entry-state-machine.spec.ts
@@ -26,7 +26,7 @@ async function mockEntryFlow(page: Page, initial: "missing" | "degraded" | "sign
     backupAvailable: false,
     pluginsMutated: false,
     runtime: { state: "healthy", version: "3.8.40", config: { token: "secret-token" } },
-    path: "/Users/private/.simplicio/bin/simplicio",
+    path: "/tmp/simplicio fixture/private/.simplicio/bin/simplicio",
     rawOutput: "secret-token",
   };
   await page.addInitScript(({ snapshots, receipt, initial, pauseInstall }) => {
@@ -129,7 +129,7 @@ test("first opening installs packaged Runtime exactly once, validates a fresh sn
   expect(count(preparingCalls, "desktop_prepare_runtime_environment")).toBe(1);
   await expect(page.getByRole("progressbar")).toHaveAttribute("value", "80");
   await expect(page.getByText("Runtime 3.8.40 validado", { exact: true })).toBeVisible();
-  await expect(page.locator("body")).not.toContainText("/Users/private");
+  await expect(page.locator("body")).not.toContainText("/tmp/simplicio fixture/private");
   await expect(page.locator("body")).not.toContainText("secret-token");
 
   await page.evaluate(() => (window as EntryTestWindow).__finishRuntimeRefresh?.());

--- a/apps/desktop/e2e/unified-usage.spec.ts
+++ b/apps/desktop/e2e/unified-usage.spec.ts
@@ -51,7 +51,7 @@ test("snapshot no-data is honest and export retains the queried time range", asy
         if (command === "desktop_unified_usage") return projection;
         if (command === "desktop_export_unified_usage") return {
           schema: "simplicio.desktop-unified-usage-export/v1", format: args.format,
-          path: "/Users/test/Downloads/usage.json", bytes: 128, report_digest: projection.metadata.report_digest,
+          path: "/tmp/simplicio fixture/Downloads/usage.json", bytes: 128, report_digest: projection.metadata.report_digest,
         };
         if (command === "plugin:event|listen") return 1;
         if (command === "plugin:event|unlisten") return;

--- a/apps/desktop/src/bridge.unified_usage.test.ts
+++ b/apps/desktop/src/bridge.unified_usage.test.ts
@@ -84,7 +84,7 @@ describe("desktop unified usage bridge", () => {
     invokeMock.mockResolvedValue({
       schema: "simplicio.desktop-unified-usage-export/v1",
       format: "json",
-      path: "/Users/test/Downloads/simplicio-unified-usage.json",
+      path: "/tmp/simplicio fixture/Downloads/simplicio-unified-usage.json",
       bytes: 128,
       report_digest: NO_DATA.metadata.report_digest,
     });

--- a/apps/desktop/src/integration_setup.test.ts
+++ b/apps/desktop/src/integration_setup.test.ts
@@ -71,7 +71,7 @@ describe("Runtime host-plugin plan review", () => {
   it("accepts only opaque SHA-256 identifiers for effect commands", () => {
     expect(isHostPluginDigest(digest("a"))).toBe(true);
     expect(isHostPluginDigest("sha256:private")).toBe(false);
-    expect(isHostPluginDigest("/Users/private/receipt")).toBe(false);
+    expect(isHostPluginDigest("/tmp/simplicio fixture/private/receipt")).toBe(false);
   });
   it("requires and shows exactly the eight canonical native/plugin hosts", () => {
     const result = parseIntegrationPlan(runtimePlan());

--- a/apps/desktop/src/runtime_install.test.ts
+++ b/apps/desktop/src/runtime_install.test.ts
@@ -20,8 +20,8 @@ describe("Runtime core installer receipt", () => {
   it("keeps only the sanitized native projection", () => {
     const parsed = parseRuntimeInstallResult({
       ...validResult(),
-      path: "/Users/private/.simplicio/bin/simplicio",
-      backupPath: "/Users/private/.simplicio/bin/simplicio.previous",
+      path: "/tmp/simplicio fixture/private/.simplicio/bin/simplicio",
+      backupPath: "/tmp/simplicio fixture/private/.simplicio/bin/simplicio.previous",
       rawOutput: "secret-token",
       runtime: { ...validResult().runtime, config: { token: "secret-token" } },
     });

--- a/scripts/test_verify_installed_validation_matrix.py
+++ b/scripts/test_verify_installed_validation_matrix.py
@@ -63,7 +63,7 @@ def test_stale_handshake_and_preview_are_not_connected_passes() -> None:
 
 def test_sensitive_receipts_and_unavailable_platforms_block() -> None:
     document = deepcopy(valid_matrix())
-    document["runtime"]["home_path"] = "/Users/test"
+    document["runtime"]["home_path"] = r"fixtures\home\test folder"
     document["platform_matrix"][0] = {
         "id": PLATFORMS[0],
         "status": "unavailable",


### PR DESCRIPTION
Related to #391.

Six test files used personal-home-shaped paths, causing repository_policy.py to reject the tracked source tree. This replaces only eight fixture/assertion lines with disposable neutral paths. Spaces, path rejection, receipt sanitization and the Python backslash-path validation remain covered. The policy scanner and production code are unchanged.

Validation on Linux at commit 52c23e4939511459e3ab6bf56363cff17d8e4e65 content:
- Repository policy passes (baseline failed on the six files).
- Focused Python validation: 4 passed.
- Focused Vitest: 3 files, 22 tests passed, maxWorkers=1.
- Distribution consistency: 8 checks passed.
- git diff --check passes.
- Independent read-only review by /root/luna_reviewer_391, configured gpt-5.6-luna/xhigh: APPROVE of diff SHA-256 5956aed7aa90ccca9d60d29a6ca80d399b75671e30faa8cfdc40d11576a036d4. This is agent review, not required human approval.

Implementation: /root/luna_worker_391, configured gpt-5.6-luna/xhigh, existing Loop lease and mechanical Dev CLI edit. Remote Git publication: coordinator through the connected GitHub plugin.

Pending: affected Playwright E2E; browser/build admission awaits physical governor repair tracked in simplicio-loop#1228. Native UI/installer lanes were not executed and are not claimed by these source checks. Keep #391 open until remaining affected tests and integrated revision validation are complete. No product release is represented by this PR.