### PR TITLE
test: include Claude wrapper in release fixture [skip ci]

### DIFF
--- a/tests/test_plugin_release_policy.py
+++ b/tests/test_plugin_release_policy.py
@@ -39,6 +39,8 @@ def release_policy(tmp_path, monkeypatch):
     bootstrap = public / module.PLUGIN_BOOTSTRAP
     bootstrap.parent.mkdir(parents=True)
     bootstrap.write_text(source, encoding="utf-8")
+    claude_bootstrap = public / "plugins/simplicio/bin/simplicio-claude-mcp-bootstrap.js"
+    claude_bootstrap.write_bytes((ROOT / claude_bootstrap.relative_to(public)).read_bytes())
     test_path = public / "plugins/simplicio/tests/bootstrap.test.js"
     test_path.parent.mkdir(parents=True)
     test_path.write_bytes((ROOT / test_path.relative_to(public)).read_bytes())


### PR DESCRIPTION
The release-policy verifier runs the real plugin bootstrap tests inside an isolated repository. The fixture copied the main bootstrap but omitted the Claude wrapper now used by those tests, blocking the 3.8.50 publication.

Copy the Claude wrapper into the fixture as well. No shipped plugin or installer behavior changes.

Validation: all 6 release-policy tests passed. A broader local worktree run had 379 passes and one unrelated Loop reference-directory assertion; the clean publication clone will run its complete release suite before publishing.
