### PR TITLE
docs: document shipped 3.8.50 host adapters [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ The installers for macOS/Linux, Windows and PyPI call the same native
 `simplicio mcp register --binary <absolute-path> --json` flow. Each client uses
 its own configuration format and points to the installed Simplicio binary.
 
-**Release boundary:** the expanded adapters below are implemented in source and
-need a Runtime release containing this change. They are not retroactively added
-to the immutable v3.8.47 download. A successful configuration write is not a
-completed MCP handshake; restart/reload the client and verify its tool list.
+**Available in [Runtime v3.8.50](https://github.com/wesleysimplicio/simplicio/releases/tag/v3.8.50):**
+the expanded adapters below are included in the signed native release and
+`simplicio-installer==3.8.50`. Devin and Codebuff require the manual integrations
+listed in the matrix. A successful configuration write is not a completed MCP
+handshake; restart/reload the client and verify its tool list.
 
 | Harness | Integration | Scope and limits |
 |---|---|---|

--- a/docs/HOST_INTEGRATIONS.md
+++ b/docs/HOST_INTEGRATIONS.md
@@ -10,8 +10,9 @@ Runtime owns the transactional configuration changes. The PyPI launcher records
 the redacted result beside the binary in `simplicio-host-integrations.json`.
 The [29-host README matrix](../README.md#host-integrations) and
 [installer paths and upstream contracts](INSTALLER_HOSTS.md) describe the
-expanded adapters and their release boundary. Immutable v3.8.47 downloads do
-not gain adapters merely because the public metadata changed.
+expanded adapters released in [v3.8.50](https://github.com/wesleysimplicio/simplicio/releases/tag/v3.8.50).
+Upgrade the Runtime to use them; older immutable downloads do not gain adapters
+merely because the public metadata changed.
 
 ## Detection and registration evidence
 

--- a/docs/INSTALLER_HOSTS.md
+++ b/docs/INSTALLER_HOSTS.md
@@ -1,8 +1,10 @@
 # Installer host registration
 
 The public shell, PowerShell and PyPI installers delegate MCP configuration to
-the downloaded Runtime. The adapter expansion must ship in a new signed Runtime
-release before these paths are available to public installer users.
+the downloaded Runtime. The expanded adapters ship in the signed
+[Runtime v3.8.50 release](https://github.com/wesleysimplicio/simplicio/releases/tag/v3.8.50)
+and are available through the public shell, PowerShell and PyPI installers.
+Devin and Codebuff retain the manual integration requirements documented below.
 
 ## Additional user configuration paths
 


### PR DESCRIPTION
Runtime v3.8.50 and simplicio-installer 3.8.50 are now published and remotely verified. Update the README and host registration docs from pending-release language to the shipped version, while retaining Devin/Codebuff manual requirements and per-client handshake limits.

Validation: release receipt verified all four signed artifacts, native MCP discovery, terminal installation, and installation from PyPI on macOS arm64. Documentation links point to the published immutable release; diff check passed.
