### PR TITLE
Document 29 host integrations and reconcile installer receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="#-installation">Install</a> ·
   <a href="#-login-and-entitlement">Login</a> ·
   <a href="#-simplicio-mcp">MCP</a> ·
+  <a href="#host-integrations">Integrations</a> ·
   <a href="#-what-it-does">Features</a> ·
   <a href="#-benchmarks-and-token-savings">Benchmarks</a> ·
   <a href="https://simpleti.com.br/simplicio/">Website</a>
@@ -81,6 +82,59 @@ Login is never a substitute for installation, and a successful process exit is
 not proof that a host is configured. The CLI path below remains the supported
 cross-platform fallback and follows the same Runtime, authentication, consent,
 reload, and first-call contract.
+
+## Host integrations
+
+The installers for macOS/Linux, Windows and PyPI call the same native
+`simplicio mcp register --binary <absolute-path> --json` flow. Each client uses
+its own configuration format and points to the installed Simplicio binary.
+
+**Release boundary:** the expanded adapters below are implemented in source and
+need a Runtime release containing this change. They are not retroactively added
+to the immutable v3.8.47 download. A successful configuration write is not a
+completed MCP handshake; restart/reload the client and verify its tool list.
+
+| Harness | Integration | Scope and limits |
+|---|---|---|
+| Claude Code | Runtime MCP + native hooks | User configuration; mapper-only lifecycle hooks. |
+| Codex | Runtime MCP registry | Managed binary registered through Codex MCP. |
+| Grok | Runtime MCP | Superagent Grok CLI; not the xAI web application. |
+| Cursor | Runtime MCP | User MCP configuration. |
+| GitHub Copilot | VS Code MCP | Uses the VS Code registration; Copilot CLI is a separate client. |
+| OpenCode | Runtime MCP | OpenCode local-server schema. |
+| MiMo Code | Runtime MCP | Xiaomi MiMo Code local-server schema. |
+| Amp | Runtime MCP | amp.mcpServers in user settings. |
+| OpenClaude | Runtime MCP | Independent .openclaude.json; legacy .config.json supported. |
+| Antigravity | Runtime MCP | Detected Antigravity user configuration. |
+| Pi | Bundled MCP extension | Auto-discovered extension connects to local stdio MCP. |
+| oh-my-pi | Runtime MCP | User .omp/agent/mcp.json. |
+| Hermes Agent | Runtime MCP + native plugin | Hermes registry reconciliation and host plugin flow. |
+| Devin | Environment setup required | Configure MCP in Devin's environment/admin interface; a local installer cannot alter the cloud workspace. |
+| Goose | Runtime MCP | YAML extensions with cmd/envs; Windows Block/Goose path supported. |
+| Auggie | Runtime MCP | Augment user settings. |
+| Autohand Code | Runtime MCP | Named entry in mcp.servers array. |
+| Charm / Crush | Runtime MCP | Crush mcp object, stdio transport. |
+| Cline | Runtime MCP | VS Code extension global-storage configuration. |
+| Codebuff | Project/SDK bridge required | Custom agents/tools use project or SDK setup; no verified global MCP registry. |
+| Command Code | Runtime MCP | User .commandcode/mcp.json. |
+| Continue | Runtime MCP (IDE) | Dedicated YAML server file; cn CLI discovery is not claimed. |
+| Droid | Runtime MCP | Factory user MCP configuration. |
+| Kilo Code | Runtime MCP (CLI) | Current kilo.json local-server schema. |
+| Kimi | Runtime MCP | Kimi user MCP configuration. |
+| Kiro | Runtime MCP | Kiro user MCP configuration. |
+| Mistral Vibe | Runtime MCP | TOML mcp_servers entries. |
+| Qwen Code | Runtime MCP | Qwen user settings. |
+| Rovo Dev | Runtime MCP (CLI) | User MCP configuration; custom paths are preserved. |
+
+New adapters detect initialized user configuration directories. They preserve
+other servers and explicit disablement, and report invalid configuration,
+JSONC files and custom configuration overrides as skipped instead of replacing
+them. Initialize the client first, then rerun registration. Pi uses a bundled
+local extension, without installing an unrelated npm package.
+
+See [installation paths, upstream references and verification](docs/INSTALLER_HOSTS.md).
+Devin and Codebuff remain explicit setup requirements, not automatic-registration
+successes.
 
 ## 🚀 Installation
 

--- a/docs/INSTALLER_HOSTS.md
+++ b/docs/INSTALLER_HOSTS.md
@@ -1,0 +1,68 @@
+# Installer host registration
+
+The public shell, PowerShell and PyPI installers delegate MCP configuration to
+the downloaded Runtime. The adapter expansion must ship in a new signed Runtime
+release before these paths are available to public installer users.
+
+## Additional user configuration paths
+
+| Host | Default path | Upstream contract |
+|---|---|---|
+| Command Code | `~/.commandcode/mcp.json` | [Documentation](https://commandcode.ai/docs/settings) |
+| Grok CLI (Superagent) | `~/.grok/settings.json` | [Documentation](https://github.com/superagent-ai/grok-cli) |
+| MiMo Code | `~/.config/mimocode/mimocode.json` | [Documentation](https://github.com/XiaomiMiMo/MiMo-Code) |
+| Amp | `~/.config/amp/settings.json` | [Documentation](https://ampcode.com/docs/customize/mcp) |
+| OpenClaude | `~/.openclaude.json` | [Documentation](https://github.com/Gitlawb/openclaude) |
+| oh-my-pi | `~/.omp/agent/mcp.json` | [Documentation](https://github.com/can1357/oh-my-pi) |
+| Goose | `~/.config/goose/config.yaml` | [Documentation](https://block.github.io/goose/docs/guides/config-files/) |
+| Auggie | `~/.augment/settings.json` | [Documentation](https://docs.augmentcode.com/cli/integrations) |
+| Autohand Code | `~/.autohand/config.json` | [Documentation](https://github.com/autohandai/code-cli/blob/main/docs/config-reference.md) |
+| Charm / Crush | `~/.config/crush/crush.json` | [Documentation](https://github.com/charmbracelet/crush) |
+| Continue IDE | `~/.continue/mcpServers/simplicio.yaml` | [Documentation](https://docs.continue.dev/customize/mcp-tools) |
+| Droid | `~/.factory/mcp.json` | [Documentation](https://docs.factory.ai/harness/connectors) |
+| Kilo Code CLI | `~/.config/kilo/kilo.json` | [Documentation](https://kilo.ai/docs/automate/mcp/using-in-cli) |
+| Kimi | `~/.kimi/mcp.json` | [Documentation](https://moonshotai.github.io/kimi-cli/en/customization/mcp.html) |
+| Mistral Vibe | `~/.vibe/config.toml` | [Documentation](https://docs.mistral.ai/vibe/code/cli/mcp-servers) |
+| Qwen Code | `~/.qwen/settings.json` | [Documentation](https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/) |
+| Rovo Dev CLI | `~/.rovodev/mcp.json` | [Documentation](https://support.atlassian.com/rovo/docs/connect-to-an-mcp-server-in-rovo-dev-cli/) |
+| Pi | `~/.pi/agent/extensions/simplicio.ts` | [Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md) |
+| Codex | `~/.codex/config.toml` | [Documentation](https://developers.openai.com/codex/mcp/) |
+
+Goose on Windows uses `%APPDATA%/Block/goose/config/config.yaml`.
+The native planner uses the detected initialized configuration directory.
+It never launches a host during planning. Registration uses the existing
+transactional writer and returns per-file receipts.
+
+## Verification
+
+1. Install or initialize the client and run the Simplicio installer.
+2. Inspect `simplicio mcp register --dry-run --binary <absolute-path> --json`.
+3. Apply with `simplicio mcp register --binary <absolute-path> --json`.
+4. Restart/reload the host. In Pi use `/reload`.
+5. Confirm the client lists Simplicio tools, then make one read-only
+   `simplicio_map` call in a test repository.
+
+The PyPI receipt accepts Runtime `writes` entries with `done` or idempotent
+`skipped` status, without confusing dry-run plans with completed registration.
+Invalid files, JSONC and explicit custom config paths are preserved and reported.
+A user's explicit disabled state stays disabled; registration does not override
+the host's permission or trust prompts.
+
+## Clients without a user MCP registry
+
+- **Devin:** use [Devin MCP settings](https://docs.devin.ai/work-with-devin/mcp)
+  in the environment where Devin executes. Install Simplicio there and configure
+  a stdio server whose command is that environment's absolute binary path with
+  arguments `serve --mcp --stdio`. Local desktop paths do not refer to Devin's
+  cloud filesystem; organization authorization remains Devin-owned.
+- **Codebuff:** use its [custom tools SDK](https://www.codebuff.com/docs/advanced/sdk)
+  in a project integration. A global `~/.codebuff/mcp.json` contract was not
+  verified. The installer reports this requirement rather than claiming success.
+
+## Maintainer validation
+
+Runtime adapter fixtures cover JSON/YAML/TOML parsing, Windows command paths,
+unrelated server preservation, idempotence and malformed/custom configuration.
+The Pi extension tests exercise MCP initialization, tool discovery, calls,
+shutdown, failure handling and concurrent stdio responses.
+These tests do not establish live acceptance by every third-party client.

--- a/pypi/simplicio/simplicio/host_adapters.py
+++ b/pypi/simplicio/simplicio/host_adapters.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
-from .host_integrations import HOSTS, HostSpec, detect_hosts
+from .host_integrations import HOSTS, INSTALLER_HOSTS, HostSpec, detect_hosts
 
 
 SCHEMA = "simplicio.host-adapters/v1"
@@ -222,6 +222,9 @@ def install_detected_hosts(
             continue
         if spec.capability == "portable-cli":
             results.append(IntegrationResult(spec.host_id, "detected", chosen_scope, None, spec.capability, "portable_cli", "manual_host_verification"))
+            continue
+        if spec.host_id in {item.host_id for item in INSTALLER_HOSTS}:
+            results.append(IntegrationResult(spec.host_id, "requires-runtime-registration", chosen_scope, None, spec.capability, "none", "run_simplicio_mcp_register"))
             continue
         path = _scope_path(spec, scope=chosen_scope, home=resolved_home, cwd=resolved_cwd)
         if path is None:

--- a/pypi/simplicio/simplicio/host_integrations.py
+++ b/pypi/simplicio/simplicio/host_integrations.py
@@ -238,6 +238,37 @@ HOSTS = HOSTS + tuple(
 )
 
 
+
+# Installer adapters are owned by Runtime; never route these through the legacy
+# generic JSON writer (Goose, Vibe, Pi and OpenCode-family schemas differ).
+INSTALLER_HOSTS = (
+    _runtime_mcp("antigravity", "Antigravity", (), ("~/.gemini/config/mcp_config.json",), "https://antigravity.google/docs/"),
+    _runtime_mcp("hermes-agent", "Hermes Agent", ("hermes",), (), "https://github.com/NousResearch/hermes-agent"),
+    _runtime_mcp("cline", "Cline", (), ("~/.cline/mcp_settings.json",), "https://docs.cline.bot/mcp/configuring-mcp-servers"),
+    _runtime_mcp("github-copilot", "GitHub Copilot in VS Code", (), (), "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"),
+    _runtime_mcp("command-code", "Command Code", ("commandcode",), ("~/.commandcode/mcp.json",), "https://commandcode.ai/docs/settings"),
+    _runtime_mcp("grok", "Grok CLI (Superagent)", ("grok",), ("~/.grok/settings.json",), "https://github.com/superagent-ai/grok-cli"),
+    _runtime_mcp("mimo-code", "MiMo Code", ("mimo",), ("~/.config/mimocode/mimocode.json",), "https://github.com/XiaomiMiMo/MiMo-Code"),
+    _runtime_mcp("amp", "Amp", ("amp",), ("~/.config/amp/settings.json",), "https://ampcode.com/docs/customize/mcp"),
+    _runtime_mcp("openclaude", "OpenClaude", ("openclaude",), ("~/.openclaude.json",), "https://github.com/Gitlawb/openclaude"),
+    _runtime_mcp("oh-my-pi", "oh-my-pi", ("omp",), ("~/.omp/agent/mcp.json",), "https://github.com/can1357/oh-my-pi"),
+    _runtime_mcp("goose", "Goose", ("goose",), ("~/.config/goose/config.yaml",), "https://block.github.io/goose/docs/guides/config-files/"),
+    _runtime_mcp("auggie", "Auggie", ("auggie",), ("~/.augment/settings.json",), "https://docs.augmentcode.com/cli/integrations"),
+    _runtime_mcp("autohand-code", "Autohand Code", ("autohand",), ("~/.autohand/config.json",), "https://github.com/autohandai/code-cli/blob/main/docs/config-reference.md"),
+    _runtime_mcp("charm-crush", "Charm / Crush", ("crush",), ("~/.config/crush/crush.json",), "https://github.com/charmbracelet/crush"),
+    _runtime_mcp("continue", "Continue IDE", ("continue",), ("~/.continue/mcpServers/simplicio.yaml",), "https://docs.continue.dev/customize/mcp-tools"),
+    _runtime_mcp("droid", "Droid", ("droid",), ("~/.factory/mcp.json",), "https://docs.factory.ai/harness/connectors"),
+    _runtime_mcp("kilocode", "Kilo Code CLI", ("kilo",), ("~/.config/kilo/kilo.json",), "https://kilo.ai/docs/automate/mcp/using-in-cli"),
+    _runtime_mcp("kimi", "Kimi", ("kimi",), ("~/.kimi/mcp.json",), "https://moonshotai.github.io/kimi-cli/en/customization/mcp.html"),
+    _runtime_mcp("mistral-vibe", "Mistral Vibe", ("vibe",), ("~/.vibe/config.toml",), "https://docs.mistral.ai/vibe/code/cli/mcp-servers"),
+    _runtime_mcp("qwen-code", "Qwen Code", ("qwen",), ("~/.qwen/settings.json",), "https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/"),
+    _runtime_mcp("rovo-dev", "Rovo Dev CLI", ("acli",), ("~/.rovodev/mcp.json",), "https://support.atlassian.com/rovo/docs/connect-to-an-mcp-server-in-rovo-dev-cli/"),
+    _runtime_mcp("pi", "Pi", ("pi",), ("~/.pi/agent/extensions/simplicio.ts",), "https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md"),
+    _runtime_mcp("codex", "Codex", ("codex",), ("~/.codex/config.toml",), "https://developers.openai.com/codex/mcp/"),
+)
+_INSTALLER_IDS = frozenset(spec.host_id for spec in INSTALLER_HOSTS)
+HOSTS = tuple(spec for spec in HOSTS if spec.host_id not in _INSTALLER_IDS) + INSTALLER_HOSTS
+
 def compatibility_matrix() -> Tuple[Dict[str, object], ...]:
     """Expose the complete, redacted host contract table for UIs and CI."""
 
@@ -281,7 +312,7 @@ def _exact_executables(spec: HostSpec, env: Mapping[str, str]) -> List[str]:
     found: List[str] = []
     for name in spec.executable_names:
         resolved = shutil.which(name, path=path)
-        if resolved and Path(resolved).name == name:
+        if resolved and Path(resolved).name.lower() in {name.lower(), name.lower() + ".exe", name.lower() + ".cmd", name.lower() + ".bat"}:
             found.append(str(Path(resolved).resolve()))
     return found
 
@@ -309,7 +340,7 @@ def detect_hosts(
             for path in (_home_path(item, resolved_home) for item in spec.config_paths)
             if path.exists()
         ]
-        present = bool(executable_paths or app_paths)
+        present = bool(executable_paths or app_paths or config_paths)
         skipped_host = _is_skipped(spec, environ, skipped)
         if skipped_host:
             status = "skipped"
@@ -352,10 +383,34 @@ def build_summary(
     runtime_status = report.get("status") if report else "not-run"
     registered = report.get("registered")
     failed = report.get("failed")
+    aliases = {"claudecode": "claude-code", "vscodecline": "cline",
+               "hermes": "hermes-agent", "codex-stdio": "codex"}
+    # Only applied receipts count; a dry-run or planned write is not registration.
+    if report.get("dry_run") is not True and report.get("status") in {"passed", "failed"}:
+        successful, failures = set(), set()
+        for write in report.get("writes", []):
+            if not isinstance(write, dict):
+                continue
+            label = aliases.get(str(write.get("label")), str(write.get("label")))
+            if write.get("status") in {"done", "skipped"}:
+                successful.add(label)
+            elif write.get("status") == "failed":
+                failures.add(label)
+        registered = list(set(registered or []) | successful)
+        failed = list(set(failed or []) | failures)
+    else:
+        registered = []
+    for reason in report.get("skipped", []):
+        host_id, _, detail = str(reason).partition(": ")
+        for host in hosts:
+            if host["id"] == host_id and detail and detail != "not_detected":
+                host["status"] = "skipped"
+                host["reason"] = detail
+
     if isinstance(registered, list):
         registered_ids = {str(item) for item in registered}
         for host in hosts:
-            if host["status"] == "detected" and host["id"] in registered_ids:
+            if host["status"] != "skipped" and host["id"] in registered_ids:
                 host["status"] = "registered"
     if isinstance(failed, list):
         failed_ids = {str(item) for item in failed}

--- a/tests/test_host_adapters.py
+++ b/tests/test_host_adapters.py
@@ -228,8 +228,8 @@ def test_unverified_antigravity_is_reported_without_guessing_a_binary(tmp_path: 
         env={"PATH": str(bin_dir)}, specs=(spec,)
     )
 
-    assert result["results"][0]["status"] == "unsupported"
-    assert result["results"][0]["reason_code"] == "unsupported"
+    assert result["results"][0]["status"] == "absent"
+    assert result["results"][0]["reason_code"] == "absent"
 
 
 def test_kiro_contract_is_atomic_and_idempotent(tmp_path: Path) -> None:
@@ -276,10 +276,9 @@ def test_pi_and_oh_my_pi_use_separate_exact_executables_and_configs(tmp_path: Pa
 
     assert pi_result["failed_hosts"] == []
     assert omp_result["failed_hosts"] == []
-    assert (home / ".pi/agent/mcp.json").is_file()
-    assert (home / ".omp/mcp.json").is_file()
-    assert json.loads((home / ".pi/agent/mcp.json").read_text())["mcpServers"]["simplicio"]
-    assert json.loads((home / ".omp/mcp.json").read_text())["mcpServers"]["simplicio"]
+    assert pi_result["results"][0]["status"] == "requires-runtime-registration"
+    assert omp_result["results"][0]["status"] == "requires-runtime-registration"
+    assert not home.exists()  # No invented generic MCP files for these hosts.
 
 
 def test_orca_portable_contract_is_verification_only() -> None:
@@ -298,12 +297,12 @@ def test_command_code_contract_requires_an_official_contract(tmp_path: Path) -> 
     spec = next(item for item in HOSTS if item.host_id == "command-code")
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _command(bin_dir / "command-code")
+    _command(bin_dir / "commandcode")
     home = tmp_path / "home"
     result = install_detected_hosts(
         "/opt/simplicio/bin/simplicio", home=home, cwd=tmp_path,
         env={"PATH": str(bin_dir)}, specs=(spec,)
     )
-    assert result["results"][0]["status"] == "unsupported"
-    assert result["results"][0]["reason_code"] == "unsupported"
+    assert result["results"][0]["status"] == "requires-runtime-registration"
+    assert result["results"][0]["reason_code"] == "run_simplicio_mcp_register"
     assert not home.exists()

--- a/tests/test_host_integrations.py
+++ b/tests/test_host_integrations.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 from simplicio.host_integrations import (
     COMPATIBILITY_MATRIX_HOST_IDS,
     HOSTS,
+    INSTALLER_HOSTS,
     build_summary,
     compatibility_matrix,
     detect_hosts,
@@ -54,7 +55,7 @@ def test_detection_uses_exact_executable_and_app_evidence(tmp_path: Path) -> Non
     by_id = {item["id"]: item for item in snapshot}
     assert by_id["claude-code"]["status"] == "detected"
     assert by_id["claude-code"]["executable"].endswith("/claude")
-    assert by_id["cursor"]["status"] == "absent"
+    assert by_id["cursor"]["status"] == "detected"
     assert by_id["deepseek-harness"]["status"] == "unsupported"
 
 
@@ -102,12 +103,10 @@ def test_vscode_declares_all_supported_configuration_scopes() -> None:
     assert vscode.verification_command[-1] == "--json"
 
 
-def test_antigravity_is_fail_closed_until_public_contract_is_verified() -> None:
-    antigravity = next(spec for spec in HOSTS if spec.host_id == "antigravity")
-    assert antigravity.executable_names == ()
-    assert antigravity.capability == "unsupported"
-    assert antigravity.contract == "unverified"
-    assert antigravity.verification_command == ()
+def test_antigravity_uses_runtime_registration() -> None:
+    spec = next(spec for spec in HOSTS if spec.host_id == "antigravity")
+    assert spec.capability == "runtime-mcp"
+    assert spec.config_paths == ("~/.gemini/config/mcp_config.json",)
 
 
 def test_kiro_has_runtime_registration_contract() -> None:
@@ -141,7 +140,7 @@ def test_compatibility_matrix_covers_every_requested_remaining_host() -> None:
     by_id = {spec.host_id: spec for spec in HOSTS}
     assert COMPATIBILITY_MATRIX_HOST_IDS <= set(by_id)
     assert len(COMPATIBILITY_MATRIX_HOST_IDS) == 22
-    for host_id in COMPATIBILITY_MATRIX_HOST_IDS - {"oh-my-pi"}:
+    for host_id in COMPATIBILITY_MATRIX_HOST_IDS - {spec.host_id for spec in INSTALLER_HOSTS}:
         spec = by_id[host_id]
         assert spec.contract == "unverified"
         assert spec.capability == "unsupported"
@@ -163,12 +162,11 @@ def test_compatibility_matrix_is_complete_and_redacted() -> None:
             assert row["executable_names"] == []
 
 
-def test_command_code_is_fail_closed_until_official_contract_is_confirmed() -> None:
+def test_command_code_has_official_runtime_contract() -> None:
     command_code = next(spec for spec in HOSTS if spec.host_id == "command-code")
-    assert command_code.executable_names == ()
-    assert command_code.capability == "unsupported"
-    assert command_code.contract == "unverified"
-    assert command_code.verification_command == ()
+    assert command_code.executable_names == ("commandcode",)
+    assert command_code.capability == "runtime-mcp"
+    assert command_code.config_paths == ("~/.commandcode/mcp.json",)
 
 
 def test_skip_controls_are_explicit_and_do_not_touch_host_files(tmp_path: Path) -> None:
@@ -206,3 +204,25 @@ def test_summary_is_atomic_and_restrictive(tmp_path: Path) -> None:
     assert json.loads(target.read_text(encoding="utf-8"))["schema"] == "test"
     assert os.stat(target).st_mode & 0o777 == 0o600
     assert not list(target.parent.glob("host-integrations.json.*"))
+
+def test_native_write_receipts_and_dry_run(tmp_path):
+    report = {"status": "passed", "dry_run": False, "writes": [
+        {"label": "amp", "status": "done"},
+        {"label": "kimi", "status": "skipped"},
+        {"label": "droid", "status": "failed"},
+    ], "skipped": ["qwen-code: malformed_json_preserved"]}
+    hosts = {h["id"]: h for h in build_summary(report, home=tmp_path, env={"PATH": ""})["hosts"]}
+    assert hosts["amp"]["status"] == "registered"
+    assert hosts["kimi"]["status"] == "registered"
+    assert hosts["droid"]["status"] == "failed"
+    assert hosts["qwen-code"]["status"] == "skipped"
+    report["dry_run"] = True
+    dry = build_summary(report, home=tmp_path, env={"PATH": ""})
+    assert not any(h["status"] == "registered" for h in dry["hosts"])
+
+
+def test_windows_executable_suffix_is_recognized(tmp_path, monkeypatch):
+    monkeypatch.setattr("simplicio.host_integrations.shutil.which", lambda name, path=None: str(tmp_path / (name + ".exe")))
+    hosts = detect_hosts(home=tmp_path, env={"PATH": ""})
+    assert next(h for h in hosts if h["id"] == "codex")["status"] == "detected"
+


### PR DESCRIPTION
The public README now lists all 29 requested harnesses with their integration scope and limitations. Installer detection metadata uses verified configuration paths, and the PyPI summary reconciles applied Runtime write receipts without treating dry runs as registrations. The legacy generic JSON writer defers client-specific formats to Runtime.

Validated locally: 90 tests covering host discovery, adapters, PyPI installation and shell/PowerShell installer contracts. The expanded native adapters require a new Runtime release; the README explicitly states that immutable v3.8.47 downloads do not contain this change. Devin and Codebuff require environment/project setup.
