### PR TITLE
feat(desktop): show usage bound to Runtime sessions

### DIFF
--- a/apps/desktop/src/components/BoundSessionUsageReport.test.tsx
+++ b/apps/desktop/src/components/BoundSessionUsageReport.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BoundSessionUsageReport } from "./BoundSessionUsageReport";
+import type { BoundSessionUsage } from "../session_idle";
+
+describe("bound session evidence", () => {
+  it("shows unknown totals, preserved subtotals and collection limits separately", () => {
+    const usage: BoundSessionUsage = {
+      schema: "simplicio.bound-session-usage/v1", scope: "bound_runtime_sessions",
+      collection_partial: true,
+      session_reports: [{
+        session_id: "runtime-session", status: "partial", binding_count: 1, events: 2,
+        totals: { input_tokens: 12, output_tokens: null, reasoning_tokens: null, cache_read_tokens: null, cache_write_tokens: null },
+        known_totals: { input_tokens: 12, output_tokens: 3 },
+      }],
+    };
+    const html = renderToStaticMarkup(<BoundSessionUsageReport usage={usage} />);
+    expect(html).toContain("runtime-session");
+    expect(html).toContain("2 eventos preservados");
+    expect(html).toContain("subtotal conhecido 3");
+    expect(html).toContain("fontes indisponíveis");
+    expect(html).toContain("<dt>Raciocínio</dt><dd>—");
+    expect(html).not.toContain("coleta concluída");
+  });
+});

--- a/apps/desktop/src/components/BoundSessionUsageReport.tsx
+++ b/apps/desktop/src/components/BoundSessionUsageReport.tsx
@@ -1,0 +1,25 @@
+import type { BoundSessionUsage } from "../session_idle";
+const metrics = [
+  ["input_tokens", "Entrada"], ["output_tokens", "Saída"],
+  ["reasoning_tokens", "Raciocínio"], ["cache_read_tokens", "Cache lido"],
+  ["cache_write_tokens", "Cache escrito"],
+] as const;
+
+export function BoundSessionUsageReport({ usage }: { usage: BoundSessionUsage }) {
+  return <section aria-label="Consumo por sessão" className="provider-usage-list">
+    <h3>Consumo por sessão</h3>
+    {usage.collection_partial && <p role="status">A coleta encontrou limites ou fontes indisponíveis. Os valores mostram a evidência preservada.</p>}
+    {usage.session_reports.map(report => <div className="provider-usage-row" key={report.session_id}>
+      <div className="provider-usage-row-heading"><strong>{report.session_id}</strong>
+        <span className="neutral-badge">{report.status === "provider_session_not_bound" ? "Provider ainda não vinculado"
+          : report.events === 0 ? "Aguardando consumo" : report.events + " eventos preservados"}</span></div>
+      <dl>{metrics.map(([key, label]) => <div key={key}>
+        <dt>{label}</dt><dd>{report.totals[key] === null ? "—" : report.totals[key].toLocaleString("pt-BR")}
+          {report.totals[key] === null && report.known_totals[key] !== undefined
+            && <small> · subtotal conhecido {report.known_totals[key]?.toLocaleString("pt-BR")}</small>}
+        </dd>
+      </div>)}</dl>
+    </div>)}
+    <p className="token-proof-note">Valores informados pelo provider e vinculados a esta sessão. Campos sem evidência permanecem —; novas informações podem chegar depois do fechamento.</p>
+  </section>;
+}

--- a/apps/desktop/src/screens/TokensScreen.tsx
+++ b/apps/desktop/src/screens/TokensScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { BoundSessionUsageReport } from "../components/BoundSessionUsageReport";
 import { Glyph } from "../components/Brand";
 import { ContextSavings } from "../components/ContextSavings";
 import { TokenProjects } from "../components/TokenProjects";
@@ -22,7 +23,7 @@ const IDLE_REPORT_METRICS: Array<[ProviderUsageMetric, string]> = [
 
 function IdleFinalizationReport({ finalization }: { finalization?: IdleSessionFinalization | null }) {
   if (!finalization) return null;
-  const statusLabel = finalization.usage.status === "complete"
+  const statusLabel = finalization.session_usage ? "consumo por sessão" : finalization.usage.status === "complete"
     ? "coleta concluída"
     : finalization.usage.status === "pending_provider_refresh"
       ? "aguardando providers"
@@ -38,7 +39,7 @@ function IdleFinalizationReport({ finalization }: { finalization?: IdleSessionFi
       <span className="neutral-badge">{statusLabel}</span>
     </div>
     <p>{finalization.closed_sessions.length} sessão(ões) fechada(s) · recibo {finalization.finalization_id ?? "sem identificador exposto"}.</p>
-    {providerReports.length > 0
+    {finalization.session_usage ? <BoundSessionUsageReport usage={finalization.session_usage} /> : providerReports.length > 0
       ? <div className="provider-usage-list">{providerReports.map((report) => <div className="provider-usage-row" key={report.provider}>
         <div className="provider-usage-row-heading"><strong>{report.provider}</strong><span className="neutral-badge">{report.events > 0 ? report.events + " eventos" : report.status}</span></div>
         <small>{IDLE_REPORT_METRICS.map(([metric, label]) => label + " " + number(report, metric)).join(" · ")}</small>

--- a/apps/desktop/src/session_idle.test.ts
+++ b/apps/desktop/src/session_idle.test.ts
@@ -100,3 +100,49 @@ describe('logical idle-session policy', () => {
     expect(() => parseIdleSessionFinalization(invalid)).toThrow('session_idle_finalization_invalid');
   });
 });
+
+function boundUsage() {
+  return {
+    schema: 'simplicio.bound-session-usage/v1',
+    scope: 'bound_runtime_sessions', redacted: true, network_calls: 0, provider_processes_terminated: false,
+    scan: { provider_reports: [{ failure_codes: [] as string[] }], redacted: true, network_calls: 0 },
+    session_reports: [{
+      session_id: 'session-1', status: 'partial', binding_count: 1, events: 2,
+      totals: { input_tokens: 12, output_tokens: null, reasoning_tokens: null, cache_read_tokens: null, cache_write_tokens: null },
+      known_totals: { input_tokens: 12, output_tokens: 3 },
+      provenance: 'provider_reported', redacted: true,
+    }],
+  };
+}
+
+describe('bound Runtime session usage', () => {
+  it('keeps unknown totals separate from known subtotals', () => {
+    const receipt = parseIdleSessionFinalization({ ...baseReceipt, session_usage: boundUsage() });
+    expect(receipt.session_usage?.session_reports[0].totals.output_tokens).toBeNull();
+    expect(receipt.session_usage?.session_reports[0].known_totals.output_tokens).toBe(3);
+    expect(receipt.session_usage?.collection_partial).toBe(false);
+  });
+  it('exposes a bounded collection failure', () => {
+    const usage = boundUsage();
+    usage.scan.provider_reports[0].failure_codes = ['source_bound_reached'];
+    expect(parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })
+      .session_usage?.collection_partial).toBe(true);
+  });
+  it('rejects another session and duplicate session projections', () => {
+    const usage = boundUsage();
+    usage.session_reports[0].session_id = 'another-session';
+    expect(() => parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })).toThrow();
+    usage.session_reports[0].session_id = 'session-1';
+    usage.session_reports.push(usage.session_reports[0]);
+    expect(() => parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })).toThrow();
+  });
+  it('rejects missing metrics and inconsistent known totals', () => {
+    const usage = boundUsage();
+    usage.session_reports[0].known_totals.input_tokens = 99;
+    expect(() => parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })).toThrow();
+    usage.session_reports[0].known_totals.input_tokens = 12;
+    expect(() => parseIdleSessionFinalization({ ...baseReceipt, session_usage: {
+      ...usage, session_reports: [{ ...usage.session_reports[0], totals: {} }],
+    } })).toThrow();
+  });
+});

--- a/apps/desktop/src/session_idle.test.ts
+++ b/apps/desktop/src/session_idle.test.ts
@@ -105,7 +105,7 @@ function boundUsage() {
   return {
     schema: 'simplicio.bound-session-usage/v1',
     scope: 'bound_runtime_sessions', redacted: true, network_calls: 0, provider_processes_terminated: false,
-    scan: { provider_reports: [{ failure_codes: [] as string[] }], redacted: true, network_calls: 0 },
+    scan: { provider_reports: [{ status: 'collected', failure_codes: [] as string[] }], redacted: true, network_calls: 0 },
     session_reports: [{
       session_id: 'session-1', status: 'partial', binding_count: 1, events: 2,
       totals: { input_tokens: 12, output_tokens: null, reasoning_tokens: null, cache_read_tokens: null, cache_write_tokens: null },
@@ -125,6 +125,15 @@ describe('bound Runtime session usage', () => {
   it('exposes a bounded collection failure', () => {
     const usage = boundUsage();
     usage.scan.provider_reports[0].failure_codes = ['source_bound_reached'];
+    expect(parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })
+      .session_usage?.collection_partial).toBe(true);
+  });
+  it('keeps failed or empty collection unavailable for a bound session', () => {
+    const usage = boundUsage();
+    expect(parseIdleSessionFinalization({ ...baseReceipt, session_usage: {
+      ...usage, scan: { status: 'unavailable', provider_reports: [], redacted: true, network_calls: 0 },
+    } }).session_usage?.collection_partial).toBe(true);
+    usage.scan.provider_reports = [];
     expect(parseIdleSessionFinalization({ ...baseReceipt, session_usage: usage })
       .session_usage?.collection_partial).toBe(true);
   });

--- a/apps/desktop/src/session_idle.ts
+++ b/apps/desktop/src/session_idle.ts
@@ -257,7 +257,12 @@ function parseBoundSessionUsage(value: unknown, closures: IdleSessionClosure[]):
   const providers = scan.provider_reports;
   let partial = true;
   if (Array.isArray(providers) && providers.length <= 32 && scan.redacted === true && scan.network_calls === 0) {
-    partial = providers.some(value => parseFailureCodes(record(value).failure_codes).length > 0);
+    partial = scan.status !== undefined
+      || (providers.length === 0 && reports.some(report => report.binding_count > 0))
+      || providers.some(value => {
+        const provider = record(value);
+        return provider.status !== 'collected' || parseFailureCodes(provider.failure_codes).length > 0;
+      });
   }
   return { schema: 'simplicio.bound-session-usage/v1', scope: 'bound_runtime_sessions',
     session_reports: reports, collection_partial: partial };

--- a/apps/desktop/src/session_idle.ts
+++ b/apps/desktop/src/session_idle.ts
@@ -66,6 +66,22 @@ export interface IdleSessionClosure {
   updated_at: number;
 }
 
+
+export interface BoundSessionUsageReport {
+  session_id: string;
+  status: 'provider_session_not_bound' | 'pending_provider_refresh' | 'available' | 'partial';
+  binding_count: number;
+  events: number;
+  totals: Record<ProviderUsageMetric, number | null>;
+  known_totals: Partial<Record<ProviderUsageMetric, number>>;
+}
+export interface BoundSessionUsage {
+  schema: 'simplicio.bound-session-usage/v1';
+  scope: 'bound_runtime_sessions';
+  session_reports: BoundSessionUsageReport[];
+  collection_partial: boolean;
+}
+
 export interface IdleSessionFinalization {
   schema: typeof SESSION_IDLE_FINALIZATION_SCHEMA;
   status: 'logical_closed';
@@ -77,6 +93,7 @@ export interface IdleSessionFinalization {
   idle_ms: number;
   closed_sessions: IdleSessionClosure[];
   usage: IdleSessionUsage;
+  session_usage?: BoundSessionUsage;
   provider_processes_terminated: false;
   redacted: true;
 }
@@ -202,6 +219,50 @@ function parseProviderReport(value: unknown): ProviderUsageReport {
   return report;
 }
 
+
+function parseBoundSessionUsage(value: unknown, closures: IdleSessionClosure[]): BoundSessionUsage {
+  const raw = record(value);
+  if (raw.schema !== 'simplicio.bound-session-usage/v1' || raw.scope !== 'bound_runtime_sessions'
+    || raw.redacted !== true || raw.network_calls !== 0 || raw.provider_processes_terminated !== false
+    || !Array.isArray(raw.session_reports) || raw.session_reports.length > 256) {
+    throw new Error('session_idle_finalization_invalid');
+  }
+  const ids = new Set(closures.map(item => item.session_id));
+  const seen = new Set<string>();
+  const reports = raw.session_reports.map((value): BoundSessionUsageReport => {
+    const item = record(value);
+    const id = boundedString(item.session_id, SESSION_ID_MAX);
+    if (!ids.has(id) || seen.has(id) || item.redacted !== true
+      || item.provenance !== 'provider_reported') throw new Error('session_idle_finalization_invalid');
+    seen.add(id);
+    const status = item.status;
+    if (status !== 'provider_session_not_bound' && status !== 'pending_provider_refresh'
+      && status !== 'available' && status !== 'partial') throw new Error('session_idle_finalization_invalid');
+    const totalsRaw = record(item.totals);
+    const totals = {} as Record<ProviderUsageMetric, number | null>;
+    for (const metric of METRICS) {
+      totals[metric] = totalsRaw[metric] === null ? null : safeInteger(totalsRaw[metric]);
+    }
+    const known = parseProviderTotals(item.known_totals);
+    for (const metric of METRICS) {
+      if (totals[metric] !== null && totals[metric] !== known[metric]) {
+        throw new Error('session_idle_finalization_invalid');
+      }
+    }
+    return { session_id: id, status, binding_count: boundedCount(item.binding_count, 10_000),
+      events: boundedCount(item.events, 10_000), totals, known_totals: known };
+  });
+  if (seen.size !== ids.size) throw new Error('session_idle_finalization_invalid');
+  const scan = record(raw.scan);
+  const providers = scan.provider_reports;
+  let partial = true;
+  if (Array.isArray(providers) && providers.length <= 32 && scan.redacted === true && scan.network_calls === 0) {
+    partial = providers.some(value => parseFailureCodes(record(value).failure_codes).length > 0);
+  }
+  return { schema: 'simplicio.bound-session-usage/v1', scope: 'bound_runtime_sessions',
+    session_reports: reports, collection_partial: partial };
+}
+
 function parseClosure(value: unknown): IdleSessionClosure {
   const raw = record(value);
   return {
@@ -259,6 +320,7 @@ export function parseIdleSessionFinalization(value: unknown): IdleSessionFinaliz
     now_millis: nowMillis,
     idle_ms: idleMs,
     closed_sessions: closedSessions,
+    ...(raw.session_usage === undefined ? {} : { session_usage: parseBoundSessionUsage(raw.session_usage, closedSessions) }),
     usage,
     provider_processes_terminated: false,
     redacted: true,


### PR DESCRIPTION
Desktop currently discards the Runtime's per-session usage projection and can only show source-wide provider totals. Parse the new bound-session receipt, reject mismatched or duplicate session identities, and show preserved metrics in Tokens. Unknown totals remain distinct from known subtotals; collection limits are visible.

Validation: 18 focused tests passed across the receipt parser, usage store, Tokens history and new report component. Production build and repository policy check passed.

Related to #376. This is the Desktop consumer of the companion Runtime session-usage change. It does not prove installed-host binding or signed application acceptance and does not close the issue.
