### PR TITLE
fix(desktop): clear idle receipts on session reset

### DIFF
--- a/apps/desktop/src/usage_store.test.ts
+++ b/apps/desktop/src/usage_store.test.ts
@@ -77,4 +77,31 @@ describe("Desktop usage store", () => {
     }
     expect(store.getState().idleHistory).toHaveLength(MAX_IDLE_FINALIZATION_HISTORY);
   });
+  it("clears idle finalization history when the Desktop session is reset", () => {
+    const store = createDesktopUsageStore();
+    const receipt: IdleSessionFinalization = {
+      schema: "simplicio.session-idle-finalization/v1",
+      status: "logical_closed",
+      finalization_id: "sha256:logout-reset",
+      profile_id: "default",
+      workspace_id: "/workspace",
+      now_millis: 1,
+      idle_ms: IDLE_SESSION_TIMEOUT_MS,
+      closed_sessions: [{ session_id: "s1", status: "idle", updated_at: 1 }],
+      usage: {
+        status: "pending_provider_refresh",
+        metrics: ["input_tokens", "output_tokens", "reasoning_tokens", "cache_read_tokens", "cache_write_tokens"],
+      },
+      provider_processes_terminated: false,
+      redacted: true,
+    };
+    store.setIdleFinalization(receipt);
+    expect(store.getState().idleHistory).toHaveLength(1);
+
+    store.setIdleFinalization(null);
+
+    expect(store.getState().idleFinalization).toBeNull();
+    expect(store.getState().idleHistory).toEqual([]);
+  });
+
 });

--- a/apps/desktop/src/usage_store.ts
+++ b/apps/desktop/src/usage_store.ts
@@ -54,7 +54,12 @@ export function createDesktopUsageStore(
       notify();
     },
     setIdleFinalization(receipt) {
-      if (!receipt) return;
+      if (!receipt) {
+        if (!state.idleFinalization && state.idleHistory.length === 0) return;
+        state = { ...state, idleFinalization: null, idleHistory: [] };
+        notify();
+        return;
+      }
       const same = state.idleHistory[0]
         && ((receipt.finalization_id && state.idleHistory[0].finalization_id === receipt.finalization_id)
           || (!receipt.finalization_id && state.idleHistory[0].now_millis === receipt.now_millis));


### PR DESCRIPTION
## Summary

Related to #376.

- Clear the Desktop's in-memory idle-finalization receipt and bounded history when the authenticated session is reset.
- Preserve the existing Runtime-owned receipt, provider provenance, unknown metrics, and logical-only close semantics.
- Add a focused regression test for the reset path.

## Scope

Desktop projection/state only. Runtime remains the authority for session lifecycle, collection, persistence, and receipts. No provider process is terminated and no token value is inferred.

## Validation

- Not run: this lane was restricted to GitHub API operations with no local checkout, runner, build, or GitHub Actions.
- Re-read the branch ref and commit diff through GitHub API after publication.
