### PR TITLE
fix(desktop): isolate report runs and validate execution evidence

### DIFF
--- a/apps/desktop/e2e/execution-reports.spec.ts
+++ b/apps/desktop/e2e/execution-reports.spec.ts
@@ -1,0 +1,401 @@
+import { expect, test, type Page } from "@playwright/test";
+import { createDemoSnapshot } from "../src/demo";
+
+const executionReport = {
+  "schema": "simplicio.execution-report/v1",
+  "present": true,
+  "owner": "simplicio-runtime",
+  "run_id": "run-current",
+  "status": "COMPLETE",
+  "started_at_unix": 1788796000,
+  "finished_at_unix": 1788796064,
+  "wall_ms": 64000,
+  "execution_profile": "runtime-backed",
+  "engine": "native",
+  "engine_version": "3.8.47",
+  "loop_decision": {
+    "verdict": "required"
+  },
+  "operators_used": [
+    "simplicio-loop",
+    "simplicio-mapper"
+  ],
+  "revision": "rev-2",
+  "coverage": {
+    "status": "partial",
+    "fields": [
+      "tasks",
+      "stages",
+      "tools"
+    ],
+    "missing": [
+      "cost_microusd"
+    ]
+  },
+  "measured_fields": [
+    "task_wall_ms",
+    "tokens_per_task"
+  ],
+  "unverified_fields": [
+    "cost_microusd"
+  ],
+  "unavailable_reasons": {
+    "cost_microusd": "no pricing receipt"
+  },
+  "history": [
+    {
+      "run_id": "run-current",
+      "status": "COMPLETE",
+      "wall_ms": 64000,
+      "task_count": 2,
+      "recorded_at_unix": 1788796064
+    },
+    {
+      "run_id": "run-failed",
+      "status": "FAIL",
+      "wall_ms": 21000,
+      "task_count": 1,
+      "recorded_at_unix": 1788700000
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "task-native",
+      "issue": "#390",
+      "title": "Relatório via Loop nativo",
+      "wall_ms": 1800,
+      "model": "gpt-5.6",
+      "provider": "openai",
+      "engine": "native",
+      "engine_version": "3.8.47",
+      "attempt_id": "attempt-1",
+      "parent_span_id": "span-root",
+      "completion_verdict": "verified",
+      "run_id": "run-current",
+      "session_ids": [
+        "session-a"
+      ],
+      "receipts": [
+        "receipt-native"
+      ],
+      "tokens": {
+        "tokens_in": 100,
+        "tokens_out": 40,
+        "tokens_total": 140,
+        "tokens_cached": 20,
+        "cache_read_provenance": "provider",
+        "tokens_reasoning": 10,
+        "reasoning_semantics": "included_in_output",
+        "source": "provider-reported",
+        "cost_status": "known",
+        "cost_provenance": "runtime-receipt"
+      },
+      "stages": [
+        {
+          "stage_id": "discover",
+          "name": "Descoberta",
+          "status": "complete",
+          "wall_ms": 240,
+          "tokens": {},
+          "tool_count": 1,
+          "error_count": 0,
+          "attempt_count": 1
+        },
+        {
+          "stage_id": "verify",
+          "name": "Verificação",
+          "status": "complete",
+          "wall_ms": 420,
+          "tokens": {},
+          "tool_count": 1,
+          "error_count": 0,
+          "attempt_count": 1
+        }
+      ],
+      "tools": [
+        {
+          "name": "simplicio_map",
+          "status": "complete",
+          "invocations": 1,
+          "wall_ms": 120,
+          "error_count": 0
+        }
+      ],
+      "errors": [],
+      "retries": [],
+      "validation": {
+        "status": "passed",
+        "checks": 3,
+        "executed": 3,
+        "passed": 3,
+        "failures": 0,
+        "source": "vitest"
+      },
+      "coverage": {
+        "status": "complete",
+        "fields": [
+          "stages",
+          "tools",
+          "validation"
+        ],
+        "missing": []
+      },
+      "outcome": "COMPLETE",
+      "operators_used": [
+        "simplicio-loop"
+      ],
+      "notes": []
+    },
+    {
+      "task_id": "task-python",
+      "issue": "#390",
+      "title": "Fallback Python do relatório",
+      "wall_ms": 2600,
+      "model": "gpt-5.6",
+      "provider": "openai",
+      "engine": "python",
+      "engine_version": "3.8.47",
+      "fallback_reason": "native_unavailable",
+      "attempt_id": "attempt-2",
+      "parent_span_id": "span-root",
+      "completion_verdict": "partial",
+      "run_id": "run-current",
+      "session_ids": [
+        "session-b"
+      ],
+      "receipts": [
+        "receipt-python"
+      ],
+      "unresolved": [
+        "late-correction"
+      ],
+      "tokens": {
+        "tokens_in": 80,
+        "tokens_out": 30,
+        "tokens_total": 110,
+        "tokens_cached": 10,
+        "cache_read_provenance": "local",
+        "tokens_reasoning": 6,
+        "reasoning_semantics": "unknown",
+        "source": "provider-reported",
+        "cost_status": "estimated",
+        "cost_provenance": "catalog"
+      },
+      "stages": [
+        {
+          "stage_id": "act",
+          "name": "Execução",
+          "status": "partial",
+          "wall_ms": 700,
+          "tokens": {},
+          "tool_count": 1,
+          "error_count": 1,
+          "attempt_count": 2
+        }
+      ],
+      "tools": [
+        {
+          "name": "simplicio-dev-cli",
+          "status": "partial",
+          "invocations": 2,
+          "wall_ms": 500,
+          "error_count": 1
+        }
+      ],
+      "errors": [
+        {
+          "code": "fallback_started",
+          "stage_id": "act",
+          "retryable": false
+        }
+      ],
+      "retries": [
+        {
+          "attempt": 2,
+          "reason_code": "native_unavailable",
+          "status": "complete",
+          "wall_ms": 500
+        }
+      ],
+      "validation": {
+        "status": "partial",
+        "checks": 2,
+        "executed": 2,
+        "passed": 1,
+        "failures": 1,
+        "source": "vitest"
+      },
+      "coverage": {
+        "status": "partial",
+        "fields": [
+          "stages",
+          "tools"
+        ],
+        "missing": [
+          "cost_microusd"
+        ]
+      },
+      "outcome": "COMPLETE",
+      "operators_used": [
+        "simplicio-loop",
+        "python-fallback"
+      ],
+      "notes": []
+    }
+  ],
+  "consolidated": {
+    "task_count": 2,
+    "wall_ms_run": 64000,
+    "wall_ms_tasks_sum": 4400,
+    "tokens_in_sum": 180,
+    "tokens_out_sum": 70,
+    "tokens_total_sum": 250,
+    "tokens_rollup": "complete",
+    "tokens_cache_read_sum": 30,
+    "tokens_cache_read_rollup": "complete",
+    "tokens_cache_write_sum": null,
+    "tokens_cache_write_rollup": "absent",
+    "tokens_reasoning_sum": 16,
+    "tokens_reasoning_rollup": "partial",
+    "cost_microusd_sum": 45,
+    "cost_rollup": "complete",
+    "cost_status": "estimated",
+    "cost_provenance": "catalog",
+    "tool_invocations": 3,
+    "error_count": 1,
+    "retry_count": 1,
+    "validation": {
+      "status": "partial",
+      "checks": 5,
+      "executed": 5,
+      "passed": 4,
+      "failures": 1,
+      "source": "vitest"
+    }
+  }
+};
+
+async function mockExecutionReport(page: Page, mode: "success" | "loading" | "error" | "stale" = "success", report = executionReport) {
+  await page.addInitScript(({ snapshot, mode, executionReport }) => {
+    Object.assign(window, {
+      __releaseExecutionReport: undefined,
+      __executionReportCalls: 0,
+      __TAURI_INTERNALS__: {
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          if (command === "desktop_runtime_install_status") {
+            return { schema: "simplicio.desktop-install-status/v1", status: "clear", redacted: true };
+          }
+          if (command === "desktop_preparation_status") return true;
+          if (command === "desktop_snapshot") return snapshot;
+          if (command === "desktop_context_report") throw "context_ledger_unavailable";
+          if (command === "desktop_unified_usage") throw "usage_snapshot_unavailable";
+          if (command === "desktop_session_close_idle") throw "session_idle_finalization_unavailable";
+          if (command === "desktop_execution_report") {
+            (window as any).__executionReportCalls += 1;
+            if (mode === "error" || (mode === "stale" && (window as any).__executionReportCalls > 1)) {
+              throw "execution_report_transport_error";
+            }
+            if (mode === "loading" && (window as any).__executionReportCalls === 1) {
+              await new Promise<void>((resolve) => { (window as any).__releaseExecutionReport = resolve; });
+            }
+            return executionReport;
+          }
+          throw "unexpected_test_command:" + command;
+        },
+      },
+    });
+  }, { snapshot: { ...createDemoSnapshot("active"), source: "runtime" }, mode, executionReport: report });
+}
+
+test("renders task report provenance, partial coverage and accessible filters", async ({ page }) => {
+  await mockExecutionReport(page);
+  await page.goto("/?state=active&view=reports");
+
+  await expect(page.getByRole("heading", { name: "Relatórios de execução", exact: true })).toBeVisible();
+  await expect(page.getByText("Atualização ao vivo", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Engine native · 3\.8\.47/)).toBeVisible();
+  await expect(page.getByText(/Decisão Loop: required/)).toBeVisible();
+  await expect(page.getByText("cobertura parcial", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(/raciocínio 16 \(subtotal parcial\)/)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Tarefas deste run", exact: true })).toBeVisible();
+
+  await page.getByRole("textbox", { name: "Filtrar tarefas" }).fill("Fallback Python");
+  await expect(page.getByText("1 de 2 item(ns)", { exact: true })).toBeVisible();
+  await page.getByRole("textbox", { name: "Filtrar tarefas" }).fill("");
+  await page.locator("details").nth(1).locator("summary").click();
+  await expect(page.getByText("fallback registrado", { exact: true })).toBeVisible();
+  await expect(page.getByText("native_unavailable", { exact: true })).toBeVisible();
+
+  await page.getByLabel("Filtrar histórico por estado").selectOption("FAIL");
+  await expect(page.getByText("1 de 2 run(s)", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: /run-failed falhou/ })).toBeVisible();
+});
+
+test("keeps the loading state until the first report read resolves", async ({ page }) => {
+  await mockExecutionReport(page, "loading");
+  await page.goto("/?state=active&view=reports");
+  await expect(page.getByRole("status")).toContainText("Consultando o último relatório do Runtime");
+  await page.evaluate(() => (window as any).__releaseExecutionReport());
+  await expect(page.getByText("Atualização ao vivo", { exact: true })).toBeVisible();
+});
+
+test("shows a generic error and no report data when Runtime is unavailable", async ({ page }) => {
+  await mockExecutionReport(page, "error");
+  await page.goto("/?state=active&view=reports");
+  await expect(page.getByRole("alert")).toContainText("Não foi possível ler o relatório do Runtime");
+  await expect(page.getByRole("alert")).not.toContainText("execution_report_transport_error");
+  await expect(page.getByText("Tarefas deste run", { exact: true })).toHaveCount(0);
+});
+
+test("keeps the confirmed revision visible and marks a failed refresh as stale", async ({ page }) => {
+  await mockExecutionReport(page);
+  await page.goto("/?state=active&view=reports");
+  await expect(page.getByText("Atualização ao vivo", { exact: true })).toBeVisible();
+
+  await page.addInitScript(() => undefined);
+  await page.evaluate(() => {
+    const internals = (window as any).__TAURI_INTERNALS__;
+    const original = internals.invoke;
+    internals.invoke = async (command: string, args: Record<string, unknown> = {}) => {
+      if (command === "desktop_execution_report") throw "execution_report_transport_error";
+      return original(command, args);
+    };
+  });
+  await page.getByRole("button", { name: "Atualizar", exact: true }).click();
+  await expect(page.getByText("Dados desatualizados", { exact: true })).toBeVisible();
+  await expect(page.getByText("A leitura mais recente falhou; os dados exibidos são da última revisão confirmada.", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: /run-current concluída/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reconectar", exact: true })).toBeVisible();
+});
+
+test("clears the previous run when a different run cannot be loaded", async ({ page }) => {
+  await mockExecutionReport(page);
+  await page.goto("/?state=active&view=reports");
+  await expect(page.getByText("Atualização ao vivo", { exact: true })).toBeVisible();
+  await page.evaluate(() => {
+    const internals = (window as any).__TAURI_INTERNALS__;
+    const original = internals.invoke;
+    internals.invoke = async (command: string, args: Record<string, unknown> = {}) => {
+      if (command === "desktop_execution_report" && args.runId === "run-failed") {
+        throw "selected_run_unavailable";
+      }
+      return original(command, args);
+    };
+  });
+  await page.getByLabel("Selecionar run exibido").selectOption("run-failed");
+  await expect(page.getByRole("alert")).toContainText("Não foi possível ler o relatório do Runtime");
+  await expect(page.getByText("Tarefas deste run", { exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Exportar JSON", exact: true })).toHaveCount(0);
+});
+
+test("does not present zero executed tests as a successful validation", async ({ page }) => {
+  const report = structuredClone(executionReport);
+  report.tasks[0].validation = { status: "passed", checks: 0, executed: 0, passed: 0, failures: 0, source: "vitest" };
+  await mockExecutionReport(page, "success", report);
+  await page.goto("/?state=active&view=reports");
+  await expect(page.getByText("Atualização ao vivo", { exact: true })).toBeVisible();
+  const task = page.locator("details").first();
+  await task.locator("summary").click();
+  await expect(task.locator(".report-validation")).not.toHaveClass(/report-validation-success/);
+  await expect(task.locator(".report-validation")).toContainText("não executada");
+});

--- a/apps/desktop/src/execution_report.test.ts
+++ b/apps/desktop/src/execution_report.test.ts
@@ -65,6 +65,24 @@ describe("execution report contract", () => {
     expect(report.tasks[0].validation.failures).toBe(1);
   });
 
+  it.each([
+    [{ status: "passed", checks: 0, executed: 0, failures: 0 }, "not_run"],
+    [{ status: "passed", executed: 0, failures: 0 }, "not_run"],
+    [{ status: "passed" }, "unavailable"],
+    [{ status: "passed", checks: 4, failures: 1 }, "failed"],
+    [{ status: "passed", checks: 4, failures: 0 }, "passed"],
+  ])("requires executed checks before accepting validation success: %j", (validation, status) => {
+    const report = parseExecutionReport({
+      schema: "simplicio.execution-report/v1",
+      tasks: [{ task_id: "task-validation", validation }],
+      consolidated: { validation },
+    });
+    expect(report.present).toBe(true);
+    if (!report.present) return;
+    expect(report.tasks[0].validation.status).toBe(status);
+    expect(report.consolidated.validation.status).toBe(status);
+  });
+
   it("does not turn a missing token dimension into zero", () => {
     const report = parseExecutionReport({
       schema: "simplicio.execution-report/v1",

--- a/apps/desktop/src/execution_report.ts
+++ b/apps/desktop/src/execution_report.ts
@@ -366,8 +366,17 @@ function parseRetry(raw: unknown): ReportRetry {
 
 function parseValidation(raw: unknown): ReportValidation {
   const value = optionalRecord(raw);
+  const executed = aliasNumber(value, ["executed", "checks"]);
+  const checks = aliasNumber(value, ["checks", "executed"]);
+  const failures = aliasNumber(value, ["failures", "failed"]);
+  let status = text(value.status, "unavailable", 48);
+  if (status === "passed") {
+    if (failures !== null && failures > 0) status = "failed";
+    else if (executed === 0 || checks === 0) status = "not_run";
+    else if (executed === null) status = "unavailable";
+  }
   return {
-    status: text(value.status, "unavailable", 48),
+    status,
     coverageStatus: text(value.coverage_status ?? value.coverage, "unavailable", 32),
     checks: aliasNumber(value, ["checks", "executed"]),
     failures: aliasNumber(value, ["failures", "failed"]),
@@ -442,7 +451,7 @@ function parseConsolidated(raw: unknown, taskCount: number): ReportConsolidated 
     tokensCacheReadRollup: text(value.tokens_cache_read_rollup, "absent", 32),
     tokensCacheWriteRollup: text(value.tokens_cache_write_rollup, "absent", 32),
     tokensReasoningSum: nonNegative(value.tokens_reasoning_sum),
-    tokensReasoningRollup: text(value.reasoning_rollup, "absent", 32),
+    tokensReasoningRollup: aliasText(value, ["tokens_reasoning_rollup", "reasoning_rollup"], 32) ?? "absent",
     costMicrousdSum: nonNegative(value.cost_microusd_sum),
     costRollup: text(value.cost_rollup, "unavailable", 32),
     costStatus: text(value.cost_status, "unavailable", 48),

--- a/apps/desktop/src/reports.css
+++ b/apps/desktop/src/reports.css
@@ -67,6 +67,51 @@
   font-weight: 600;
 }
 
+.report-context-meta {
+  min-width: 0;
+  display: grid !important;
+  justify-items: end;
+  gap: 3px;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.report-context-meta span { min-width: 0; overflow-wrap: anywhere; }
+
+.report-sync {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin: -8px 0 18px;
+  padding: 9px 12px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  color: var(--muted);
+  font: 10px/1.45 var(--mono);
+  background: #fbfcfc;
+}
+
+.report-sync > div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.report-sync strong { color: var(--ink); font-family: var(--sans); font-size: 11px; font-weight: 650; }
+.report-sync-stale { border-color: #efdfb5; background: #fffdf7; }
+.report-sync-offline { border-color: #f0d6d1; background: #fff8f7; }
+.report-sync-connecting { border-color: #d7e9de; background: #f6fbf7; }
+.report-sync-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--green); }
+.report-sync-stale .report-sync-dot { background: var(--warning); }
+.report-sync-offline .report-sync-dot { background: var(--danger); }
+.report-sync-connecting .report-sync-dot { background: var(--muted-soft); }
+.report-sync > span { min-width: 0; overflow-wrap: anywhere; }
+
+
 .report-context-dot {
   width: 7px;
   height: 7px;
@@ -300,6 +345,44 @@
   gap: 10px;
   padding: 14px 0 2px;
 }
+
+.report-task-meta-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.report-task-meta-grid > div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+  padding: 11px 12px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.report-task-meta-grid strong,
+.report-task-meta-grid small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.report-task-meta-grid strong { color: var(--ink); font-size: 12px; font-weight: 600; }
+.report-task-meta-grid small { color: var(--muted); font: 10px/1.45 var(--mono); }
+
+.report-task-trace {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  color: var(--muted-soft);
+  font: 10px/1.5 var(--mono);
+}
+
+.report-task-trace span { min-width: 0; overflow-wrap: anywhere; }
+
 
 .report-task-facts > div {
   min-width: 0;
@@ -664,6 +747,7 @@
 @media (max-width: 720px) {
   .reports-heading,
   .report-context,
+  .report-sync,
   .report-coverage,
   .report-validation {
     align-items: flex-start;
@@ -671,13 +755,17 @@
   }
 
   .reports-heading-actions,
+  .report-context-meta,
   .report-coverage-side { justify-content: flex-start; text-align: left; }
+  .report-context-meta { justify-items: start; }
+  .report-sync { gap: 7px; }
   .report-history-controls { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .report-filter-field-wide { grid-column: 1 / -1; }
   .report-history-list { grid-template-columns: minmax(0, 1fr); }
   .report-context { gap: 7px; }
   .report-coverage-side { min-width: 0; }
-  .report-task-facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .report-task-facts,
+  .report-task-meta-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .report-task-details { padding-left: 20px; }
 }
 
@@ -686,6 +774,7 @@
   .report-metrics,
   .report-lanes,
   .report-task-facts,
+  .report-task-meta-grid,
   .report-history-controls { grid-template-columns: minmax(0, 1fr); }
   .report-filter-field-wide { grid-column: auto; }
   .report-lane:last-child { grid-column: auto; }

--- a/apps/desktop/src/screens/ReportsScreen.tsx
+++ b/apps/desktop/src/screens/ReportsScreen.tsx
@@ -254,6 +254,20 @@ export function ReportsScreen({ repoPath = "" }: { repoPath?: string }) {
   const request = useRef(0);
   const inFlight = useRef<{ key: string; promise: Promise<void> } | null>(null);
   const hasReport = useRef(false);
+  const queryKey = JSON.stringify([repoPath, selectedRunId || null]);
+  const previousQueryKey = useRef(queryKey);
+
+  useEffect(() => {
+    if (previousQueryKey.current === queryKey) return;
+    previousQueryKey.current = queryKey;
+    request.current += 1;
+    setReport(null);
+    setBusy(false);
+    setError(null);
+    setConnection("connecting");
+    setLastRefreshAt(null);
+    hasReport.current = false;
+  }, [queryKey]);
 
   const refresh = useCallback(() => {
     const key = repoPath + "\\u0000" + (selectedRunId || "");


### PR DESCRIPTION
Selecting another run now clears the previous report before loading, so a failed read cannot export unrelated data. Normalize zero or missing executed-check counts to non-passing validation states, preserve the canonical reasoning rollup, and finish report status styling. Validation: 12 contract tests, six browser tests, production build, repository policy and diff checks passed. The browser suite covers loading, errors, stale revisions, scope changes, provenance, filters and zero executed tests using explicit mocked Runtime responses. Advances #390. Real installed Desktop acceptance with native and Python Loop telemetry remains open.