### PR TITLE
test: restore neutral report fixture paths (#391)

### DIFF
--- a/apps/desktop/src/execution_report.test.ts
+++ b/apps/desktop/src/execution_report.test.ts
@@ -154,7 +154,7 @@ describe("execution report contract", () => {
           reasoning_semantics: "included_in_output",
         },
         validation: { status: "partial", checks: 3, failures: 1, executed: 3, passed: 2, ignored: 0, source: "vitest" },
-        errors: [{ code: "validation_failed", message: "/Users/wesley/token=secret", stage_id: "verify" }],
+        errors: [{ code: "validation_failed", message: "/tmp/simplicio-test-user/token=secret", stage_id: "verify" }],
       }],
       consolidated: {
         task_count: 1,


### PR DESCRIPTION
The execution-report fixture introduced after PR #392 reintroduced a personal home path and failed repository_policy.py. Use a neutral temporary path while preserving redaction semantics. Validation: repository policy passed, distribution consistency 8 checks, Vitest 29 tests, Playwright 7 tests, installed matrix 4 tests, TypeScript/Vite build passed. Fixes #391.