### PR TITLE
feat-desktop-add-execution-reports-screen

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -596,6 +596,26 @@ async fn desktop_unified_usage(query: Value, repo_path: Option<String>) -> Resul
 }
 
 #[tauri::command]
+async fn desktop_execution_report(
+    repo_path: Option<String>,
+    run_id: Option<String>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        require_read_access()?;
+        let default_repo = default_projection_repo()?;
+        let args = projection_queries::execution_report_args(
+            repo_path.as_deref(),
+            run_id.as_deref(),
+            &default_repo,
+        )?;
+        let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+        run_runtime_json(&borrowed).map_err(|_| "execution_report_unavailable".to_string())
+    })
+    .await
+    .map_err(|_| "execution_report_unavailable".to_string())?
+}
+
+#[tauri::command]
 async fn desktop_export_unified_usage(
     app: tauri::AppHandle,
     query: Value,
@@ -1273,6 +1293,7 @@ pub fn run() {
             desktop_usage_changefeed,
             desktop_session_close_idle,
             desktop_unified_usage,
+            desktop_execution_report,
             desktop_export_unified_usage,
             desktop_cost_projection,
             desktop_context_report,

--- a/apps/desktop/src-tauri/src/projection_queries.rs
+++ b/apps/desktop/src-tauri/src/projection_queries.rs
@@ -106,6 +106,44 @@ pub fn query_args(
     ])
 }
 
+fn report_id(value: Option<&str>) -> Result<Option<String>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err("projection_query_invalid".into());
+    }
+    Ok(Some(value.to_string()))
+}
+
+pub fn execution_report_args(
+    selected_repo: Option<&str>,
+    selected_run_id: Option<&str>,
+    default_repo: &Path,
+) -> Result<Vec<String>, String> {
+    let repo = selected_repo
+        .map(repo_path)
+        .transpose()?
+        .unwrap_or_else(|| default_repo.to_path_buf());
+    let repo = repo_path(&repo.to_string_lossy())?;
+    let mut args = vec![
+        "execution-report".into(),
+        "show".into(),
+        "--repo".into(),
+        repo.to_string_lossy().into_owned(),
+        "--json".into(),
+    ];
+    if let Some(run_id) = report_id(selected_run_id)? {
+        args.extend(["--run-id".into(), run_id]);
+    }
+    Ok(args)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,6 +165,21 @@ mod tests {
         assert_eq!(args[5], "--json");
         let args = query_args("desktop-unified-usage", &json!({}), None, &repo).unwrap();
         assert_eq!(args[0], "desktop-unified-usage");
+    }
+
+    #[test]
+    fn builds_bounded_execution_report_args() {
+        let repo = std::env::temp_dir().canonicalize().unwrap();
+        let args = execution_report_args(None, None, &repo).unwrap();
+        assert_eq!(args[0], "execution-report");
+        assert_eq!(args[1], "show");
+        assert_eq!(args[2], "--repo");
+        assert_eq!(args[3], repo.to_string_lossy());
+        assert_eq!(args[4], "--json");
+        let args = execution_report_args(None, Some("run-123"), &repo).unwrap();
+        assert_eq!(args[5], "--run-id");
+        assert_eq!(args[6], "run-123");
+        assert!(execution_report_args(None, Some("../private"), &repo).is_err());
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -40,6 +40,7 @@ import { ActivityScreen } from "./screens/ActivityScreen";
 import { BotCenterScreen } from "./screens/BotCenterScreen";
 import { ProductSurfaceScreen } from "./screens/ProductScreens";
 import { TokensScreen } from "./screens/TokensScreen";
+import { ReportsScreen } from "./screens/ReportsScreen";
 import { ReferenceSettingsScreen } from "./screens/ReferenceSettingsScreen";
 import { isReferenceSettingsView } from "./reference_screens";
 import "./runtime_panels.css";
@@ -556,6 +557,7 @@ export function DesktopApp({ snapshot: initialSnapshot }: { snapshot?: DesktopSn
       )}
       {view === "memory" && <MemoryScreen snapshot={snapshot} />}
       {view === "tokens" && <TokensScreen key={tokenRepo} initialRepoPath={tokenRepo} projectPaths={workbench.projects.map(project => project.path)} usage={usage} />}
+      {view === "reports" && <ReportsScreen repoPath={contextRepoPath} />}
       {(view === "settings" || view === "diagnostics") && (
         <SettingsScreen section={view === "diagnostics" ? "diagnostics" : "account"} snapshot={snapshot} busy={action !== null}
           onRefresh={refresh} onSubscribe={subscribe} onLogout={logout} logoutBusy={action === "logout"}

--- a/apps/desktop/src/bridge.ts
+++ b/apps/desktop/src/bridge.ts
@@ -22,6 +22,7 @@ import { parseUsageProjects } from "./project_usage";
 import { applyUsageChangefeedEvent, createUsageChangefeedState, type UsageChangefeedState } from "./usage_changefeed";
 import { exportUnifiedUsageProjection, parseUnifiedUsageProjection, type UnifiedUsageProjection, type UsageQuery } from "./unified_usage";
 import { parseCostProjection, type CostProjection, type CostQuery } from "./cost_projection";
+import { createPreviewExecutionReport, parseExecutionReport, type ExecutionReport } from "./execution_report";
 import { createConsolidatedReader, type ConsolidatedQuery, type ConsolidatedReport } from "./consolidated_tokens";
 import {
   createPreviewRuntimeInstallResult,
@@ -58,6 +59,18 @@ export async function loadDesktopUnifiedUsage(query: UsageQuery = {}, repoPath?:
     invoke<unknown>("desktop_unified_usage", { query, repoPath: repoPath || null }),
     60_000,
     "unified_usage_timeout",
+  ));
+}
+
+export async function loadDesktopExecutionReport(repoPath?: string, runId?: string): Promise<ExecutionReport> {
+  if (!isTauri()) return createPreviewExecutionReport();
+  return parseExecutionReport(await withTimeout(
+    invoke<unknown>("desktop_execution_report", {
+      repoPath: repoPath || null,
+      runId: runId || null,
+    }),
+    60_000,
+    "execution_report_timeout",
   ));
 }
 

--- a/apps/desktop/src/components/Shell.tsx
+++ b/apps/desktop/src/components/Shell.tsx
@@ -11,7 +11,7 @@ export type { View } from "../workbench";
 
 interface Destination { id: View; icon: GlyphName; group?: string; description?: string }
 const navigation: Destination[] = ([
-  { id: "home", icon: "home" }, { id: "activity", icon: "activity" },
+  { id: "home", icon: "home" }, { id: "activity", icon: "activity" }, { id: "reports", icon: "activity" },
   { id: "automations", icon: "automation" },
   { id: "agents", icon: "teams" }, { id: "providers", icon: "providers" }, { id: "tokens", icon: "spark" },
 ] satisfies Destination[]).filter((item) => isNavigationVisible(item.id));

--- a/apps/desktop/src/execution_report.test.ts
+++ b/apps/desktop/src/execution_report.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { createPreviewExecutionReport, parseExecutionReport } from "./execution_report";
+
+describe("execution report contract", () => {
+  it("keeps cache and included reasoning out of the exclusive total", () => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      owner: "simplicio-runtime",
+      run_id: "run-5569",
+      status: "COMPLETE",
+      tasks: [{
+        task_id: "task-1",
+        title: "normalização",
+        outcome: "COMPLETE",
+        tokens: {
+          tokens_in: 1_000,
+          tokens_out: 200,
+          tokens_cached: 800,
+          cache_read_tokens: 800,          cache_write_tokens: 200,
+          tokens_reasoning: 150,
+          tokens_total: 1_200,
+          input_semantics: "uncached_only",
+          reasoning_semantics: "included_in_output",
+          cost_microusd: null,
+          cost_status: "unavailable",
+          source: "provider-reported",
+        },
+        stages: [{
+          stage_id: "verify",
+          name: "Validação",
+          status: "failed",
+          wall_ms: 300,
+          tokens: {},
+          tool_count: 1,
+          error_count: 1,
+          attempt_count: 2,
+        }],
+        tools: [{ name: "cargo-test", status: "failed", invocations: 2, wall_ms: 300, error_count: 1 }],
+        errors: [{ code: "validation_failed", stage_id: "verify", retryable: true }],
+        retries: [{ attempt: 2, reason_code: "validation_failed", status: "failed", wall_ms: 300 }],
+        validation: { status: "failed", checks: 4, failures: 1, source: "cargo-test" },
+        coverage: { status: "complete", fields: ["stages"], missing: [] },
+      }],
+      consolidated: {
+        task_count: 1,
+        tokens_total_sum: 1_200,
+        tokens_cache_read_sum: 800,        tokens_cache_write_sum: 200,
+        tokens_reasoning_sum: 150,
+        error_count: 1,
+        retry_count: 1,
+        validation: { status: "failed", checks: 4, failures: 1, source: "cargo-test" },
+      },
+      measured_fields: ["tokens_per_task"],
+      unverified_fields: [],
+      unavailable_reasons: {},
+    });
+
+    expect(report.present).toBe(true);
+    if (!report.present) return;
+    expect(report.tasks[0].tokens.total).toBe(1_200);
+    expect(report.tasks[0].tokens.cacheRead).toBe(800);    expect(report.tasks[0].tokens.cacheWrite).toBe(200);
+    expect(report.tasks[0].tokens.reasoning).toBe(150);
+    expect(report.tasks[0].stages[0].status).toBe("failed");
+    expect(report.tasks[0].retries[0].attempt).toBe(2);
+    expect(report.tasks[0].validation.failures).toBe(1);
+  });
+
+  it("does not turn a missing token dimension into zero", () => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      tasks: [{ task_id: "task-1", title: "partial", tokens: { tokens_in: 5 } }],
+    });
+    expect(report.present).toBe(true);
+    if (!report.present) return;
+    expect(report.tasks[0].tokens.total).toBeNull();
+  });
+
+  it("rejects conflicting cache aliases instead of choosing a value", () => {
+    expect(() => parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      tasks: [{
+        task_id: "task-1",
+        title: "bad",
+        tokens: { tokens_in: 1, tokens_out: 1, tokens_total: 2, tokens_cached: 3, cache_read_tokens: 4 },
+      }],
+    })).toThrow("execution_report_invalid");
+  });
+
+  it("represents an absent report explicitly", () => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      present: false,
+      message: "not recorded",
+    });
+    expect(report).toMatchObject({ present: false, message: "not recorded" });
+  });
+
+  it("provides an unmistakable preview fixture with partial coverage", () => {
+    const report = createPreviewExecutionReport(1_700_000_000);
+    expect(report.runId).toBe("preview-run-5568");
+    expect(report.coverage.status).toBe("partial");
+    expect(report.tasks[1].errors[0].code).toBe("validation_failed");
+  });
+
+  it("parses bounded run history without exposing filesystem paths", () => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      run_id: "run-current",
+      history: [{ run_id: "run-old", status: "FAIL", wall_ms: 42, task_count: 2, recorded_at_unix: 1_700_000_000 }],
+    });
+    expect(report.present).toBe(true);
+    if (!report.present) return;
+    expect(report.history).toEqual([{
+      runId: "run-old",
+      status: "FAIL",
+      wallMs: 42,
+      taskCount: 2,
+      recordedAtUnix: 1_700_000_000,
+    }]);
+  });
+});

--- a/apps/desktop/src/execution_report.test.ts
+++ b/apps/desktop/src/execution_report.test.ts
@@ -48,7 +48,7 @@ describe("execution report contract", () => {
         tokens_reasoning_sum: 150,
         error_count: 1,
         retry_count: 1,
-        validation: { status: "failed", checks: 4, failures: 1, source: "cargo-test" },
+        validation: { status: "failed", coverage_status: "partial", checks: 4, failures: 1, source: "cargo-test" },
       },
       measured_fields: ["tokens_per_task"],
       unverified_fields: [],
@@ -92,7 +92,7 @@ describe("execution report contract", () => {
       present: false,
       message: "not recorded",
     });
-    expect(report).toMatchObject({ present: false, message: "not recorded" });
+    expect(report).toMatchObject({ present: false, message: "Nenhum relatório de execução foi registrado." });
   });
 
   it("provides an unmistakable preview fixture with partial coverage", () => {
@@ -117,5 +117,70 @@ describe("execution report contract", () => {
       taskCount: 2,
       recordedAtUnix: 1_700_000_000,
     }]);
+  });
+
+  it("preserves provenance and keeps uncertain rollups explicit", () => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      run_id: "run-current",
+      engine: "native",
+      engine_version: "3.8.47",
+      loop_decision: { verdict: "required" },
+      tasks: [{
+        task_id: "task-1",
+        title: "MCP via Loop",
+        model: "gpt-5.6",
+        provider: "openai",
+        engine: "python",
+        engine_version: "fallback-1",
+        fallback_reason: "native_unavailable",
+        attempt_id: "attempt-2",
+        parent_span_id: "span-1",
+        completion_verdict: "partial",
+        run_id: "run-current",
+        session_ids: ["session-a", "session-b"],
+        receipts: ["receipt-1"],
+        unresolved: ["late-correction"],
+        resources: { cpu_percent: 12.5, ram_mb: 64.5, system_ram_mb: 1024.25, source: "measured" },
+        tokens: {
+          tokens_in: 10,
+          tokens_out: 2,
+          tokens_total: 12,
+          tokens_cached: 4,
+          cache_read_provenance: "provider",
+          cache_write_tokens: 1,
+          cache_write_provenance: "local",
+          tokens_reasoning: 2,
+          reasoning_semantics: "included_in_output",
+        },
+        validation: { status: "partial", checks: 3, failures: 1, executed: 3, passed: 2, ignored: 0, source: "vitest" },
+        errors: [{ code: "validation_failed", message: "/Users/wesley/token=secret", stage_id: "verify" }],
+      }],
+      consolidated: {
+        task_count: 1,
+        tokens_cache_read_sum: 4,
+        tokens_cache_read_rollup: "partial",
+        tokens_reasoning_sum: 2,
+        reasoning_rollup: "partial",
+        cost_microusd_sum: 123,
+        cost_rollup: "complete",
+        cost_status: "estimated",
+        cost_provenance: "catalog-estimate",
+      },
+    });
+    expect(report.present).toBe(true);
+    if (!report.present) return;
+    expect(report.engine).toBe("native");
+    expect(report.loopDecision?.verdict).toBe("required");
+    expect(report.tasks[0].engine).toBe("python");
+    expect(report.tasks[0].fallbackReason).toBe("native_unavailable");
+    expect(report.tasks[0].sessionIds).toEqual(["session-a", "session-b"]);
+    expect(report.tasks[0].resources?.cpuPercent).toBe(12.5);
+    expect(report.tasks[0].tokens.cacheReadProvenance).toBe("provider");
+    expect(report.tasks[0].validation.failures).toBe(1);
+    expect(report.tasks[0].errors[0].message).toBeNull();
+    expect(report.consolidated.tokensCacheReadRollup).toBe("partial");
+    expect(report.consolidated.tokensReasoningRollup).toBe("partial");
+    expect(report.consolidated.costStatus).toBe("estimated");    expect(report.consolidated.costProvenance).toBe("catalog-estimate");
   });
 });

--- a/apps/desktop/src/execution_report.ts
+++ b/apps/desktop/src/execution_report.ts
@@ -1,0 +1,522 @@
+export const EXECUTION_REPORT_SCHEMA = "simplicio.execution-report/v1";
+export const MAX_REPORT_TASKS = 512;
+export const MAX_REPORT_ITEMS = 128;
+
+export type ReportStatus = "OPEN" | "COMPLETE" | "FAIL" | "UNVERIFIED" | string;
+export type ReportCoverageStatus = "complete" | "partial" | "unavailable" | "no_data";
+export type ValidationStatus = "passed" | "failed" | "not_run" | "unavailable" | string;
+export type ReportCostStatus = "known" | "estimated" | "unavailable" | string;
+
+export interface ReportTokenUsage {
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  reasoning: number | null;
+  total: number | null;
+  inputSemantics: string;
+  reasoningSemantics: string;
+  costMicrousd: number | null;
+  costStatus: ReportCostStatus;
+  costProvenance: string;
+  source: string;
+}
+
+export interface ReportStage {
+  id: string;
+  name: string;
+  status: string;
+  wallMs: number | null;
+  tokens: ReportTokenUsage;
+  toolCount: number;
+  errorCount: number;
+  attemptCount: number;
+  notes: string[];
+}
+
+export interface ReportTool {
+  name: string;
+  status: string;
+  invocations: number;
+  wallMs: number | null;
+  errorCount: number;
+}
+
+export interface ReportError {
+  code: string;
+  stageId: string | null;
+  message: string | null;
+  retryable: boolean | null;
+}
+
+export interface ReportRetry {
+  attempt: number;
+  reasonCode: string;
+  status: string;
+  wallMs: number | null;
+}
+
+export interface ReportValidation {
+  status: ValidationStatus;
+  checks: number;
+  failures: number;
+  source: string;
+  notes: string[];
+}
+
+export interface ReportCoverage {
+  status: ReportCoverageStatus;
+  fields: string[];
+  missing: string[];
+}
+
+export interface ReportTask {
+  taskId: string;
+  issue: string | null;
+  title: string;
+  wallMs: number | null;
+  phaseLatencyMs: Record<string, unknown>;
+  tokens: ReportTokenUsage;
+  stages: ReportStage[];
+  tools: ReportTool[];
+  errors: ReportError[];
+  retries: ReportRetry[];
+  validation: ReportValidation;
+  coverage: ReportCoverage;
+  outcome: string;
+  operators: string[];
+  notes: string[];
+}
+
+export interface ReportConsolidated {
+  taskCount: number;
+  wallMsRun: number | null;
+  wallMsTasksSum: number | null;
+  tokensInSum: number | null;
+  tokensOutSum: number | null;
+  tokensTotalSum: number | null;
+  tokensRollup: string;
+  tokensCacheReadSum: number | null;
+  tokensCacheWriteSum: number | null;
+  tokensReasoningSum: number | null;
+  costMicrousdSum: number | null;
+  costRollup: string;
+  toolInvocations: number;
+  errorCount: number;
+  retryCount: number;
+  validation: ReportValidation;
+}
+
+export interface ReportHistoryEntry {
+  runId: string;
+  status: string;
+  wallMs: number | null;
+  taskCount: number | null;
+  recordedAtUnix: number | null;
+}
+
+export interface PresentExecutionReport {
+  schema: typeof EXECUTION_REPORT_SCHEMA;
+  present: true;
+  owner: string;
+  runId: string;
+  repoFingerprint: string | null;
+  status: ReportStatus;
+  startedAtUnix: number | null;
+  finishedAtUnix: number | null;
+  wallMs: number | null;
+  executionProfile: string;
+  operators: string[];
+  tasks: ReportTask[];
+  history: ReportHistoryEntry[];
+  consolidated: ReportConsolidated;
+  measuredFields: string[];
+  unverifiedFields: string[];
+  unavailableReasons: Record<string, unknown>;
+  coverage: ReportCoverage;
+  revision: string | null;
+  fetchedAtUnix: number;
+}
+
+export interface MissingExecutionReport {
+  schema: typeof EXECUTION_REPORT_SCHEMA;
+  present: false;
+  message: string;
+  fetchedAtUnix: number;
+}
+
+export type ExecutionReport = PresentExecutionReport | MissingExecutionReport;
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("execution_report_invalid");
+  return value as Record<string, unknown>;
+}
+
+function optionalRecord(value: unknown): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  return record(value);
+}
+
+function text(value: unknown, fallback: string, max = 512): string {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "string" || value.length === 0 || value.length > max || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error("execution_report_invalid");
+  }
+  return value;
+}
+
+function optionalText(value: unknown, max = 512): string | null {
+  if (value === undefined || value === null) return null;
+  return text(value, "", max);
+}
+
+function nonNegative(value: unknown): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new Error("execution_report_invalid");
+  return value;
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "boolean") throw new Error("execution_report_invalid");
+  return value;
+}
+
+function array(value: Record<string, unknown>, key: string, max = MAX_REPORT_ITEMS): unknown[] {
+  const candidate = value[key];
+  if (candidate === undefined || candidate === null) return [];
+  if (!Array.isArray(candidate) || candidate.length > max) throw new Error("execution_report_invalid");
+  return candidate;
+}
+
+function strings(value: Record<string, unknown>, key: string, max = MAX_REPORT_ITEMS): string[] {
+  return array(value, key, max).map((item) => text(item, ""));
+}
+
+function metric(value: Record<string, unknown>, primary: string, secondary?: string): number | null {
+  const first = nonNegative(value[primary]);
+  const second = secondary ? nonNegative(value[secondary]) : null;
+  if (first !== null && second !== null && first !== second) throw new Error("execution_report_invalid");
+  return first ?? second;
+}
+
+const knownCoverage = new Set<ReportCoverageStatus>(["complete", "partial", "unavailable", "no_data"]);
+
+function parseCoverage(raw: unknown, fallbackMissing: string[] = []): ReportCoverage {
+  const value = optionalRecord(raw);
+  const status = text(value.status, fallbackMissing.length ? "partial" : "unavailable") as ReportCoverageStatus;
+  if (!knownCoverage.has(status)) throw new Error("execution_report_invalid");
+  const missing = strings(value, "missing");
+  return {
+    status,
+    fields: strings(value, "fields"),
+    missing: missing.length ? missing : fallbackMissing,
+  };
+}
+
+function parseTokens(raw: unknown): ReportTokenUsage {
+  const value = optionalRecord(raw);
+  const input = nonNegative(value.tokens_in);
+  const output = nonNegative(value.tokens_out);
+  const total = nonNegative(value.tokens_total);
+  let expectedTotal: number | null = null;
+  if (input !== null && output !== null) {
+    if (input > Number.MAX_SAFE_INTEGER - output) throw new Error("execution_report_invalid");
+    expectedTotal = input + output;
+  }
+  if (total !== null && expectedTotal !== null && total !== expectedTotal) throw new Error("execution_report_invalid");
+  if (total !== null && expectedTotal === null) throw new Error("execution_report_invalid");
+  return {
+    input,
+    output,
+    cacheRead: metric(value, "tokens_cached", "cache_read_tokens"),
+    cacheWrite: metric(value, "cache_write_tokens", "tokens_cache_write"),
+    reasoning: nonNegative(value.tokens_reasoning),
+    total: expectedTotal,
+    inputSemantics: text(value.input_semantics, "unknown", 96),
+    reasoningSemantics: text(value.reasoning_semantics, "unknown", 96),
+    costMicrousd: nonNegative(value.cost_microusd),
+    costStatus: text(value.cost_status, "unavailable", 48),
+    costProvenance: text(value.cost_provenance, "unavailable", 96),
+    source: text(value.source, "absent", 96),
+  };
+}
+
+function parseStage(raw: unknown): ReportStage {
+  const value = record(raw);
+  return {
+    id: text(value.stage_id ?? value.id, "unknown", 128),
+    name: text(value.name, "Etapa não identificada"),
+    status: text(value.status, "unavailable", 96),
+    wallMs: nonNegative(value.wall_ms),
+    tokens: parseTokens(value.tokens),
+    toolCount: nonNegative(value.tool_count) ?? 0,
+    errorCount: nonNegative(value.error_count) ?? 0,
+    attemptCount: nonNegative(value.attempt_count) ?? 0,
+    notes: strings(value, "notes"),
+  };
+}
+
+function parseTool(raw: unknown): ReportTool {
+  const value = record(raw);
+  return {
+    name: text(value.name, "tool", 128),
+    status: text(value.status, "unavailable", 96),
+    invocations: nonNegative(value.invocations) ?? 0,
+    wallMs: nonNegative(value.wall_ms),
+    errorCount: nonNegative(value.error_count) ?? 0,
+  };
+}
+
+function parseError(raw: unknown): ReportError {
+  const value = record(raw);
+  return {
+    code: text(value.code, "unknown_error", 128),
+    stageId: optionalText(value.stage_id, 128),
+    message: optionalText(value.message, 256),
+    retryable: booleanOrNull(value.retryable),
+  };
+}
+
+function parseRetry(raw: unknown): ReportRetry {
+  const value = record(raw);
+  return {
+    attempt: nonNegative(value.attempt) ?? 0,
+    reasonCode: text(value.reason_code, "unknown_retry", 128),
+    status: text(value.status, "unavailable", 96),
+    wallMs: nonNegative(value.wall_ms),
+  };
+}
+
+function parseValidation(raw: unknown): ReportValidation {
+  const value = optionalRecord(raw);
+  return {
+    status: text(value.status, "unavailable", 48),
+    checks: nonNegative(value.checks) ?? 0,
+    failures: nonNegative(value.failures) ?? 0,
+    source: text(value.source, "not_recorded", 128),
+    notes: strings(value, "notes"),
+  };
+}
+
+function parseTask(raw: unknown): ReportTask {
+  const value = record(raw);
+  const phaseLatency = optionalRecord(value.phase_latency_ms);
+  return {
+    taskId: text(value.task_id, "unknown", 256),
+    issue: optionalText(value.issue, 128),
+    title: text(value.title, "Tarefa sem título"),
+    wallMs: nonNegative(value.wall_ms),
+    phaseLatencyMs: phaseLatency,
+    tokens: parseTokens(value.tokens),
+    stages: array(value, "stages").map(parseStage),
+    tools: array(value, "tools").map(parseTool),
+    errors: array(value, "errors").map(parseError),
+    retries: array(value, "retries").map(parseRetry),
+    validation: parseValidation(value.validation),
+    coverage: parseCoverage(value.coverage),
+    outcome: text(value.outcome, "UNVERIFIED", 64),
+    operators: strings(value, "operators_used"),
+    notes: strings(value, "notes"),
+  };
+}
+
+function parseConsolidated(raw: unknown, taskCount: number): ReportConsolidated {
+  const value = optionalRecord(raw);
+  const tokensRollup = text(value.tokens_rollup, "complete", 32);
+  return {
+    taskCount: nonNegative(value.task_count) ?? taskCount,
+    wallMsRun: nonNegative(value.wall_ms_run),
+    wallMsTasksSum: nonNegative(value.wall_ms_tasks_sum),
+    tokensInSum: nonNegative(value.tokens_in_sum),
+    tokensOutSum: nonNegative(value.tokens_out_sum),
+    tokensTotalSum: tokensRollup === "partial" ? null : nonNegative(value.tokens_total_sum),
+    tokensRollup,
+    tokensCacheReadSum: nonNegative(value.tokens_cache_read_sum),
+    tokensCacheWriteSum: nonNegative(value.tokens_cache_write_sum),
+    tokensReasoningSum: nonNegative(value.tokens_reasoning_sum),
+    costMicrousdSum: nonNegative(value.cost_microusd_sum),
+    costRollup: text(value.cost_rollup, "unavailable", 32),
+    toolInvocations: nonNegative(value.tool_invocations) ?? 0,
+    errorCount: nonNegative(value.error_count) ?? 0,
+    retryCount: nonNegative(value.retry_count) ?? 0,
+    validation: parseValidation(value.validation),
+  };
+}
+
+function parseHistory(raw: unknown): ReportHistoryEntry[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw) || raw.length > MAX_REPORT_ITEMS) throw new Error("execution_report_invalid");
+  return raw.map((item) => {
+    const value = record(item);
+    return {
+      runId: text(value.run_id, "unknown", 128),
+      status: text(value.status, "UNVERIFIED", 64),
+      wallMs: nonNegative(value.wall_ms),
+      taskCount: nonNegative(value.task_count),
+      recordedAtUnix: nonNegative(value.recorded_at_unix),
+    };
+  });
+}
+
+export function parseExecutionReport(raw: unknown, fetchedAtUnix = Math.floor(Date.now() / 1000)): ExecutionReport {
+  const value = record(raw);
+  if (value.schema !== EXECUTION_REPORT_SCHEMA) throw new Error("execution_report_invalid");
+  if (value.present === false) {
+    return {
+      schema: EXECUTION_REPORT_SCHEMA,
+      present: false,
+      message: text(value.message, "Nenhum relatório de execução foi registrado."),
+      fetchedAtUnix,
+    };
+  }
+  const tasks = array(value, "tasks", MAX_REPORT_TASKS).map(parseTask);
+  const unverifiedFields = strings(value, "unverified_fields");
+  const measuredFields = strings(value, "measured_fields");
+  const coverage = parseCoverage(value.coverage, unverifiedFields);
+  return {
+    schema: EXECUTION_REPORT_SCHEMA,
+    present: true,
+    owner: text(value.owner, "simplicio-runtime", 128),
+    runId: text(value.run_id, "unknown", 256),
+    repoFingerprint: optionalText(value.repo_fingerprint, 128),
+    status: text(value.status, "UNVERIFIED", 64),
+    startedAtUnix: nonNegative(value.started_at_unix),
+    finishedAtUnix: nonNegative(value.finished_at_unix),
+    wallMs: nonNegative(value.wall_ms),
+    executionProfile: text(value.execution_profile, "runtime-backed", 128),
+    operators: strings(value, "operators_used"),
+    tasks,
+    history: parseHistory(value.history),
+    consolidated: parseConsolidated(value.consolidated, tasks.length),
+    measuredFields,
+    unverifiedFields,
+    unavailableReasons: optionalRecord(value.unavailable_reasons),
+    coverage,
+    revision: optionalText(value.revision, 128),
+    fetchedAtUnix,
+  };
+}
+
+function demoTokens(input: number, output: number, cacheRead: number | null, reasoning: number | null, source: string): ReportTokenUsage {
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite: null,
+    reasoning,
+    total: input + output,
+    inputSemantics: "uncached_only",
+    reasoningSemantics: reasoning === null ? "unknown" : "included_in_output",
+    costMicrousd: null,
+    costStatus: "unavailable",
+    costProvenance: "unavailable",
+    source,
+  };
+}
+
+export function createPreviewExecutionReport(fetchedAtUnix = Math.floor(Date.now() / 1000)): PresentExecutionReport {
+  const mapperTokens = demoTokens(420, 180, 320, null, "measured");
+  const repairTokens = demoTokens(1_000, 200, 800, 150, "provider-reported");
+  const task = (taskId: string, title: string, outcome: string, tokens: ReportTokenUsage, stage: ReportStage, tools: ReportTool[], errors: ReportError[], retries: ReportRetry[], validation: ReportValidation, issue: string | null): ReportTask => ({
+    taskId,
+    issue,
+    title,
+    wallMs: stage.wallMs,
+    phaseLatencyMs: {},
+    tokens,
+    stages: [stage],
+    tools,
+    errors,
+    retries,
+    validation,
+    coverage: {
+      status: errors.length || retries.length ? "partial" : "complete",
+      fields: ["stages", "tools", "validation"],
+      missing: errors.length || retries.length ? [] : ["errors", "retries"],
+    },
+    outcome,
+    operators: ["simplicio-loop", "simplicio-dev-cli"],
+    notes: [],
+  });
+  const mapperValidation: ReportValidation = { status: "passed", checks: 3, failures: 0, source: "runtime", notes: [] };
+  const failedValidation: ReportValidation = { status: "failed", checks: 5, failures: 1, source: "cargo-test", notes: ["Uma verificação falhou; detalhes preservados como evidência."] };
+  return {
+    schema: EXECUTION_REPORT_SCHEMA,
+    present: true,
+    owner: "simplicio-runtime",
+    runId: "preview-run-5568",
+    repoFingerprint: null,
+    status: "FAIL",
+    startedAtUnix: fetchedAtUnix - 68,
+    finishedAtUnix: fetchedAtUnix,
+    wallMs: 68_000,
+    executionProfile: "runtime-backed",
+    operators: ["simplicio-loop", "simplicio-mapper", "simplicio-dev-cli"],
+    tasks: [
+      task("map", "Mapear contexto do épico", "COMPLETE", mapperTokens, {
+        id: "discover",
+        name: "Descoberta",
+        status: "complete",
+        wallMs: 820,
+        tokens: mapperTokens,
+        toolCount: 2,
+        errorCount: 0,
+        attemptCount: 1,
+        notes: [],
+      }, [{ name: "simplicio_map", status: "complete", invocations: 1, wallMs: 640, errorCount: 0 }], [], [], mapperValidation, "#5568"),
+      task("implement", "Integrar telemetria por tarefa", "FAIL", repairTokens, {
+        id: "verify",
+        name: "Validação",
+        status: "failed",
+        wallMs: 3_400,
+        tokens: repairTokens,
+        toolCount: 1,
+        errorCount: 1,
+        attemptCount: 2,
+        notes: [],
+      }, [{ name: "cargo test", status: "failed", invocations: 2, wallMs: 3_400, errorCount: 1 }], [{ code: "validation_failed", stageId: "verify", message: "A validação não foi confirmada.", retryable: true }], [{ attempt: 2, reasonCode: "validation_failed", status: "failed", wallMs: 3_400 }], failedValidation, "#5569"),
+    ],
+    history: [{
+      runId: "preview-run-5568",
+      status: "FAIL",
+      wallMs: 68_000,
+      taskCount: 2,
+      recordedAtUnix: fetchedAtUnix,
+    }],
+    consolidated: {
+      taskCount: 2,
+      wallMsRun: 68_000,
+      wallMsTasksSum: 4_220,
+      tokensInSum: 1_420,
+      tokensOutSum: 380,
+      tokensTotalSum: 1_800,
+      tokensCacheReadSum: 1_120,      tokensRollup: "complete",
+      tokensCacheWriteSum: null,
+      tokensReasoningSum: 150,
+      costMicrousdSum: null,
+      costRollup: "unavailable",
+      toolInvocations: 3,
+      errorCount: 1,
+      retryCount: 1,
+      validation: { status: "failed", checks: 8, failures: 1, source: "runtime", notes: [] },
+    },
+    measuredFields: ["run_id", "started_at_unix", "task_wall_ms", "tokens_per_task"],
+    unverifiedFields: ["cpu_percent", "cost_microusd"],
+    unavailableReasons: { cost_microusd: "no pricing receipt in preview" },
+    coverage: { status: "partial", fields: ["tasks", "stages", "tools", "validation"], missing: ["cost_microusd", "otel"] },
+    revision: "preview:2",
+    fetchedAtUnix,
+  };
+}
+
+export function downloadExecutionReport(report: ExecutionReport): void {
+  if (typeof document === "undefined") return;
+  const payload = JSON.stringify(report, null, 2);
+  const url = URL.createObjectURL(new Blob([payload], { type: "application/json" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "simplicio-execution-report.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/apps/desktop/src/execution_report.ts
+++ b/apps/desktop/src/execution_report.ts
@@ -4,14 +4,15 @@ export const MAX_REPORT_ITEMS = 128;
 
 export type ReportStatus = "OPEN" | "COMPLETE" | "FAIL" | "UNVERIFIED" | string;
 export type ReportCoverageStatus = "complete" | "partial" | "unavailable" | "no_data";
-export type ValidationStatus = "passed" | "failed" | "not_run" | "unavailable" | string;
+export type ValidationStatus = "passed" | "failed" | "partial" | "not_run" | "unavailable" | string;
 export type ReportCostStatus = "known" | "estimated" | "unavailable" | string;
 
 export interface ReportTokenUsage {
   input: number | null;
   output: number | null;
   cacheRead: number | null;
-  cacheWrite: number | null;
+  cacheWrite: number | null;  cacheReadProvenance?: string | null;
+  cacheWriteProvenance?: string | null;
   reasoning: number | null;
   total: number | null;
   inputSemantics: string;
@@ -19,6 +20,13 @@ export interface ReportTokenUsage {
   costMicrousd: number | null;
   costStatus: ReportCostStatus;
   costProvenance: string;
+  source: string;
+}
+
+export interface ReportResourceSample {
+  cpuPercent: number | null;
+  ramMb: number | null;
+  systemRamMb: number | null;
   source: string;
 }
 
@@ -58,8 +66,12 @@ export interface ReportRetry {
 
 export interface ReportValidation {
   status: ValidationStatus;
-  checks: number;
-  failures: number;
+  coverageStatus?: string;
+  checks: number | null;
+  failures: number | null;
+  executed?: number | null;
+  passed?: number | null;
+  ignored?: number | null;
   source: string;
   notes: string[];
 }
@@ -76,6 +88,20 @@ export interface ReportTask {
   title: string;
   wallMs: number | null;
   phaseLatencyMs: Record<string, unknown>;
+  resources?: ReportResourceSample | null;
+  model?: string | null;
+  provider?: string | null;
+  engine?: string | null;
+  engineVersion?: string | null;
+  fallbackReason?: string | null;
+  attemptId?: string | null;
+  parentSpanId?: string | null;
+  completionVerdict?: string | null;
+  taskRunId?: string | null;
+  sessionIds?: string[];
+  receipts?: string[];
+  unresolved?: string[];
+  provenance?: string | null;
   tokens: ReportTokenUsage;
   stages: ReportStage[];
   tools: ReportTool[];
@@ -97,10 +123,14 @@ export interface ReportConsolidated {
   tokensTotalSum: number | null;
   tokensRollup: string;
   tokensCacheReadSum: number | null;
-  tokensCacheWriteSum: number | null;
+  tokensCacheWriteSum: number | null;  tokensCacheReadRollup?: string;
+  tokensCacheWriteRollup?: string;
   tokensReasoningSum: number | null;
+  tokensReasoningRollup?: string;
   costMicrousdSum: number | null;
   costRollup: string;
+  costStatus: ReportCostStatus;
+  costProvenance: string;
   toolInvocations: number;
   errorCount: number;
   retryCount: number;
@@ -126,7 +156,10 @@ export interface PresentExecutionReport {
   finishedAtUnix: number | null;
   wallMs: number | null;
   executionProfile: string;
-  operators: string[];
+  operators: string[];  engine?: string | null;
+  engineVersion?: string | null;
+  fallbackReason?: string | null;
+  loopDecision?: Record<string, unknown> | null;
   tasks: ReportTask[];
   history: ReportHistoryEntry[];
   consolidated: ReportConsolidated;
@@ -174,6 +207,47 @@ function nonNegative(value: unknown): number | null {
   if (value === undefined || value === null) return null;
   if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new Error("execution_report_invalid");
   return value;
+}
+
+function nonNegativeReal(value: unknown): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new Error("execution_report_invalid");
+  return value;
+}
+
+function aliasText(value: Record<string, unknown>, keys: string[], max = 512): string | null {
+  const found = keys
+    .map((key) => value[key])
+    .filter((candidate) => candidate !== undefined && candidate !== null)
+    .map((candidate) => text(candidate, "", max));
+  const distinct = [...new Set(found)];
+  if (distinct.length > 1) throw new Error("execution_report_invalid");
+  return distinct[0] ?? null;
+}
+
+function aliasNumber(value: Record<string, unknown>, keys: string[]): number | null {
+  const found = keys
+    .map((key) => value[key])
+    .filter((candidate) => candidate !== undefined && candidate !== null)
+    .map((candidate) => nonNegative(candidate));
+  const distinct = [...new Set(found)];
+  if (distinct.length > 1) throw new Error("execution_report_invalid");
+  return distinct[0] ?? null;
+}
+
+function aliasStrings(value: Record<string, unknown>, keys: string[], max = MAX_REPORT_ITEMS): string[] {
+  const found: string[] = [];
+  for (const key of keys) {
+    const candidate = value[key];
+    if (candidate === undefined || candidate === null) continue;
+    if (Array.isArray(candidate)) {
+      if (candidate.length > max) throw new Error("execution_report_invalid");
+      found.push(...candidate.map((item) => text(item, "", 256)));
+    } else {
+      found.push(text(candidate, "", 256));
+    }
+  }
+  return [...new Set(found)];
 }
 
 function booleanOrNull(value: unknown): boolean | null {
@@ -231,6 +305,8 @@ function parseTokens(raw: unknown): ReportTokenUsage {
     output,
     cacheRead: metric(value, "tokens_cached", "cache_read_tokens"),
     cacheWrite: metric(value, "cache_write_tokens", "tokens_cache_write"),
+    cacheReadProvenance: aliasText(value, ["cache_read_provenance", "cache_read_source", "provider_cache_read_source"], 96),
+    cacheWriteProvenance: aliasText(value, ["cache_write_provenance", "cache_write_source", "provider_cache_write_source"], 96),
     reasoning: nonNegative(value.tokens_reasoning),
     total: expectedTotal,
     inputSemantics: text(value.input_semantics, "unknown", 96),
@@ -273,7 +349,7 @@ function parseError(raw: unknown): ReportError {
   return {
     code: text(value.code, "unknown_error", 128),
     stageId: optionalText(value.stage_id, 128),
-    message: optionalText(value.message, 256),
+    message: null,
     retryable: booleanOrNull(value.retryable),
   };
 }
@@ -292,10 +368,25 @@ function parseValidation(raw: unknown): ReportValidation {
   const value = optionalRecord(raw);
   return {
     status: text(value.status, "unavailable", 48),
-    checks: nonNegative(value.checks) ?? 0,
-    failures: nonNegative(value.failures) ?? 0,
+    coverageStatus: text(value.coverage_status ?? value.coverage, "unavailable", 32),
+    checks: aliasNumber(value, ["checks", "executed"]),
+    failures: aliasNumber(value, ["failures", "failed"]),
+    executed: aliasNumber(value, ["executed", "checks"]),
+    passed: aliasNumber(value, ["passed", "successful"]),
+    ignored: aliasNumber(value, ["ignored", "skipped"]),
     source: text(value.source, "not_recorded", 128),
     notes: strings(value, "notes"),
+  };
+}
+
+function parseResources(raw: unknown): ReportResourceSample | null {
+  if (raw === undefined || raw === null) return null;
+  const value = record(raw);
+  return {
+    cpuPercent: nonNegativeReal(value.cpu_percent),
+    ramMb: nonNegativeReal(value.ram_mb),
+    systemRamMb: nonNegativeReal(value.system_ram_mb),
+    source: text(value.source, "unavailable", 96),
   };
 }
 
@@ -308,6 +399,20 @@ function parseTask(raw: unknown): ReportTask {
     title: text(value.title, "Tarefa sem título"),
     wallMs: nonNegative(value.wall_ms),
     phaseLatencyMs: phaseLatency,
+    resources: parseResources(value.resources),
+    model: aliasText(value, ["model", "model_id", "model_name"], 128),
+    provider: aliasText(value, ["provider", "provider_id"], 128),
+    engine: aliasText(value, ["engine", "executor", "runtime_engine"], 96),
+    engineVersion: aliasText(value, ["engine_version", "runtime_version"], 128),
+    fallbackReason: aliasText(value, ["fallback_reason", "fallbackReason"], 256),
+    attemptId: aliasText(value, ["attempt_id", "attemptId"], 128),
+    parentSpanId: aliasText(value, ["parent_span_id", "parent_span", "parentSpanId"], 128),
+    completionVerdict: aliasText(value, ["completion_verdict", "result"], 128),
+    taskRunId: aliasText(value, ["run_id", "task_run_id"], 128),
+    sessionIds: aliasStrings(value, ["session_ids", "session_id", "sessions"]),
+    receipts: aliasStrings(value, ["receipts", "receipt_ids"]),
+    unresolved: aliasStrings(value, ["unresolved", "unresolved_items"]),
+    provenance: aliasText(value, ["provenance", "source"], 128),
     tokens: parseTokens(value.tokens),
     stages: array(value, "stages").map(parseStage),
     tools: array(value, "tools").map(parseTool),
@@ -334,9 +439,14 @@ function parseConsolidated(raw: unknown, taskCount: number): ReportConsolidated 
     tokensRollup,
     tokensCacheReadSum: nonNegative(value.tokens_cache_read_sum),
     tokensCacheWriteSum: nonNegative(value.tokens_cache_write_sum),
+    tokensCacheReadRollup: text(value.tokens_cache_read_rollup, "absent", 32),
+    tokensCacheWriteRollup: text(value.tokens_cache_write_rollup, "absent", 32),
     tokensReasoningSum: nonNegative(value.tokens_reasoning_sum),
+    tokensReasoningRollup: text(value.reasoning_rollup, "absent", 32),
     costMicrousdSum: nonNegative(value.cost_microusd_sum),
     costRollup: text(value.cost_rollup, "unavailable", 32),
+    costStatus: text(value.cost_status, "unavailable", 48),
+    costProvenance: text(value.cost_provenance, "unavailable", 96),
     toolInvocations: nonNegative(value.tool_invocations) ?? 0,
     errorCount: nonNegative(value.error_count) ?? 0,
     retryCount: nonNegative(value.retry_count) ?? 0,
@@ -366,7 +476,7 @@ export function parseExecutionReport(raw: unknown, fetchedAtUnix = Math.floor(Da
     return {
       schema: EXECUTION_REPORT_SCHEMA,
       present: false,
-      message: text(value.message, "Nenhum relatório de execução foi registrado."),
+      message: "Nenhum relatório de execução foi registrado.",
       fetchedAtUnix,
     };
   }
@@ -385,6 +495,10 @@ export function parseExecutionReport(raw: unknown, fetchedAtUnix = Math.floor(Da
     finishedAtUnix: nonNegative(value.finished_at_unix),
     wallMs: nonNegative(value.wall_ms),
     executionProfile: text(value.execution_profile, "runtime-backed", 128),
+    engine: aliasText(value, ["engine", "executor", "runtime_engine"], 96),
+    engineVersion: aliasText(value, ["engine_version", "runtime_version"], 128),
+    fallbackReason: aliasText(value, ["fallback_reason", "fallbackReason"], 256),
+    loopDecision: value.loop_decision === undefined || value.loop_decision === null ? null : record(value.loop_decision),
     operators: strings(value, "operators_used"),
     tasks,
     history: parseHistory(value.history),
@@ -496,10 +610,12 @@ export function createPreviewExecutionReport(fetchedAtUnix = Math.floor(Date.now
       tokensReasoningSum: 150,
       costMicrousdSum: null,
       costRollup: "unavailable",
+      costStatus: "unavailable",
+      costProvenance: "no pricing receipt in preview",
       toolInvocations: 3,
       errorCount: 1,
       retryCount: 1,
-      validation: { status: "failed", checks: 8, failures: 1, source: "runtime", notes: [] },
+      validation: { status: "failed", coverageStatus: "partial", checks: 8, failures: 1, source: "runtime", notes: [] },
     },
     measuredFields: ["run_id", "started_at_unix", "task_wall_ms", "tokens_per_task"],
     unverifiedFields: ["cpu_percent", "cost_microusd"],

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,6 +5,7 @@ import "./styles.css";
 import "./product_surfaces.css";
 import "./motion_tokens.css";
 import "./workbench.css";
+import "./reports.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/desktop/src/reports.css
+++ b/apps/desktop/src/reports.css
@@ -1,0 +1,699 @@
+.reports-page {
+  max-width: 1180px !important;
+  padding-bottom: 56px !important;
+}
+
+.reports-heading {
+  align-items: flex-end !important;
+}
+
+.reports-heading-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.report-status,
+.report-task-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #f6f8f7;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.report-status {
+  min-height: 30px;
+  padding: 0 11px;
+}
+
+.report-status-success { color: #236343; background: #edf7f1; border-color: #d5e9dc; }
+.report-status-danger { color: #9b4b43; background: #fff1ef; border-color: #f0d6d1; }
+.report-status-warning { color: #89621e; background: #fff8e8; border-color: #efdfb5; }
+
+.report-context {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: -6px 0 20px;
+  padding: 10px 13px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  color: var(--muted);
+  font: 11px/1.5 var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.report-context > div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.report-context strong {
+  color: var(--ink);
+  font-family: inherit;
+  font-weight: 600;
+}
+
+.report-context-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 3px var(--green-soft);
+}
+
+.report-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.report-metric {
+  min-width: 0;
+  padding: 18px 18px 17px;
+  border: 1px solid var(--line);
+  border-top: 3px solid #cde3d5;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.report-metric span,
+.report-task-facts span {
+  display: block;
+  color: var(--muted-soft);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.report-metric strong {
+  display: block;
+  margin: 9px 0 7px;
+  color: var(--ink);
+  font-size: clamp(22px, 3vw, 31px);
+  font-weight: 650;
+  letter-spacing: -.055em;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.report-metric small,
+.report-task-facts small {
+  display: block;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.report-metric.muted strong { color: var(--muted-soft); }
+
+.report-coverage {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  padding: 19px 20px;
+  border-left: 3px solid var(--green);
+  background: #fbfdfb;
+}
+
+.report-coverage-partial,
+.report-coverage-unavailable,
+.report-coverage-no_data {
+  border-left-color: var(--warning);
+  background: #fffdf7;
+}
+
+.report-coverage h2 {
+  margin: 2px 0 5px;
+  color: var(--ink);
+  font-size: 16px;
+  letter-spacing: -.02em;
+}
+
+.report-coverage p {
+  max-width: 680px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.report-coverage-side {
+  min-width: 160px;
+  display: grid;
+  gap: 5px;
+  text-align: right;
+  color: var(--muted);
+  font: 11px/1.5 var(--mono);
+}
+
+.report-coverage-side strong {
+  color: var(--green-dark);
+  font-weight: 550;
+  overflow-wrap: anywhere;
+}
+
+.reports-task-panel {
+  min-width: 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  background: #fff;
+  overflow: hidden;
+}
+
+.reports-task-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 20px 17px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.reports-task-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 17px;
+  letter-spacing: -.025em;
+}
+
+.reports-task-heading > span {
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+
+.reports-task-list {
+  display: grid;
+}
+
+.report-task {
+  min-width: 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.report-task:last-child { border-bottom: 0; }
+
+.report-task > summary {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 12px;
+  padding: 15px 20px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.report-task > summary::-webkit-details-marker { display: none; }
+
+.report-task > summary:hover { background: #fbfcfc; }
+
+.report-task > summary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -3px;
+}
+
+.report-task-status {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+}
+
+.report-task-status-success { color: #236343; background: #edf7f1; border-color: #d5e9dc; }
+.report-task-status-danger { color: #a04f46; background: #fff1ef; border-color: #f0d6d1; }
+.report-task-status-warning { color: #89621e; background: #fff8e8; border-color: #efdfb5; }
+.report-task-status-neutral { color: var(--muted); background: #f6f7f8; }
+
+.report-task-summary {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.report-task-summary strong {
+  min-width: 0;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.report-task-summary small,
+.report-task-summary-meta small {
+  color: var(--muted);
+  font: 10px/1.4 var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.report-task-summary-meta {
+  min-width: 92px;
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  text-align: right;
+}
+
+.report-task-summary-meta b {
+  color: var(--ink);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.report-task > summary > .glyph {
+  color: var(--muted-soft);
+  transition: transform 140ms ease;
+}
+
+.report-task[open] > summary > .glyph { transform: rotate(180deg); }
+
+.report-task-details {
+  display: grid;
+  gap: 16px;
+  padding: 0 20px 20px 62px;
+  background: #fcfdfc;
+}
+
+.report-task-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  padding: 14px 0 2px;
+}
+
+.report-task-facts > div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.report-task-facts strong {
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.report-lanes {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.report-lane {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.report-lane-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.report-lane-heading h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.report-lane-heading > span {
+  color: var(--muted-soft);
+  font: 10px var(--mono);
+}
+
+.report-muted,
+.report-empty-inline {
+  color: var(--muted-soft);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.report-stage-list,
+.report-tool-list,
+.report-event-list {
+  display: grid;
+  gap: 9px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.report-stage-list li,
+.report-tool-list li,
+.report-event-list li {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.report-stage-marker {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  margin: 5px 2px 0 1px;
+  border-radius: 2px;
+  background: var(--green);
+}
+
+.report-line-copy,
+.report-tool-list li > div {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  flex: 1;
+}
+
+.report-line-copy strong,
+.report-tool-list strong,
+.report-event-list strong {
+  min-width: 0;
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.report-line-copy span,
+.report-line-copy small,
+.report-tool-list span,
+.report-event-list span {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.report-line-count,
+.report-tool-list b {
+  flex: 0 0 auto;
+  color: var(--muted-soft);
+  font: 10px var(--mono);
+  text-align: right;
+}
+
+.report-event-error { border-left: 2px solid var(--danger); padding-left: 8px; }
+.report-event-retry { border-left: 2px solid var(--warning); padding-left: 8px; }
+
+.report-validation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 13px 14px;
+  border: 1px solid #d7e9de;
+  border-radius: 9px;
+  background: #f6fbf7;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.report-validation-danger { border-color: #f0d6d1; background: #fff8f7; }
+.report-validation-warning { border-color: #efdfb5; background: #fffdf7; }
+
+.report-validation > div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.report-validation .eyebrow { margin: 0; font-size: 9px; }
+
+.report-validation strong,
+.report-validation > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.report-validation strong { color: var(--ink); font-size: 12px; }
+.report-validation > span { text-align: right; }
+
+.report-task-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted-soft);
+  font: 10px/1.5 var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.report-proof-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 16px;
+  color: var(--muted-soft);
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.report-proof-note .glyph { flex: 0 0 auto; margin-top: 2px; }
+
+.report-empty,
+.report-loading {
+  padding: 52px 28px;
+  text-align: center;
+}
+
+.report-empty h2,
+.report-loading h1 {
+  margin: 13px 0 8px;
+  color: var(--ink);
+  letter-spacing: -.035em;
+}
+
+.report-empty p,
+.report-loading p {
+  max-width: 540px;
+  margin: 0 auto 8px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.report-empty-mark {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  margin: 0 auto;
+  border: 1px solid #d7e9de;
+  border-radius: 14px;
+  color: var(--green-dark);
+  background: #f1f8f3;
+}
+
+.report-loading .eyebrow { margin-bottom: 0; }
+.report-loading-bar {
+  width: min(260px, 100%);
+  height: 4px;
+  margin: 26px auto 0;
+  border-radius: 99px;
+  background: linear-gradient(90deg, #d7e9de 0%, #2f704e 45%, #d7e9de 100%);
+  background-size: 200% 100%;
+  animation: report-loading 1.3s ease-in-out infinite;
+}
+
+@keyframes report-loading {
+  from { background-position: 100% 0; }
+  to { background-position: -100% 0; }
+}
+
+.report-history-shell {
+  display: grid;
+  gap: 0;
+  margin-bottom: 18px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.report-history-controls {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.5fr) repeat(3, minmax(140px, 1fr));
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line-soft);
+  background: #fbfcfc;
+}
+
+.report-filter-field {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.report-filter-field > span {
+  color: var(--muted-soft);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.report-filter-field input,
+.report-filter-field select {
+  width: 100%;
+  min-width: 0;
+  min-height: 35px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--ink);
+  background: #fff;
+  font: 11px/1.2 var(--sans);
+}
+
+.report-filter-field input:focus-visible,
+.report-filter-field select:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.report-history-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 13px;
+}
+
+.report-history-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 16px;
+  letter-spacing: -.025em;
+}
+
+.report-history-heading > span {
+  color: var(--muted);
+  font: 10px var(--mono);
+}
+
+.report-history-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 0 16px 16px;
+}
+
+.report-history-item {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  padding: 10px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  color: inherit;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.report-history-item:hover { border-color: #bddac8; background: #fbfdfb; }
+.report-history-item:focus-visible { outline: var(--focus-ring); outline-offset: 1px; }
+.report-history-item.active { border-color: #a7cbb5; box-shadow: inset 3px 0 var(--green); background: #f8fcf9; }
+
+.report-history-copy,
+.report-history-meta {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.report-history-copy strong,
+.report-history-meta b {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.report-history-copy small,
+.report-history-meta small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font: 10px/1.4 var(--mono);
+}
+
+.report-history-meta { justify-items: end; text-align: right; }
+
+.report-empty-inline { margin: 0; padding: 0 20px 20px; }
+
+@media (max-width: 960px) {
+  .report-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .report-lanes { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .report-lane:last-child { grid-column: 1 / -1; }
+}
+
+@media (max-width: 720px) {
+  .reports-heading,
+  .report-context,
+  .report-coverage,
+  .report-validation {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .reports-heading-actions,
+  .report-coverage-side { justify-content: flex-start; text-align: left; }
+  .report-history-controls { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .report-filter-field-wide { grid-column: 1 / -1; }
+  .report-history-list { grid-template-columns: minmax(0, 1fr); }
+  .report-context { gap: 7px; }
+  .report-coverage-side { min-width: 0; }
+  .report-task-facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .report-task-details { padding-left: 20px; }
+}
+
+@media (max-width: 520px) {
+  .reports-page { padding: 24px 16px 40px !important; }
+  .report-metrics,
+  .report-lanes,
+  .report-task-facts,
+  .report-history-controls { grid-template-columns: minmax(0, 1fr); }
+  .report-filter-field-wide { grid-column: auto; }
+  .report-lane:last-child { grid-column: auto; }
+  .report-task > summary { grid-template-columns: 30px minmax(0, 1fr) 18px; padding: 14px 13px; }
+  .report-task-summary-meta { display: none; }
+  .reports-task-heading,
+  .report-task-details { padding-left: 13px; padding-right: 13px; }
+  .report-task-footer { flex-direction: column; }
+  .reports-heading-actions .button { flex: 1 1 auto; }
+  .reports-heading-actions .report-status { margin-right: auto; }
+}

--- a/apps/desktop/src/screens/ReportsScreen.tsx
+++ b/apps/desktop/src/screens/ReportsScreen.tsx
@@ -66,9 +66,31 @@ function outcomeTone(value: string): string {
     case "FAILED":
       return "danger";
     case "IN_PROGRESS":
+    case "OPEN":
       return "warning";
     default:
       return "neutral";
+  }
+}
+
+function validationTone(value: string): string {
+  switch (value) {
+    case "passed": return "success";
+    case "failed": return "danger";
+    case "partial":
+    case "not_run": return "warning";
+    default: return "neutral";
+  }
+}
+
+type ReportConnection = "connecting" | "live" | "stale" | "offline";
+
+function connectionLabel(value: ReportConnection): string {
+  switch (value) {
+    case "live": return "Atualização ao vivo";
+    case "stale": return "Dados desatualizados";
+    case "offline": return "Runtime indisponível";
+    default: return "Reconectando ao Runtime";
   }
 }
 
@@ -82,20 +104,52 @@ function coverageLabel(value: string): string {
 }
 
 function tokenSummary(tokens: ReportTokenUsage): string {
-  const parts = [
+  const cacheRead = tokens.cacheRead === null
+    ? "cache lido —"
+    : "cache lido " + tokens.cacheRead.toLocaleString("pt-BR") + (tokens.cacheReadProvenance ? " (" + tokens.cacheReadProvenance + ")" : "");
+  const cacheWrite = tokens.cacheWrite === null
+    ? "cache escrito —"
+    : "cache escrito " + tokens.cacheWrite.toLocaleString("pt-BR") + (tokens.cacheWriteProvenance ? " (" + tokens.cacheWriteProvenance + ")" : "");
+  const reasoning = tokens.reasoning === null
+    ? "raciocínio —"
+    : "raciocínio " + tokens.reasoning.toLocaleString("pt-BR") + (tokens.reasoningSemantics !== "unknown" ? " (" + tokens.reasoningSemantics + ")" : "");
+  return [
     tokens.total === null ? "total —" : tokens.total.toLocaleString("pt-BR") + " tokens",
-    tokens.cacheRead === null ? "cache lido —" : "cache lido " + tokens.cacheRead.toLocaleString("pt-BR"),
-    tokens.cacheWrite === null ? "cache escrito —" : "cache escrito " + tokens.cacheWrite.toLocaleString("pt-BR"),
-    tokens.reasoning === null ? "raciocínio —" : "raciocínio " + tokens.reasoning.toLocaleString("pt-BR"),
-  ];
-  return parts.join(" · ");
+    cacheRead,
+    cacheWrite,
+    reasoning,
+  ].join(" · ");
 }
 
 function validationLabel(validation: ReportValidation): string {
-  if (validation.status === "passed") return validation.checks + " verificações aprovadas";
-  if (validation.status === "failed") return validation.failures + " falha(s) em " + validation.checks + " verificações";
+  const checks = validation.checks === null ? "quantidade não registrada" : validation.checks.toLocaleString("pt-BR");
+  const failures = validation.failures === null ? "quantidade não registrada" : validation.failures.toLocaleString("pt-BR");
+  const coverage = validation.coverageStatus === "partial" ? " · cobertura parcial" : "";
+  if (validation.status === "passed") {
+    if (validation.executed === 0 || validation.checks === 0) return "nenhuma verificação executada";
+    return (validation.passed === null || validation.passed === undefined ? checks : validation.passed.toLocaleString("pt-BR")) + " verificações aprovadas";
+  }
+  if (validation.status === "failed" || (validation.failures !== null && validation.failures > 0)) return failures + " falha(s) em " + checks + " verificações" + coverage;
+  if (validation.status === "partial") return failures + " falha(s); validação parcial";
   if (validation.status === "not_run") return "não executada";
-  return "não disponível";
+  return "não disponível" + coverage;
+}
+
+function aggregateMetric(label: string, value: number | null, rollup: string | undefined): string {
+  if (value === null) return label + " —";
+  return label + " " + number(value) + (rollup === "partial" ? " (subtotal parcial)" : "");
+}
+
+function costLabel(consolidated: { costMicrousdSum: number | null; costRollup: string; costStatus: string }): string {
+  if (consolidated.costMicrousdSum === null) return "sem preço confirmado";
+  const origin = consolidated.costStatus === "known"
+    ? "preço confirmado"
+    : consolidated.costStatus === "estimated"
+      ? "estimativa"
+      : consolidated.costStatus === "mixed"
+        ? "origens mistas"
+        : "origem não informada";
+  return consolidated.costRollup === "partial" ? origin + " · cobertura parcial" : origin;
 }
 
 function projectLabel(path: string): string {
@@ -121,6 +175,21 @@ function TaskDetails({ task }: { task: ReportTask }) {
         <div><span>Tokens</span><strong>{number(task.tokens.total)}</strong><small>{tokenSummary(task.tokens)}</small></div>
         <div><span>Custo</span><strong>{cost(task.tokens.costMicrousd)}</strong><small>{task.tokens.costStatus} · {task.tokens.costProvenance}</small></div>
         <div><span>Validação</span><strong>{validationLabel(task.validation)}</strong><small>{task.validation.source}</small></div>
+      </div>
+
+      <div className="report-task-meta-grid">
+        <div><span>Modelo</span><strong>{task.model || "—"}</strong><small>{task.provider || "provedor não informado"}</small></div>
+        <div><span>Engine</span><strong>{task.engine || "indisponível"}</strong><small>{task.engineVersion || "versão não registrada"}</small></div>
+        <div><span>Fallback</span><strong>{task.fallbackReason ? "fallback registrado" : "sem fallback registrado"}</strong><small>{task.fallbackReason || "não informado"}</small></div>
+        <div><span>Sessões</span><strong>{task.sessionIds?.length ? task.sessionIds.join(" · ") : "—"}</strong><small>{task.taskRunId ? "run " + task.taskRunId : "identidade de run não informada"}</small></div>
+      </div>
+
+      <div className="report-task-trace">
+        <span>Conclusão: {task.completionVerdict || "não verificada"}</span>
+        <span>Tentativa: {task.attemptId || "não informada"}</span>
+        <span>Parent span: {task.parentSpanId || "não informado"}</span>
+        <span>Recibos: {task.receipts?.length ? task.receipts.join(" · ") : "não registrados"}</span>
+        {task.unresolved?.length ? <span>Não resolvido: {task.unresolved.join(" · ")}</span> : null}
       </div>
 
       <div className="report-lanes">
@@ -154,13 +223,13 @@ function TaskDetails({ task }: { task: ReportTask }) {
           {task.errors.length === 0 && task.retries.length === 0
             ? <p className="report-muted">Nenhuma falha ou retry registrado.</p>
             : <ul className="report-event-list">
-              {task.errors.map((error, index) => <li className="report-event-error" key={"error-" + error.code + index}><strong>{error.code}</strong><span>{error.message || "detalhe não disponível"}{error.retryable === true ? " · retryável" : ""}</span></li>)}
+              {task.errors.map((error, index) => <li className="report-event-error" key={"error-" + error.code + index}><strong>{error.code}</strong><span>{error.stageId ? "etapa " + error.stageId : "etapa não informada"}{error.retryable === true ? " · retryável" : ""}</span></li>)}
               {task.retries.map((retry) => <li className="report-event-retry" key={"retry-" + retry.attempt}><strong>Tentativa {retry.attempt}</strong><span>{retry.reasonCode} · {retry.status} · {duration(retry.wallMs)}</span></li>)}
             </ul>}
         </section>
       </div>
 
-      <div className={"report-validation report-validation-" + outcomeTone(task.validation.status)}>
+      <div className={"report-validation report-validation-" + validationTone(task.validation.status)}>
         <div><span className="eyebrow">Gate de validação</span><strong>{validationLabel(task.validation)}</strong></div>
         <span>{task.validation.notes.length ? task.validation.notes.join(" · ") : task.validation.source}</span>
       </div>
@@ -180,28 +249,57 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
   const [taskFilter, setTaskFilter] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [connection, setConnection] = useState<ReportConnection>("connecting");
+  const [lastRefreshAt, setLastRefreshAt] = useState<number | null>(null);
   const request = useRef(0);
+  const inFlight = useRef<{ key: string; promise: Promise<void> } | null>(null);
+  const hasReport = useRef(false);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(() => {
+    const key = repoPath + "\\u0000" + (selectedRunId || "");
+    if (inFlight.current?.key === key) return inFlight.current.promise;
     const current = ++request.current;
-    setBusy(true);
-    setError(null);
-    try {
-      const next = await loadDesktopExecutionReport(repoPath || undefined, selectedRunId);
-      if (current === request.current) setReport(next);
-    } catch (cause) {
-      if (current === request.current) setError(cause instanceof Error ? cause.message : "execution_report_unavailable");
-    } finally {
-      if (current === request.current) setBusy(false);
-    }
+    const operation = (async () => {
+      setBusy(true);
+      setError(null);
+      if (!hasReport.current) setConnection("connecting");
+      try {
+        const next = await loadDesktopExecutionReport(repoPath || undefined, selectedRunId);
+        if (current === request.current) {
+          setReport(next);
+          hasReport.current = next.present;
+          setConnection("live");
+          setLastRefreshAt(Math.floor(Date.now() / 1000));
+        }
+      } catch {
+        if (current === request.current) {
+          setConnection(hasReport.current ? "stale" : "offline");
+          setError("execution_report_unavailable");
+        }
+      } finally {
+        if (current === request.current) setBusy(false);
+      }
+    })();
+    inFlight.current = { key, promise: operation };
+    void operation.finally(() => {
+      if (inFlight.current?.promise === operation) inFlight.current = null;
+    });
+    return operation;
   }, [repoPath, selectedRunId]);
 
   useEffect(() => {
-    void refresh();
+    let disposed = false;
+    let timer: number | undefined;
     const native = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-    if (!native) return undefined;
-    const timer = window.setInterval(() => { void refresh(); }, 5_000);
-    return () => window.clearInterval(timer);
+    const poll = async () => {
+      await refresh();
+      if (native && !disposed) timer = window.setTimeout(() => { void poll(); }, 5_000);
+    };
+    void poll();
+    return () => {
+      disposed = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [refresh]);
 
   function exportReport() {
@@ -213,11 +311,11 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
   }
 
   if (!report) {
-    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Tentar novamente"}</button></section><p className="inline-error" role="alert">Não foi possível ler o relatório do Runtime{error ? ": " + error : "."}</p></div>;
+    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Tentar novamente"}</button></section><p className="inline-error" role="alert">Não foi possível ler o relatório do Runtime. Tente novamente quando o Runtime estiver disponível.</p></div>;
   }
 
   if (!report.present) {
-    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />Atualizar</button></section><section className="panel report-empty" role="status"><div className="report-empty-mark"><Glyph name="activity" size={24} /></div><h2>Nenhum relatório registrado</h2><p>{report.message}</p><p className="report-muted">O Runtime só mostra números quando há recibo local. Dados ausentes permanecem como indisponíveis.</p></section></div>;
+    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />Atualizar</button></section><section className="panel report-empty" role="status"><div className="report-empty-mark"><Glyph name="activity" size={24} /></div><h2>Nenhum relatório registrado</h2><p>O Runtime não registrou um relatório local para este escopo.</p><p className="report-muted">O Runtime só mostra números quando há recibo local. Dados ausentes permanecem como indisponíveis.</p></section></div>;
   }
 
   const { consolidated } = report;
@@ -256,8 +354,18 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
 
       <section className="report-context" aria-label="Escopo do relatório">
         <div><span className="report-context-dot" /><strong>{reportScope}</strong><span>·</span><span>run {report.runId}</span></div>
-        <span>Atualizado {dateTime(report.fetchedAtUnix)} · revisão {report.revision || "não informada"}</span>
+        <div className="report-context-meta">
+          <span>Atualizado {dateTime(report.fetchedAtUnix)} · revisão {report.revision || "não informada"}</span>
+          <span>Engine {report.engine || "não informada"}{report.engineVersion ? " · " + report.engineVersion : ""} · {report.fallbackReason || "sem fallback registrado"}</span>
+          <span>Decisão Loop: {typeof report.loopDecision?.verdict === "string" ? report.loopDecision.verdict : "não informada"}</span>
+        </div>
       </section>
+
+      <div className={"report-sync report-sync-" + connection} role="status" aria-live="polite">
+        <div><span className="report-sync-dot" /><strong>{connectionLabel(connection)}</strong><span>{lastRefreshAt === null ? "aguardando leitura" : "última leitura " + dateTime(lastRefreshAt)}</span></div>
+        {connection === "stale" ? <span>{error ? "A leitura mais recente falhou; os dados exibidos são da última revisão confirmada." : "Aguardando reconexão; não há novos dados confirmados."}</span> : null}
+        {connection === "stale" || connection === "offline" ? <button className="text-button" type="button" onClick={() => void refresh()} disabled={busy}>{busy ? "Reconectando…" : "Reconectar"}</button> : null}
+      </div>
 
       <section className="panel report-history-shell" aria-labelledby="report-history-title">
         <div className="report-history-controls">
@@ -320,12 +428,14 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
           label="Tokens"
           value={number(consolidated.tokensTotalSum)}
           detail={
-            (consolidated.tokensCacheReadSum === null ? "cache lido —" : "cache lido " + number(consolidated.tokensCacheReadSum))
+            aggregateMetric("cache lido", consolidated.tokensCacheReadSum, consolidated.tokensCacheReadRollup)
             + " · "
-            + (consolidated.tokensCacheWriteSum === null ? "cache escrito —" : "cache escrito " + number(consolidated.tokensCacheWriteSum))
+            + aggregateMetric("cache escrito", consolidated.tokensCacheWriteSum, consolidated.tokensCacheWriteRollup)
+            + " · "
+            + aggregateMetric("raciocínio", consolidated.tokensReasoningSum, consolidated.tokensReasoningRollup)
           }
         />
-        <Metric label="Custo" value={cost(consolidated.costMicrousdSum)} detail={consolidated.costRollup === "complete" ? "preço confirmado" : consolidated.costRollup === "partial" ? "preço parcial" : "sem preço confirmado"} tone={consolidated.costMicrousdSum === null ? "muted" : ""} />
+        <Metric label="Custo" value={cost(consolidated.costMicrousdSum)} detail={costLabel(consolidated)} tone={consolidated.costMicrousdSum === null ? "muted" : ""} />
       </section>
 
       <section className={"panel report-coverage report-coverage-" + report.coverage.status} aria-live="polite">
@@ -352,7 +462,7 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
 
       <footer className="report-proof-note">
         <Glyph name="lock" size={15} />
-        <span>Dados locais e redigidos: prompts, respostas, credenciais e caminhos pessoais não são exibidos. Cache, raciocínio, custo e economia não são somados quando a semântica ou a proveniência está ausente.</span>
+        <span>Dados locais. A tela não solicita prompts, respostas ou credenciais; campos sem proveniência permanecem indisponíveis. Cache, raciocínio, custo e economia não são somados quando a semântica ou a proveniência está ausente.</span>
       </footer>
     </div>
   );

--- a/apps/desktop/src/screens/ReportsScreen.tsx
+++ b/apps/desktop/src/screens/ReportsScreen.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Glyph } from "../components/Brand";
+import { loadDesktopExecutionReport } from "../bridge";
+import { downloadExecutionReport } from "../execution_report";
+import type {
+  ExecutionReport,
+  ReportTask,
+  ReportTokenUsage,
+  ReportValidation,
+} from "../execution_report";
+
+function number(value: number | null): string {
+  return value === null ? "—" : value.toLocaleString("pt-BR");
+}
+
+function duration(value: number | null): string {
+  if (value === null) return "—";
+  if (value < 1_000) return value.toLocaleString("pt-BR") + " ms";
+  const seconds = value / 1_000;
+  if (seconds < 60) return seconds.toLocaleString("pt-BR", { maximumFractionDigits: 1 }) + " s";
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return minutes + " min" + (rest ? " " + rest + " s" : "");
+}
+
+function cost(value: number | null): string {
+  if (value === null) return "—";
+  return (value / 1_000_000).toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 6,
+  });
+}
+
+function dateTime(value: number | null): string {
+  if (value === null) return "horário não disponível";
+  return new Date(value * 1_000).toLocaleString("pt-BR");
+}
+
+function outcomeLabel(value: string): string {
+  switch (value) {
+    case "COMPLETE":
+    case "VERIFIED":
+    case "PASSED":
+      return "concluída";
+    case "FAIL":
+    case "FAILED":
+      return "falhou";
+    case "SKIP":
+    case "SKIPPED":
+      return "ignorada";
+    case "IN_PROGRESS":
+      return "em andamento";
+    default:
+      return "não verificada";
+  }
+}
+
+function outcomeTone(value: string): string {
+  switch (value) {
+    case "COMPLETE":
+    case "VERIFIED":
+    case "PASSED":
+      return "success";
+    case "FAIL":
+    case "FAILED":
+      return "danger";
+    case "IN_PROGRESS":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+function coverageLabel(value: string): string {
+  switch (value) {
+    case "complete": return "cobertura completa";
+    case "partial": return "cobertura parcial";
+    case "no_data": return "sem dados";
+    default: return "cobertura indisponível";
+  }
+}
+
+function tokenSummary(tokens: ReportTokenUsage): string {
+  const parts = [
+    tokens.total === null ? "total —" : tokens.total.toLocaleString("pt-BR") + " tokens",
+    tokens.cacheRead === null ? "cache lido —" : "cache lido " + tokens.cacheRead.toLocaleString("pt-BR"),
+    tokens.cacheWrite === null ? "cache escrito —" : "cache escrito " + tokens.cacheWrite.toLocaleString("pt-BR"),
+    tokens.reasoning === null ? "raciocínio —" : "raciocínio " + tokens.reasoning.toLocaleString("pt-BR"),
+  ];
+  return parts.join(" · ");
+}
+
+function validationLabel(validation: ReportValidation): string {
+  if (validation.status === "passed") return validation.checks + " verificações aprovadas";
+  if (validation.status === "failed") return validation.failures + " falha(s) em " + validation.checks + " verificações";
+  if (validation.status === "not_run") return "não executada";
+  return "não disponível";
+}
+
+function projectLabel(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, "");
+  return normalized.split(/[\\/]/).pop() || "escopo local";
+}
+
+function Metric({ label, value, detail, tone = "" }: { label: string; value: string; detail: string; tone?: string }) {
+  return (
+    <div className={"report-metric " + tone}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </div>
+  );
+}
+
+function TaskDetails({ task }: { task: ReportTask }) {
+  return (
+    <div className="report-task-details">
+      <div className="report-task-facts">
+        <div><span>Duração</span><strong>{duration(task.wallMs)}</strong></div>
+        <div><span>Tokens</span><strong>{number(task.tokens.total)}</strong><small>{tokenSummary(task.tokens)}</small></div>
+        <div><span>Custo</span><strong>{cost(task.tokens.costMicrousd)}</strong><small>{task.tokens.costStatus} · {task.tokens.costProvenance}</small></div>
+        <div><span>Validação</span><strong>{validationLabel(task.validation)}</strong><small>{task.validation.source}</small></div>
+      </div>
+
+      <div className="report-lanes">
+        <section className="report-lane">
+          <div className="report-lane-heading"><h3>Etapas</h3><span>{task.stages.length || "—"}</span></div>
+          {task.stages.length === 0
+            ? <p className="report-muted">Etapas não registradas.</p>
+            : <ol className="report-stage-list">{task.stages.map((stage) => (
+              <li key={stage.id}>
+                <div className="report-stage-marker" />
+                <div className="report-line-copy"><strong>{stage.name}</strong><span>{stage.id} · {stage.status} · {duration(stage.wallMs)}</span><small>{tokenSummary(stage.tokens)}</small></div>
+                <span className="report-line-count">{stage.attemptCount > 1 ? stage.attemptCount + " tent." : ""}</span>
+              </li>
+            ))}</ol>}
+        </section>
+
+        <section className="report-lane">
+          <div className="report-lane-heading"><h3>Ferramentas</h3><span>{task.tools.length || "—"}</span></div>
+          {task.tools.length === 0
+            ? <p className="report-muted">Ferramentas não registradas.</p>
+            : <ul className="report-tool-list">{task.tools.map((tool) => (
+              <li key={tool.name}>
+                <div><strong>{tool.name}</strong><span>{tool.status} · {duration(tool.wallMs)}</span></div>
+                <b>{tool.invocations}×</b>
+              </li>
+            ))}</ul>}
+        </section>
+
+        <section className="report-lane">
+          <div className="report-lane-heading"><h3>Falhas e retries</h3><span>{task.errors.length + task.retries.length || "—"}</span></div>
+          {task.errors.length === 0 && task.retries.length === 0
+            ? <p className="report-muted">Nenhuma falha ou retry registrado.</p>
+            : <ul className="report-event-list">
+              {task.errors.map((error, index) => <li className="report-event-error" key={"error-" + error.code + index}><strong>{error.code}</strong><span>{error.message || "detalhe não disponível"}{error.retryable === true ? " · retryável" : ""}</span></li>)}
+              {task.retries.map((retry) => <li className="report-event-retry" key={"retry-" + retry.attempt}><strong>Tentativa {retry.attempt}</strong><span>{retry.reasonCode} · {retry.status} · {duration(retry.wallMs)}</span></li>)}
+            </ul>}
+        </section>
+      </div>
+
+      <div className={"report-validation report-validation-" + outcomeTone(task.validation.status)}>
+        <div><span className="eyebrow">Gate de validação</span><strong>{validationLabel(task.validation)}</strong></div>
+        <span>{task.validation.notes.length ? task.validation.notes.join(" · ") : task.validation.source}</span>
+      </div>
+      <div className="report-task-footer">
+        <span>{coverageLabel(task.coverage.status)}</span>
+        <span>{task.operators.length ? task.operators.join(" · ") : "operadores não registrados"}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
+  const [report, setReport] = useState<ExecutionReport | null>(null);
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
+  const [historyStatus, setHistoryStatus] = useState("all");
+  const [historyPeriod, setHistoryPeriod] = useState("all");
+  const [taskFilter, setTaskFilter] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const request = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const current = ++request.current;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await loadDesktopExecutionReport(repoPath || undefined, selectedRunId);
+      if (current === request.current) setReport(next);
+    } catch (cause) {
+      if (current === request.current) setError(cause instanceof Error ? cause.message : "execution_report_unavailable");
+    } finally {
+      if (current === request.current) setBusy(false);
+    }
+  }, [repoPath, selectedRunId]);
+
+  useEffect(() => {
+    void refresh();
+    const native = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+    if (!native) return undefined;
+    const timer = window.setInterval(() => { void refresh(); }, 5_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  function exportReport() {
+    if (report) downloadExecutionReport(report);
+  }
+
+  if (!report && busy) {
+    return <div className="page secondary-page reports-page"><div className="report-loading" role="status" aria-live="polite"><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Consultando o último relatório do Runtime…</p><div className="report-loading-bar" /></div></div>;
+  }
+
+  if (!report) {
+    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Tentar novamente"}</button></section><p className="inline-error" role="alert">Não foi possível ler o relatório do Runtime{error ? ": " + error : "."}</p></div>;
+  }
+
+  if (!report.present) {
+    return <div className="page secondary-page reports-page"><section className="page-heading"><div><span className="eyebrow">Telemetria local</span><h1>Relatórios de execução</h1><p>Resumo por tarefa com evidência de etapas, ferramentas, custo e validação.</p></div><button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />Atualizar</button></section><section className="panel report-empty" role="status"><div className="report-empty-mark"><Glyph name="activity" size={24} /></div><h2>Nenhum relatório registrado</h2><p>{report.message}</p><p className="report-muted">O Runtime só mostra números quando há recibo local. Dados ausentes permanecem como indisponíveis.</p></section></div>;
+  }
+
+  const { consolidated } = report;
+  const statusTone = outcomeTone(report.status);
+  const reportScope = repoPath ? projectLabel(repoPath) : "escopo local padrão";
+  const periodSeconds = historyPeriod === "24h" ? 86_400 : historyPeriod === "7d" ? 604_800 : historyPeriod === "30d" ? 2_592_000 : null;
+  const historyCutoff = periodSeconds === null ? null : report.fetchedAtUnix - periodSeconds;
+  const visibleHistory = report.history.filter((entry) => {
+    const stateMatches = historyStatus === "all" || entry.status === historyStatus;
+    const periodMatches = historyCutoff === null || (entry.recordedAtUnix !== null && entry.recordedAtUnix >= historyCutoff);
+    return stateMatches && periodMatches;
+  });
+  const normalizedTaskFilter = taskFilter.trim().toLocaleLowerCase("pt-BR");
+  const visibleTasks = report.tasks.filter((task) => {
+    if (!normalizedTaskFilter) return true;
+    return [task.title, task.issue || "", task.taskId]
+      .join(" ")
+      .toLocaleLowerCase("pt-BR")
+      .includes(normalizedTaskFilter);
+  });
+
+  return (
+    <div className="page secondary-page reports-page">
+      <section className="page-heading reports-heading">
+        <div>
+          <span className="eyebrow">Telemetria local · {report.executionProfile}</span>
+          <h1>Relatórios de execução</h1>
+          <p>Um registro por tarefa, com etapas e validações separadas do sucesso do modelo.</p>
+        </div>
+        <div className="reports-heading-actions">
+          <span className={"report-status report-status-" + statusTone}>{outcomeLabel(report.status)}</span>
+          <button className="button button-secondary" type="button" onClick={() => void refresh()} disabled={busy}><Glyph name="refresh" size={16} />{busy ? "Atualizando…" : "Atualizar"}</button>
+          <button className="button button-primary" type="button" onClick={exportReport}><Glyph name="external" size={16} />Exportar JSON</button>
+        </div>
+      </section>
+
+      <section className="report-context" aria-label="Escopo do relatório">
+        <div><span className="report-context-dot" /><strong>{reportScope}</strong><span>·</span><span>run {report.runId}</span></div>
+        <span>Atualizado {dateTime(report.fetchedAtUnix)} · revisão {report.revision || "não informada"}</span>
+      </section>
+
+      <section className="panel report-history-shell" aria-labelledby="report-history-title">
+        <div className="report-history-controls">
+          <label className="report-filter-field report-filter-field-wide">
+            <span>Tarefa</span>
+            <input value={taskFilter} onChange={(event) => setTaskFilter(event.target.value)} placeholder="Título, issue ou task id" aria-label="Filtrar tarefas" />
+          </label>
+          <label className="report-filter-field">
+            <span>Estado</span>
+            <select value={historyStatus} onChange={(event) => setHistoryStatus(event.target.value)} aria-label="Filtrar histórico por estado">
+              <option value="all">Todos os estados</option>
+              <option value="COMPLETE">Concluídos</option>
+              <option value="FAIL">Falhos</option>
+              <option value="OPEN">Em andamento</option>
+              <option value="UNVERIFIED">Não verificados</option>
+            </select>
+          </label>
+          <label className="report-filter-field">
+            <span>Período</span>
+            <select value={historyPeriod} onChange={(event) => setHistoryPeriod(event.target.value)} aria-label="Filtrar histórico por período">
+              <option value="all">Todo o histórico</option>
+              <option value="24h">Últimas 24 horas</option>
+              <option value="7d">Últimos 7 dias</option>
+              <option value="30d">Últimos 30 dias</option>
+            </select>
+          </label>
+          <label className="report-filter-field">
+            <span>Run exibido</span>
+            <select value={selectedRunId || ""} onChange={(event) => setSelectedRunId(event.target.value || undefined)} aria-label="Selecionar run exibido">
+              <option value="">Último run</option>
+              {report.history.map((entry) => <option key={entry.runId} value={entry.runId}>{entry.runId}</option>)}
+            </select>
+          </label>
+        </div>
+        <div className="report-history-heading">
+          <div><span className="eyebrow">Histórico local</span><h2 id="report-history-title">Runs recentes</h2></div>
+          <span>{visibleHistory.length} de {report.history.length} run(s)</span>
+        </div>
+        {visibleHistory.length === 0
+          ? <p className="report-empty-inline">Nenhum run corresponde aos filtros atuais.</p>
+          : <div className="report-history-list">{visibleHistory.map((entry) => (
+            <button
+              className={"report-history-item" + (entry.runId === report.runId ? " active" : "")}
+              type="button"
+              key={entry.runId}
+              aria-pressed={entry.runId === report.runId}
+              onClick={() => setSelectedRunId(entry.runId)}
+            >
+              <span className={"report-task-status report-task-status-" + outcomeTone(entry.status)} aria-hidden="true"><Glyph name={outcomeTone(entry.status) === "success" ? "check" : outcomeTone(entry.status) === "danger" ? "attention" : "activity"} size={14} /></span>
+              <span className="report-history-copy"><strong>{entry.runId}</strong><small>{outcomeLabel(entry.status)} · {dateTime(entry.recordedAtUnix)}</small></span>
+              <span className="report-history-meta"><b>{entry.taskCount === null ? "—" : number(entry.taskCount)} tarefa(s)</b><small>{duration(entry.wallMs)}</small></span>
+            </button>
+          ))}</div>}
+      </section>
+
+      <section className="report-metrics" aria-label="Resumo do relatório">
+        <Metric label="Tarefas" value={number(consolidated.taskCount)} detail={report.tasks.length ? report.tasks.map((task) => outcomeLabel(task.outcome)).join(" · ") : "nenhuma tarefa registrada"} />
+        <Metric label="Duração" value={duration(consolidated.wallMsRun ?? report.wallMs)} detail={consolidated.wallMsTasksSum === null ? "soma por tarefa indisponível" : "soma das tarefas " + duration(consolidated.wallMsTasksSum)} />
+        <Metric
+          label="Tokens"
+          value={number(consolidated.tokensTotalSum)}
+          detail={
+            (consolidated.tokensCacheReadSum === null ? "cache lido —" : "cache lido " + number(consolidated.tokensCacheReadSum))
+            + " · "
+            + (consolidated.tokensCacheWriteSum === null ? "cache escrito —" : "cache escrito " + number(consolidated.tokensCacheWriteSum))
+          }
+        />
+        <Metric label="Custo" value={cost(consolidated.costMicrousdSum)} detail={consolidated.costRollup === "complete" ? "preço confirmado" : consolidated.costRollup === "partial" ? "preço parcial" : "sem preço confirmado"} tone={consolidated.costMicrousdSum === null ? "muted" : ""} />
+      </section>
+
+      <section className={"panel report-coverage report-coverage-" + report.coverage.status} aria-live="polite">
+        <div><span className="eyebrow">Cobertura e proveniência</span><h2>{coverageLabel(report.coverage.status)}</h2><p>{report.coverage.missing.length ? "Ausente neste recorte: " + report.coverage.missing.join(" · ") + "." : "Os campos retornados possuem recibo local."}</p></div>
+        <div className="report-coverage-side"><strong>{report.operators.length ? report.operators.join(" · ") : "operadores não informados"}</strong><span>{report.unverifiedFields.length ? report.unverifiedFields.length + " campo(s) não verificado(s)" : "sem campos pendentes"}</span></div>
+      </section>
+
+      <section className="panel reports-task-panel" aria-labelledby="reports-tasks-title">
+        <header className="reports-task-heading"><div><span className="eyebrow">Detalhamento</span><h2 id="reports-tasks-title">Tarefas deste run</h2></div><span>{visibleTasks.length} de {report.tasks.length} item(ns)</span></header>
+        {visibleTasks.length === 0
+          ? <p className="report-empty-inline">{report.tasks.length === 0 ? "O run ainda não registrou tarefas. O Runtime não cria uma linha sintética para preencher métricas ausentes." : "Nenhuma tarefa corresponde ao filtro atual."}</p>
+          : <div className="reports-task-list">{visibleTasks.map((task) => (
+            <details className="report-task" key={task.taskId}>
+              <summary>
+                <span className={"report-task-status report-task-status-" + outcomeTone(task.outcome)} aria-hidden="true"><Glyph name={outcomeTone(task.outcome) === "success" ? "check" : outcomeTone(task.outcome) === "danger" ? "attention" : "activity"} size={15} /></span>
+                <span className="report-task-summary"><strong>{task.title}</strong><small>{task.issue || task.taskId} · {coverageLabel(task.coverage.status)}</small></span>
+                <span className="report-task-summary-meta"><b>{number(task.tokens.total)}</b><small>{duration(task.wallMs)}</small></span>
+                <Glyph name="chevron" size={17} />
+              </summary>
+              <TaskDetails task={task} />
+            </details>
+          ))}</div>}
+      </section>
+
+      <footer className="report-proof-note">
+        <Glyph name="lock" size={15} />
+        <span>Dados locais e redigidos: prompts, respostas, credenciais e caminhos pessoais não são exibidos. Cache, raciocínio, custo e economia não são somados quando a semântica ou a proveniência está ausente.</span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/desktop/src/workbench.ts
+++ b/apps/desktop/src/workbench.ts
@@ -4,7 +4,7 @@ import { providerRegistry } from "./provider_registry";
 import { isReferenceSettingsView, REFERENCE_LABELS, type ReferenceSettingsView } from "./reference_screens";
 
 export type View = ReferenceSettingsView | "home" | "project" | "agents" | "models" | "general" | "shortcuts" | "diagnostics" | "setup"
-  | "today" | "chats" | "teams" | "automations" | "apps" | "bot" | "providers" | "tokens" | "activity" | "memory" | "settings";
+  | "today" | "chats" | "teams" | "automations" | "apps" | "bot" | "providers" | "tokens" | "reports" | "activity" | "memory" | "settings";
 
 /** Presentation policy only: retain implementations and direct preview routes. */
 const HIDDEN_NAVIGATION_VIEWS: ReadonlySet<View> = new Set<View>([
@@ -22,7 +22,7 @@ export const VIEW_LABELS: Record<View, string> = {
   ...REFERENCE_LABELS,
   home: "Início", project: "Projeto", agents: "Agentes e IDEs", models: "Modelos e skills", setup: "Instalação guiada",
   general: "Aparência", shortcuts: "Atalhos", diagnostics: "Runtime e diagnóstico",
-  providers: "Integrações MCP", tokens: "Relatório de tokens", activity: "Atividade",
+  providers: "Integrações MCP", tokens: "Relatório de tokens", reports: "Relatórios de execução", activity: "Atividade",
   memory: "Memória", settings: "Conta Simplicio", today: "Hoje", chats: "Conversas",
   teams: "Equipes", automations: "Automações", apps: "Aplicativos", bot: "Central de agentes",
 };


### PR DESCRIPTION
## Summary

- add local execution reports screen with history filters, task drilldown, polling and reconnect states and JSON export
- add bounded Tauri command and strict parser with unknown, partial and estimated provenance
- surface mixed and estimated costs and failed validation separately from partial coverage

## Validation

- npm --prefix apps/desktop test -- --run (66 files, 425 tests)
- npm --prefix apps/desktop run build
- broad validation retains 3 unrelated release and marketplace failures

Related issue 5568
