### PR TITLE
test(desktop): verify last-view persistence through user navigation

### DIFF
--- a/apps/desktop/e2e/desktop.spec.ts
+++ b/apps/desktop/e2e/desktop.spec.ts
@@ -75,7 +75,8 @@ test("Desktop settings persist language and launch preferences and keep uninstal
   await expect(page.getByRole("combobox", { name: "Comportamento ao iniciar", exact: true })).toHaveValue("last_view");
   await page.reload();
   await expect(page.getByRole("combobox", { name: "Comportamento ao iniciar", exact: true })).toHaveValue("last_view");
-  await page.goto("/?state=active&view=activity");
+  await page.getByRole("button", { name: "Voltar ao app", exact: true }).click();
+  await page.getByRole("button", { name: "Atividade", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();
   await page.goto("/?state=active");
   await expect(page.getByRole("heading", { name: "Atividade" })).toBeVisible();


### PR DESCRIPTION
The preference test navigated directly to a preview URL, which does not save the last workbench view. Exercise Back to app and the Activity navigation button before reopening, so the test verifies the actual persisted preference. The focused preference case passed. The full 124-case browser run passed 119 cases and hit five timeouts during concurrent compilation and disk pressure. All five passed when rerun with one worker after reclaiming this task-owned build cache. No application behavior changed. Advances #375 without claiming signed updater, provider authentication or installed-app acceptance.